### PR TITLE
fix: preserve file_path on comments added via web UI

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1260,7 +1260,7 @@ function renderDocument(ctx) {
 
   for (let bi = 0; bi < ctx.lineBlocks.length; bi++) {
     const block = ctx.lineBlocks[bi]
-    container.appendChild(renderBlock(ctx, block, bi, commentsMap, commentedLineSet, null))
+    container.appendChild(renderBlock(ctx, block, bi, commentsMap, commentedLineSet, ctx.singleFilePath || null))
   }
 
   renderMermaidBlocks(container)
@@ -1899,6 +1899,7 @@ export const DocumentRenderer = {
     ctx.reviewRound = parseInt(ctx.el.dataset.reviewRound || "0", 10)
     ctx.multiFile = ctx.el.dataset.multiFile === 'true'
     ctx.files = []
+    ctx.singleFilePath = null
     ctx.focusedFilePath = null
     ctx.treeFolderState = {}
 
@@ -2050,6 +2051,7 @@ export const DocumentRenderer = {
       } else if (files && files.length === 1) {
         const f = files[0]
         ctx.rawContent = f.content
+        ctx.singleFilePath = f.path
         ctx.lineBlocks = isCodeFile(f.path)
           ? buildCodeLineBlocks(f.content, f.path)
           : buildLineBlocks(md, f.content)


### PR DESCRIPTION
## Summary

- `document-renderer.js` was passing `null` as the `filePath` argument to `renderBlock` for single-file reviews, so every block's `dataset.filePath` was set to an empty string
- When a comment was submitted, `submitNewComment` sent `file_path: null` to the server
- Comments with `nil` file_path are filtered out by the export endpoints (`multi_file_comments_json`), causing them to silently disappear from "Get prompt" and export responses

## Fix

Store `f.path` as `ctx.singleFilePath` when the `init` event arrives with a single file, then pass it through to `renderBlock` instead of hardcoded `null`.

Fixes #6