### PR TITLE
fix: disable hljs auto-detection for unlabelled code blocks

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -635,7 +635,7 @@ function buildLineBlocks(md, rawContent) {
       if (lang && hljs.getLanguage(lang)) {
         try { highlighted = hljs.highlight(code, { language: lang }).value } catch (_) { highlighted = escapeHtml(code) }
       } else {
-        try { highlighted = hljs.highlightAuto(code).value } catch (_) { highlighted = escapeHtml(code) }
+        highlighted = escapeHtml(code)
       }
 
       const codeLines = splitHighlightedCode(highlighted)
@@ -1916,7 +1916,6 @@ export const DocumentRenderer = {
         if (lang && hljs.getLanguage(lang)) {
           try { return hljs.highlight(str, { language: lang }).value } catch (_) {}
         }
-        try { return hljs.highlightAuto(str).value } catch (_) {}
         return ""
       },
     })


### PR DESCRIPTION
## What changed

Code blocks without a language tag (e.g. plain ```` ``` ````) were being passed through `hljs.highlightAuto()`, which guesses the language and applies syntax highlighting. This caused random words to be coloured — e.g. `this` turning red because hljs guessed JavaScript.

## Fix

Removed all `highlightAuto` fallback calls. Code blocks with no language now render as plain escaped text. Mirrors the fix in `crit` (local CLI).