### PR TITLE
fix: backfill display name on existing comments

### DIFF
--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -34,9 +34,13 @@ defmodule Crit.Reviews do
   end
 
   @doc "List all comments for a review, ordered by start_line."
-  def list_comments(%Review{id: id}) do
+  def list_comments(%Review{id: id}), do: list_comments(id)
+
+  def list_comments(review_id) when is_binary(review_id) do
     Repo.all(
-      from c in Comment, where: c.review_id == ^id, order_by: [asc: c.start_line, asc: c.end_line]
+      from c in Comment,
+        where: c.review_id == ^review_id,
+        order_by: [asc: c.start_line, asc: c.end_line]
     )
   end
 
@@ -284,6 +288,27 @@ defmodule Crit.Reviews do
           {:error, _} -> {:error, :delete_failed}
         end
     end
+  end
+
+  @doc "Update the display name on all comments by a given identity. Returns {count, nil}."
+  def update_display_name(identity, display_name) do
+    from(c in Comment, where: c.author_identity == ^identity)
+    |> Repo.update_all(set: [author_display_name: display_name])
+  end
+
+  @doc """
+  Returns {id, token} pairs for all reviews that have comments by the given identity.
+  Used to broadcast display name changes to affected live review pages.
+  """
+  def reviews_for_identity(identity) do
+    from(c in Comment,
+      where: c.author_identity == ^identity,
+      join: r in Review,
+      on: r.id == c.review_id,
+      distinct: true,
+      select: {r.id, r.token}
+    )
+    |> Repo.all()
   end
 
   @doc "Serialize a comment to the API JSON shape."

--- a/lib/crit_web/controllers/review_controller.ex
+++ b/lib/crit_web/controllers/review_controller.ex
@@ -3,8 +3,27 @@ defmodule CritWeb.ReviewController do
 
   def set_name(conn, %{"name" => name}) do
     case Crit.DisplayName.normalize(name) do
-      nil -> conn |> put_status(422) |> json(%{error: "name cannot be blank"})
-      name -> conn |> put_session("display_name", name) |> json(%{ok: true})
+      nil ->
+        conn |> put_status(422) |> json(%{error: "name cannot be blank"})
+
+      name ->
+        identity = get_session(conn, "identity")
+
+        if identity do
+          Crit.Reviews.update_display_name(identity, name)
+
+          for {id, token} <- Crit.Reviews.reviews_for_identity(identity) do
+            comments = Crit.Reviews.list_comments(id)
+
+            Phoenix.PubSub.broadcast(
+              Crit.PubSub,
+              "review:#{token}",
+              {:comments_updated, comments}
+            )
+          end
+        end
+
+        conn |> put_session("display_name", name) |> json(%{ok: true})
     end
   end
 

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -143,14 +143,17 @@ defmodule CritWeb.ReviewLive do
 
   @impl true
   def handle_event("set_display_name", %{"name" => name}, socket) do
-    # This event updates the in-memory assign only. LiveView cannot write to
-    # the cookie session after mount, so the JS hook also POSTs to /set-name
-    # (the controller endpoint) which persists the name to the session.
+    # Updates the in-memory assign only. The DB update and cross-review
+    # broadcast happen in the controller's POST /set-name handler (the JS
+    # hook fires both this event and the POST). We broadcast the current
+    # review here for immediate feedback to other viewers on this page.
     case Crit.DisplayName.normalize(name) do
       nil ->
         {:noreply, socket}
 
       name ->
+        broadcast_comments(socket.assigns.review)
+
         {:noreply,
          socket
          |> assign(:display_name, name)

--- a/test/crit/reviews_test.exs
+++ b/test/crit/reviews_test.exs
@@ -464,6 +464,140 @@ defmodule Crit.ReviewsTest do
     end
   end
 
+  describe "update_display_name/2" do
+    test "updates display name on all comments by the given identity" do
+      review = review_fixture()
+      identity = Ecto.UUID.generate()
+
+      {:ok, _c1} =
+        Reviews.create_comment(
+          review,
+          %{"start_line" => 1, "end_line" => 1, "body" => "First"},
+          identity,
+          "OldName"
+        )
+
+      {:ok, _c2} =
+        Reviews.create_comment(
+          review,
+          %{"start_line" => 2, "end_line" => 2, "body" => "Second"},
+          identity,
+          "OldName"
+        )
+
+      {2, _} = Reviews.update_display_name(identity, "NewName")
+
+      comments = Reviews.list_comments(review)
+      assert Enum.all?(comments, &(&1.author_display_name == "NewName"))
+    end
+
+    test "does not affect comments by other identities" do
+      review = review_fixture()
+      identity_a = Ecto.UUID.generate()
+      identity_b = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review,
+          %{"start_line" => 1, "end_line" => 1, "body" => "A's comment"},
+          identity_a,
+          "Alice"
+        )
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review,
+          %{"start_line" => 2, "end_line" => 2, "body" => "B's comment"},
+          identity_b,
+          "Bob"
+        )
+
+      Reviews.update_display_name(identity_a, "Alicia")
+
+      comments = Reviews.list_comments(review)
+      a_comment = Enum.find(comments, &(&1.author_identity == identity_a))
+      b_comment = Enum.find(comments, &(&1.author_identity == identity_b))
+
+      assert a_comment.author_display_name == "Alicia"
+      assert b_comment.author_display_name == "Bob"
+    end
+
+    test "updates comments across multiple reviews" do
+      review1 = review_fixture()
+
+      review2 =
+        review_fixture(%{files: [%{"path" => "other.md", "content" => "# Other"}]})
+
+      identity = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review1,
+          %{"start_line" => 1, "end_line" => 1, "body" => "On review 1"},
+          identity,
+          "Old"
+        )
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review2,
+          %{"start_line" => 1, "end_line" => 1, "body" => "On review 2"},
+          identity,
+          "Old"
+        )
+
+      {2, _} = Reviews.update_display_name(identity, "New")
+
+      assert hd(Reviews.list_comments(review1)).author_display_name == "New"
+      assert hd(Reviews.list_comments(review2)).author_display_name == "New"
+    end
+
+    test "returns {0, nil} when identity has no comments" do
+      assert {0, _} = Reviews.update_display_name(Ecto.UUID.generate(), "Nobody")
+    end
+  end
+
+  describe "reviews_for_identity/1" do
+    test "returns review id and token pairs" do
+      review = review_fixture()
+      identity = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review,
+          %{"start_line" => 1, "end_line" => 1, "body" => "hi"},
+          identity
+        )
+
+      assert [{review.id, review.token}] == Reviews.reviews_for_identity(identity)
+    end
+
+    test "returns distinct reviews even with multiple comments" do
+      review = review_fixture()
+      identity = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review,
+          %{"start_line" => 1, "end_line" => 1, "body" => "one"},
+          identity
+        )
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review,
+          %{"start_line" => 2, "end_line" => 2, "body" => "two"},
+          identity
+        )
+
+      assert [{review.id, review.token}] == Reviews.reviews_for_identity(identity)
+    end
+
+    test "returns empty list for identity with no comments" do
+      assert [] == Reviews.reviews_for_identity(Ecto.UUID.generate())
+    end
+  end
+
   describe "delete_review/1" do
     test "deletes a review by id" do
       review = review_fixture()

--- a/test/crit_web/controllers/review_controller_test.exs
+++ b/test/crit_web/controllers/review_controller_test.exs
@@ -1,0 +1,112 @@
+defmodule CritWeb.ReviewControllerTest do
+  use CritWeb.ConnCase, async: true
+
+  import Crit.ReviewsFixtures
+
+  alias Crit.Reviews
+
+  describe "POST /set-name" do
+    test "updates display name on existing comments", %{conn: conn} do
+      review = review_fixture()
+      identity = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review,
+          %{"start_line" => 1, "end_line" => 1, "body" => "Old name comment"},
+          identity,
+          "OldName"
+        )
+
+      conn =
+        conn
+        |> init_test_session(%{"identity" => identity})
+        |> post(~p"/set-name", %{"name" => "NewName"})
+
+      assert json_response(conn, 200)["ok"] == true
+
+      [comment] = Reviews.list_comments(review)
+      assert comment.author_display_name == "NewName"
+    end
+
+    test "updates comments across multiple reviews", %{conn: conn} do
+      review1 = review_fixture()
+      review2 = review_fixture(%{files: [%{"path" => "b.md", "content" => "# B"}]})
+      identity = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review1,
+          %{"start_line" => 1, "end_line" => 1, "body" => "R1"},
+          identity,
+          "Old"
+        )
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review2,
+          %{"start_line" => 1, "end_line" => 1, "body" => "R2"},
+          identity,
+          "Old"
+        )
+
+      conn
+      |> init_test_session(%{"identity" => identity})
+      |> post(~p"/set-name", %{"name" => "New"})
+
+      assert hd(Reviews.list_comments(review1)).author_display_name == "New"
+      assert hd(Reviews.list_comments(review2)).author_display_name == "New"
+    end
+
+    test "does not update other users' comments", %{conn: conn} do
+      review = review_fixture()
+      my_identity = Ecto.UUID.generate()
+      other_identity = Ecto.UUID.generate()
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review,
+          %{"start_line" => 1, "end_line" => 1, "body" => "Mine"},
+          my_identity,
+          "OldMe"
+        )
+
+      {:ok, _} =
+        Reviews.create_comment(
+          review,
+          %{"start_line" => 2, "end_line" => 2, "body" => "Theirs"},
+          other_identity,
+          "Other"
+        )
+
+      conn
+      |> init_test_session(%{"identity" => my_identity})
+      |> post(~p"/set-name", %{"name" => "NewMe"})
+
+      comments = Reviews.list_comments(review)
+      mine = Enum.find(comments, &(&1.author_identity == my_identity))
+      theirs = Enum.find(comments, &(&1.author_identity == other_identity))
+
+      assert mine.author_display_name == "NewMe"
+      assert theirs.author_display_name == "Other"
+    end
+
+    test "returns 422 for blank name", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{"identity" => Ecto.UUID.generate()})
+        |> post(~p"/set-name", %{"name" => "   "})
+
+      assert json_response(conn, 422)["error"] =~ "blank"
+    end
+
+    test "returns 422 when name param is missing", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{"identity" => Ecto.UUID.generate()})
+        |> post(~p"/set-name", %{})
+
+      assert json_response(conn, 422)["error"] =~ "required"
+    end
+  end
+end

--- a/test/crit_web/live/review_live_test.exs
+++ b/test/crit_web/live/review_live_test.exs
@@ -206,6 +206,19 @@ defmodule CritWeb.ReviewLiveTest do
       assert comment.author_display_name == "Alice"
     end
 
+    test "broadcasts comments when display name is set", %{conn: conn, review: review} do
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+      # Subscribe to verify broadcast fires
+      Phoenix.PubSub.subscribe(Crit.PubSub, "review:#{review.token}")
+
+      view
+      |> element("#document-renderer")
+      |> render_hook("set_display_name", %{"name" => "Alice"})
+
+      assert_receive {:comments_updated, _comments}, 500
+    end
+
     test "ignores blank names", %{conn: conn, review: review} do
       {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
 


### PR DESCRIPTION
## Summary
- When a user changes their display name, all their existing comments now get updated in the DB (previously only new comments used the new name)
- Live viewers on any affected review page see the updated name immediately via PubSub broadcast
- Added `Reviews.update_display_name/2` and `reviews_for_identity/1` context functions
- Controller owns the DB update; LiveView broadcasts current review for immediate feedback

## Test plan
- [x] `mix test` — 164 tests, 0 failures
- [x] `mix precommit` — all checks pass
- [x] Manual: open a review, add comments, change display name, verify old comments show new name
- [x] Manual: open same review in two tabs, change name in one, verify other tab updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)