### PR TITLE
feat: bundle all highlight.js languages

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1,32 +1,5 @@
 import markdownit from "markdown-it"
-import hljs from "highlight.js/lib/core"
-import javascript from "highlight.js/lib/languages/javascript"
-import typescript from "highlight.js/lib/languages/typescript"
-import go from "highlight.js/lib/languages/go"
-import python from "highlight.js/lib/languages/python"
-import ruby from "highlight.js/lib/languages/ruby"
-import rust from "highlight.js/lib/languages/rust"
-import sql from "highlight.js/lib/languages/sql"
-import bash from "highlight.js/lib/languages/bash"
-import json from "highlight.js/lib/languages/json"
-import yaml from "highlight.js/lib/languages/yaml"
-import xml from "highlight.js/lib/languages/xml"
-import css from "highlight.js/lib/languages/css"
-import elixir from "highlight.js/lib/languages/elixir"
-
-hljs.registerLanguage("javascript", javascript)
-hljs.registerLanguage("typescript", typescript)
-hljs.registerLanguage("go", go)
-hljs.registerLanguage("python", python)
-hljs.registerLanguage("ruby", ruby)
-hljs.registerLanguage("rust", rust)
-hljs.registerLanguage("sql", sql)
-hljs.registerLanguage("bash", bash)
-hljs.registerLanguage("json", json)
-hljs.registerLanguage("yaml", yaml)
-hljs.registerLanguage("xml", xml)
-hljs.registerLanguage("css", css)
-hljs.registerLanguage("elixir", elixir)
+import hljs from "highlight.js"
 
 // ---- Helpers ----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Switch from `highlight.js/lib/core` + 14 manual imports to full `highlight.js` bundle (192 languages)
- Document renderer is already lazy-loaded only on `/r/*` review pages — marketing pages unaffected

## Review
- [x] Code review: passed

## Test plan
- [x] Elixir compilation succeeds
- See also: tomasz-tomczyk/crit#148

🤖 Generated with [Claude Code](https://claude.com/claude-code)