### PR TITLE
feat: add @file-ref rendering in shared review comments

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -932,6 +932,17 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
   color: #e55;
 }
 
+/* File Reference in Comments */
+.file-ref {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  background: var(--bg-tertiary);
+  color: var(--accent);
+  padding: 1px 5px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
 /* Save Template Dialog */
 .save-template-overlay {
   display: none;

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -61,6 +61,28 @@ const commentMd = markdownit({
   },
 })
 
+// ===== File Reference Inline Rule =====
+commentMd.inline.ruler.push('file_ref', function(state, silent) {
+  var start = state.pos
+  var max = state.posMax
+  if (state.src.charCodeAt(start) !== 0x40 /* @ */) return false
+  if (start > 0 && !/\s/.test(state.src[start - 1])) return false
+  var end = start + 1
+  while (end < max && /[a-zA-Z0-9._\-\/]/.test(state.src[end])) end++
+  var path = state.src.substring(start + 1, end)
+  if (path.length === 0 || (path.indexOf('.') === -1 && path.indexOf('/') === -1)) return false
+  if (!silent) {
+    var token = state.push('file_ref', '', 0)
+    token.content = path
+  }
+  state.pos = end
+  return true
+})
+commentMd.renderer.rules.file_ref = function(tokens, idx) {
+  var path = tokens[idx].content
+  return '<span class="file-ref">' + escapeHtml(path) + '</span>'
+}
+
 // ===== Word-Level Diff =====
 
 // Split a line into tokens: words (alphanumeric + underscore) and individual non-word characters.


### PR DESCRIPTION
## Summary
- Port `file_ref` markdown-it inline rule from crit local to render `@file.path` references as styled inline tokens in comments
- Add `.file-ref` CSS matching crit local's styling (mono font, accent color, tertiary background)

## Review
- [x] Code review: passed
- [x] Parity: CSS and JS match crit local exactly

## Test plan
- Visual verification of `@file.path` rendering in shared review comments
- See also: tomasz-tomczyk/crit#123 — file picker autocomplete (companion PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)