### PR TITLE
fix: use 308 redirect to preserve POST method on host redirect

### DIFF
--- a/lib/crit_web/plugs/canonical_host.ex
+++ b/lib/crit_web/plugs/canonical_host.ex
@@ -35,7 +35,7 @@ defmodule CritWeb.Plugs.CanonicalHost do
 
     conn
     |> put_resp_header("location", url)
-    |> send_resp(301, "")
+    |> send_resp(308, "")
     |> halt()
   end
 end

--- a/test/crit_web/plugs/canonical_host_test.exs
+++ b/test/crit_web/plugs/canonical_host_test.exs
@@ -1,0 +1,66 @@
+defmodule CritWeb.Plugs.CanonicalHostTest do
+  use CritWeb.ConnCase
+
+  alias CritWeb.Plugs.CanonicalHost
+
+  setup do
+    Application.put_env(:crit, :canonical_host, "crit.md")
+    on_exit(fn -> Application.delete_env(:crit, :canonical_host) end)
+  end
+
+  defp call_plug(conn) do
+    CanonicalHost.call(conn, CanonicalHost.init([]))
+  end
+
+  test "redirects crit.live to canonical host with 308", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:host, "crit.live")
+      |> call_plug()
+
+    assert conn.status == 308
+    assert get_resp_header(conn, "location") == ["http://crit.md/"]
+  end
+
+  test "redirects www subdomain to canonical host with 308", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:host, "www.crit.md")
+      |> call_plug()
+
+    assert conn.status == 308
+    assert get_resp_header(conn, "location") == ["http://crit.md/"]
+  end
+
+  test "preserves path and query on redirect", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:host, "crit.live")
+      |> Map.put(:request_path, "/r/abc123")
+      |> Map.put(:query_string, "foo=bar")
+      |> call_plug()
+
+    assert conn.status == 308
+    assert get_resp_header(conn, "location") == ["http://crit.md/r/abc123?foo=bar"]
+  end
+
+  test "does not redirect canonical host", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:host, "crit.md")
+      |> call_plug()
+
+    refute conn.halted
+  end
+
+  test "does not redirect when no canonical host configured", %{conn: conn} do
+    Application.delete_env(:crit, :canonical_host)
+
+    conn =
+      conn
+      |> Map.put(:host, "crit.live")
+      |> call_plug()
+
+    refute conn.halted
+  end
+end


### PR DESCRIPTION
## Summary
- Changed canonical host redirect from 301 to 308 (Permanent Redirect)
- 301 allows clients to convert POST→GET on redirect, which drops the request body
- 308 preserves the HTTP method and body, fixing `crit share` to crit.live
- Added 5 tests for the CanonicalHost plug

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (backend-only change)

## Test plan
- E2E tested: `crit share` to localhost:4000 works, crit.live previously returned 404 with 301
- Unit tests: 5 new tests covering redirect status, path/query preservation, canonical passthrough, no-config passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)