### PR TITLE
fix: render markdown in comments panel instead of plain text

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1871,7 +1871,18 @@ function renderCommentsPanel(ctx) {
 
     const bodyEl = document.createElement('div')
     bodyEl.className = 'comments-panel-card-body'
-    bodyEl.textContent = comment.body
+    const env = {}
+    if (comment.start_line && comment.end_line && !comment.side) {
+      let fileContent = ctx.rawContent
+      if (ctx.multiFile && filePath) {
+        const file = ctx.files.find(f => f.path === filePath)
+        if (file) fileContent = file.content
+      }
+      if (fileContent) {
+        env.originalLines = fileContent.split('\n').slice(comment.start_line - 1, comment.end_line)
+      }
+    }
+    bodyEl.innerHTML = commentMd.render(comment.body, env)
 
     card.appendChild(header)
     card.appendChild(bodyEl)


### PR DESCRIPTION
## Summary
- Comments panel was using `textContent` to display comment bodies, showing raw markdown instead of rendered output
- Switched to `commentMd.render()` with `env` containing `originalLines`, matching crit local's behavior (`app.js:3960`)
- Suggestion blocks now render correctly in the panel for both single-file and multi-file reviews

Fixes #19

## Test plan
- [ ] Open a review with markdown-formatted comments (bold, italic, code, links) — verify they render in the comments panel
- [ ] Open a review with suggestion blocks — verify inline diffs render in the panel
- [ ] Test with multi-file reviews — verify suggestions resolve against the correct file's content

🤖 Generated with [Claude Code](https://claude.com/claude-code)