### PR TITLE
docs: update marketing pages for crit listen, crit share, and QR codes

### DIFF
--- a/lib/crit_web/controllers/page_controller.ex
+++ b/lib/crit_web/controllers/page_controller.ex
@@ -30,10 +30,10 @@ defmodule CritWeb.PageController do
       title: "AI Review Loop",
       tagline: "Review, hand off to your agent, iterate",
       description:
-        "Leave comments, click Finish Review, paste the prompt into your agent. The prompt points the agent to `.crit.json` and tells it to run `crit go <port>` when done. Crit detects the signal, reloads with a diff, and you review again.",
+        "Leave comments, click Finish Review, and your agent is notified automatically via `crit listen`. The agent reads `.crit.json`, makes edits, and runs `crit go <port>` when done. Crit reloads with a diff, and you review again.",
       details: [
-        "When you click \"Finish Review\", Crit writes `.crit.json` - structured comment data with per-file sections. A prompt is copied to your clipboard.",
-        "The prompt tells the agent to read `.crit.json`, address unresolved comments, and run `crit go <port>` when done. Paste it into any agent.",
+        "When you click \"Finish Review\", Crit writes `.crit.json` - structured comment data with per-file sections. Your agent is notified automatically if it was listening via `crit listen`.",
+        "The prompt tells the agent to read `.crit.json`, address unresolved comments, and run `crit go <port>` when done. No copy-paste needed — `crit listen` delivers it directly.",
         "When the agent runs `crit go`, the browser starts a new round with a diff of what changed. Previous comments show as resolved or still open.",
         "Add new comments on the updated version and repeat. When all comments are resolved, Crit detects it and generates a clean confirmation prompt — the loop ends when you're satisfied."
       ]
@@ -56,10 +56,10 @@ defmodule CritWeb.PageController do
       description:
         "Generate a public link with one click. Anyone with the link can view the document and add their own comments. Unpublish anytime to revoke access.",
       details: [
-        "Click the Share button in Crit and a unique URL is generated instantly. The link is copied to your clipboard, ready to paste into Slack, email, or a GitHub issue.",
+        "Click the Share button in Crit and a unique URL is generated instantly. Or share directly from the CLI with `crit share plan.md` — no browser needed.",
         "Anyone who opens the link sees the full document with all comments. They can add their own feedback without installing anything - it works in any browser.",
         "Each reviewer's comments are color-coded by a unique hue, making it easy to track who said what in a multi-person review.",
-        "Unpublish at any time to revoke the link. Shared reviews are automatically deleted after 30 days of inactivity."
+        "Use `crit share --qr` to print a QR code in the terminal for quick mobile access. Unpublish anytime with `crit unpublish`. Shared reviews auto-expire after 30 days of inactivity."
       ]
     },
     "syntax-highlighting" => %{

--- a/lib/crit_web/controllers/page_html/feature.html.heex
+++ b/lib/crit_web/controllers/page_html/feature.html.heex
@@ -241,10 +241,10 @@
           </div>
           <div>
             <span class="text-(--crit-green)">&rarr;</span>
-            Finish review - prompt copied <span class="text-(--crit-green)">&check;</span>
+            Finish review - agent notified <span class="text-(--crit-green)">&check;</span>
           </div>
           <div>
-            <span class="text-(--crit-fg-muted)">&rarr;</span> Waiting for agent&hellip;
+            <span class="text-(--crit-fg-muted)">&rarr;</span> Agent working&hellip;
           </div>
           <div>
             <span class="text-(--crit-green)">&rarr;</span>
@@ -257,10 +257,10 @@
           <div><span class="text-(--crit-green)">&rarr;</span> 1 new comment added</div>
           <div>
             <span class="text-(--crit-green)">&rarr;</span>
-            Finish review - prompt copied <span class="text-(--crit-green)">&check;</span>
+            Finish review - agent notified <span class="text-(--crit-green)">&check;</span>
           </div>
           <div>
-            <span class="text-(--crit-fg-muted)">&rarr;</span> Waiting for agent&hellip;
+            <span class="text-(--crit-fg-muted)">&rarr;</span> Agent working&hellip;
           </div>
           <div>
             <span class="text-(--crit-green)">&rarr;</span>

--- a/lib/crit_web/controllers/page_html/home.html.heex
+++ b/lib/crit_web/controllers/page_html/home.html.heex
@@ -17,8 +17,8 @@
         </h1>
         <p class="text-lg max-sm:text-base leading-relaxed text-(--crit-fg-secondary) max-w-[480px] mb-8">
           Review plans before your agent writes code. Review code before you ship it.
-          Leave inline comments in a browser-based UI, click Finish Review, and a structured
-          prompt goes to your clipboard. Your agent iterates. You review the diff. Repeat.
+          Leave inline comments in a browser-based UI, click Finish Review, and your agent
+          picks up the feedback automatically. It iterates. You review the diff. Repeat.
         </p>
         <div class="flex gap-3 flex-wrap">
           <%= if @demo_token do %>
@@ -177,9 +177,9 @@
         <div class="rounded-md border border-(--crit-border) bg-(--crit-code-bg) p-2.5 text-[10px] font-mono leading-5 text-(--crit-fg-secondary) select-none">
           <div>
             <span class="text-(--crit-green)">&rarr;</span>
-            Prompt copied <span class="text-(--crit-green)">&check;</span>
+            Agent notified <span class="text-(--crit-green)">&check;</span>
           </div>
-          <div class="text-(--crit-fg-muted)">&nbsp; Paste into your agent</div>
+          <div class="text-(--crit-fg-muted)">&nbsp; Waiting for updates&hellip;</div>
         </div>
       </div>
 
@@ -381,7 +381,7 @@
         <div>
           <h3 class="text-base font-semibold tracking-tight mb-1">AI Review Loop</h3>
           <p class="text-sm text-(--crit-fg-secondary) leading-relaxed">
-            Leave comments, click finish, paste the prompt into your agent. It edits the file. Crit detects the change, reloads, and shows what moved. Previous comments stay visible so nothing gets skipped.
+            Leave comments, click finish, and your agent picks up the feedback automatically. It edits the file. Crit reloads with a diff of what changed. Previous comments stay visible so nothing gets skipped.
           </p>
         </div>
         <div
@@ -397,10 +397,10 @@
           </div>
           <div>
             <span class="text-(--crit-green)">&rarr;</span>
-            Finish review - prompt copied <span class="text-(--crit-green)">&check;</span>
+            Finish review - agent notified <span class="text-(--crit-green)">&check;</span>
           </div>
           <div>
-            <span class="text-(--crit-fg-muted)">&rarr;</span> Waiting for agent&hellip;
+            <span class="text-(--crit-fg-muted)">&rarr;</span> Agent working&hellip;
           </div>
           <div>
             <span class="text-(--crit-green)">&rarr;</span>


### PR DESCRIPTION
## Summary

- Replace "paste prompt into your agent" messaging with automatic agent notification via `crit listen` (tomasz-tomczyk/crit#71)
- Update homepage hero, "How it works" step 02, AI Review Loop feature card, and terminal widgets
- Update Share feature details to mention `crit share` CLI and `--qr` flag (tomasz-tomczyk/crit#72, tomasz-tomczyk/crit#73)
- All terminal widget animations now show "agent notified" / "Agent working" instead of "prompt copied" / "Waiting for agent"

## Test plan
- [x] Verify homepage renders correctly at localhost:4000
- [x] Verify /features/ai-review-loop page shows updated terminal widget
- [x] Verify /features/share-reviews page shows updated details

🤖 Generated with [Claude Code](https://claude.com/claude-code)