### PR TITLE
fix: align theme CSS variables with crit local

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -37,7 +37,7 @@
   --crit-fg-primary: #c0caf5;
   --crit-fg-secondary: #a9b1d6;
   --crit-fg-muted: #565f89;
-  --crit-fg-dimmed: #4a5275;
+  --crit-fg-dimmed: #8b93b4;
   --crit-accent: #7aa2f7;
   --crit-accent-hover: #89b4fa;
   --crit-accent-subtle: rgba(122, 162, 247, 0.1);
@@ -55,7 +55,7 @@
   --comment-label-l: 65%;
   --comment-time-s: 30%;
   --comment-time-l: 45%;
-  --crit-selection-bg: rgba(122, 162, 247, 0.08);
+  --crit-selection-bg: rgba(210, 153, 34, 0.13);
   --crit-comment-range-bg: rgba(210, 153, 34, 0.13);
   --crit-code-bg: #1e2030;
   --crit-table-stripe: rgba(122, 162, 247, 0.04);
@@ -77,7 +77,7 @@
   --crit-fg-primary: #c0caf5;
   --crit-fg-secondary: #a9b1d6;
   --crit-fg-muted: #565f89;
-  --crit-fg-dimmed: #4a5275;
+  --crit-fg-dimmed: #8b93b4;
   --crit-accent: #7aa2f7;
   --crit-accent-hover: #89b4fa;
   --crit-accent-subtle: rgba(122, 162, 247, 0.1);
@@ -95,7 +95,7 @@
   --comment-label-l: 65%;
   --comment-time-s: 30%;
   --comment-time-l: 45%;
-  --crit-selection-bg: rgba(122, 162, 247, 0.08);
+  --crit-selection-bg: rgba(210, 153, 34, 0.13);
   --crit-comment-range-bg: rgba(210, 153, 34, 0.13);
   --crit-code-bg: #1e2030;
   --crit-table-stripe: rgba(122, 162, 247, 0.04);
@@ -117,7 +117,7 @@
   --crit-fg-primary: #24292f;
   --crit-fg-secondary: #57606a;
   --crit-fg-muted: #8b949e;
-  --crit-fg-dimmed: #c0c8d0;
+  --crit-fg-dimmed: #586069;
   --crit-accent: #0969da;
   --crit-accent-hover: #0550ae;
   --crit-accent-subtle: rgba(9, 105, 218, 0.08);
@@ -135,7 +135,7 @@
   --comment-label-l: 35%;
   --comment-time-s: 25%;
   --comment-time-l: 60%;
-  --crit-selection-bg: rgba(9, 105, 218, 0.06);
+  --crit-selection-bg: rgba(210, 153, 34, 0.15);
   --crit-comment-range-bg: rgba(210, 153, 34, 0.15);
   --crit-code-bg: #f5f5f5;
   --crit-table-stripe: rgba(0, 0, 0, 0.02);
@@ -159,7 +159,7 @@
     --crit-fg-primary: #24292f;
     --crit-fg-secondary: #57606a;
     --crit-fg-muted: #8b949e;
-    --crit-fg-dimmed: #c0c8d0;
+    --crit-fg-dimmed: #586069;
     --crit-accent: #0969da;
     --crit-accent-hover: #0550ae;
     --crit-accent-subtle: rgba(9, 105, 218, 0.08);
@@ -177,7 +177,7 @@
     --comment-label-l: 35%;
     --comment-time-s: 25%;
     --comment-time-l: 60%;
-    --crit-selection-bg: rgba(9, 105, 218, 0.06);
+    --crit-selection-bg: rgba(210, 153, 34, 0.15);
     --crit-comment-range-bg: rgba(210, 153, 34, 0.15);
     --crit-code-bg: #f5f5f5;
     --crit-table-stripe: rgba(0, 0, 0, 0.02);


### PR DESCRIPTION
## Summary
- **Fixes #20**: `--crit-fg-dimmed` was `#4a5275` (dark) / `#c0c8d0` (light) instead of crit local's `#8b93b4` / `#586069`
- **Also fixes `--crit-selection-bg`**: was blue-tinted (`rgba(122,162,247,0.08)` dark / `rgba(9,105,218,0.06)` light) instead of crit local's golden hover highlight (`rgba(210,153,34,0.13)` / `rgba(210,153,34,0.15)`)
- All 4 theme blocks updated (`:root`, `[data-theme="dark"]`, `[data-theme="light"]`, `@media prefers-color-scheme: light`)

## Test plan
- [ ] Open a review on crit-web in dark mode — dimmed text (e.g. "Suggested change" header) should be visibly lighter
- [ ] Switch to light mode — dimmed text should be darker/readable
- [ ] Hover over lines — selection highlight should be golden-tinted, matching crit local

🤖 Generated with [Claude Code](https://claude.com/claude-code)