### PR TITLE
fix: include author and replies, skip resolved in review markdown export

### DIFF
--- a/lib/crit/output.ex
+++ b/lib/crit/output.ex
@@ -15,6 +15,7 @@ defmodule Crit.Output do
 
     insert_after =
       comments
+      |> Enum.reject(& &1.resolved)
       |> Enum.sort_by(&{&1.end_line, &1.start_line})
       |> Enum.group_by(& &1.end_line)
 
@@ -33,17 +34,51 @@ defmodule Crit.Output do
     |> Enum.join("")
   end
 
-  @doc "Formats a single comment as a markdown blockquote."
+  @doc "Formats a single comment as a markdown blockquote, including author and replies."
   def format_comment(%Comment{} = c) do
-    header =
+    line_ref =
       if c.start_line == c.end_line,
         do: "Line #{c.start_line}",
         else: "Lines #{c.start_line}-#{c.end_line}"
 
+    author_part = if c.author_display_name, do: " — #{c.author_display_name}", else: ""
+    header = "#{line_ref}#{author_part}"
+
     [first | rest] = String.split(c.body, "\n")
     quoted_rest = Enum.map_join(rest, "", fn line -> "\n> " <> line end)
 
-    "> **[REVIEW COMMENT — #{header}]**: #{first}#{quoted_rest}"
+    parent_block = "> **[REVIEW COMMENT — #{header}]**: #{first}#{quoted_rest}"
+
+    replies = loaded_replies(c)
+
+    case replies do
+      [] ->
+        parent_block
+
+      replies ->
+        reply_blocks =
+          replies
+          |> Enum.reject(& &1.resolved)
+          |> Enum.map(&format_reply/1)
+
+        case reply_blocks do
+          [] -> parent_block
+          blocks -> parent_block <> "\n> \n" <> Enum.join(blocks, "\n")
+        end
+    end
+  end
+
+  defp loaded_replies(%Comment{replies: %Ecto.Association.NotLoaded{}}), do: []
+  defp loaded_replies(%Comment{replies: replies}) when is_list(replies), do: replies
+  defp loaded_replies(_), do: []
+
+  defp format_reply(%Comment{} = r) do
+    author = r.author_display_name || "Anonymous"
+
+    [first | rest] = String.split(r.body, "\n")
+    quoted_rest = Enum.map_join(rest, "", fn line -> "\n> " <> line end)
+
+    "> **Reply (#{author})**: #{first}#{quoted_rest}"
   end
 
   @doc "Generate review markdown for multi-file reviews, with file headers."

--- a/test/crit/output_test.exs
+++ b/test/crit/output_test.exs
@@ -20,6 +20,171 @@ defmodule Crit.OutputTest do
       assert result =~ "line2"
       assert result =~ "> **[REVIEW COMMENT — Line 2]**: fix this"
     end
+
+    test "excludes resolved comments from output" do
+      content = "line1\nline2\nline3"
+
+      comments = [
+        %Comment{start_line: 1, end_line: 1, body: "unresolved", resolved: false},
+        %Comment{start_line: 2, end_line: 2, body: "resolved", resolved: true}
+      ]
+
+      result = Output.generate_review_md(content, comments)
+      assert result =~ "unresolved"
+      refute result =~ "> **[REVIEW COMMENT — Line 2]**: resolved"
+    end
+
+    test "emits nothing when all comments on a line are resolved" do
+      content = "line1\nline2"
+
+      comments = [
+        %Comment{start_line: 1, end_line: 1, body: "done", resolved: true},
+        %Comment{start_line: 1, end_line: 1, body: "also done", resolved: true}
+      ]
+
+      result = Output.generate_review_md(content, comments)
+      refute result =~ "REVIEW COMMENT"
+    end
+  end
+
+  describe "format_comment/1" do
+    test "includes author display name in header" do
+      comment = %Comment{
+        start_line: 4,
+        end_line: 4,
+        body: "Bold choice.",
+        author_display_name: "Tomasz"
+      }
+
+      result = Output.format_comment(comment)
+      assert result == "> **[REVIEW COMMENT — Line 4 — Tomasz]**: Bold choice."
+    end
+
+    test "renders without author when author_display_name is nil" do
+      comment = %Comment{
+        start_line: 4,
+        end_line: 4,
+        body: "Anonymous feedback.",
+        author_display_name: nil
+      }
+
+      result = Output.format_comment(comment)
+      assert result == "> **[REVIEW COMMENT — Line 4]**: Anonymous feedback."
+    end
+
+    test "renders line range for multi-line comments" do
+      comment = %Comment{
+        start_line: 2,
+        end_line: 5,
+        body: "Refactor this block.",
+        author_display_name: "Alice"
+      }
+
+      result = Output.format_comment(comment)
+      assert result =~ "Lines 2-5 — Alice"
+    end
+
+    test "includes replies under parent comment" do
+      comment = %Comment{
+        start_line: 4,
+        end_line: 4,
+        body: "Bold choice.",
+        author_display_name: "Tomasz",
+        replies: [
+          %Comment{
+            body: "COBOL has better error messages. Strong +1.",
+            author_display_name: "Senior Architect",
+            resolved: false
+          },
+          %Comment{
+            body: "What's COBOL?",
+            author_display_name: "Intern",
+            resolved: false
+          }
+        ]
+      }
+
+      result = Output.format_comment(comment)
+      assert result =~ "> **[REVIEW COMMENT — Line 4 — Tomasz]**: Bold choice."
+      assert result =~ "> **Reply (Senior Architect)**: COBOL has better error messages."
+      assert result =~ "> **Reply (Intern)**: What's COBOL?"
+    end
+
+    test "reply with nil author renders as Anonymous" do
+      comment = %Comment{
+        start_line: 1,
+        end_line: 1,
+        body: "Parent.",
+        author_display_name: nil,
+        replies: [
+          %Comment{body: "A reply.", author_display_name: nil, resolved: false}
+        ]
+      }
+
+      result = Output.format_comment(comment)
+      assert result =~ "> **Reply (Anonymous)**: A reply."
+    end
+
+    test "excludes resolved replies" do
+      comment = %Comment{
+        start_line: 1,
+        end_line: 1,
+        body: "Parent.",
+        author_display_name: "Author",
+        replies: [
+          %Comment{body: "Visible reply.", author_display_name: "A", resolved: false},
+          %Comment{body: "Resolved reply.", author_display_name: "B", resolved: true}
+        ]
+      }
+
+      result = Output.format_comment(comment)
+      assert result =~ "Visible reply."
+      refute result =~ "Resolved reply."
+    end
+
+    test "handles multiline comment body" do
+      comment = %Comment{
+        start_line: 1,
+        end_line: 1,
+        body: "First line.\nSecond line.",
+        author_display_name: "Author"
+      }
+
+      result = Output.format_comment(comment)
+      assert result == "> **[REVIEW COMMENT — Line 1 — Author]**: First line.\n> Second line."
+    end
+
+    test "handles multiline reply body" do
+      comment = %Comment{
+        start_line: 1,
+        end_line: 1,
+        body: "Parent.",
+        author_display_name: nil,
+        replies: [
+          %Comment{
+            body: "Reply line 1.\nReply line 2.",
+            author_display_name: "Replier",
+            resolved: false
+          }
+        ]
+      }
+
+      result = Output.format_comment(comment)
+      assert result =~ "> **Reply (Replier)**: Reply line 1.\n> Reply line 2."
+    end
+
+    test "handles unloaded replies association gracefully" do
+      comment = %Comment{
+        start_line: 1,
+        end_line: 1,
+        body: "No replies loaded.",
+        author_display_name: "Author"
+      }
+
+      # Default struct has NotLoaded for replies - should not crash
+      result = Output.format_comment(comment)
+      assert result == "> **[REVIEW COMMENT — Line 1 — Author]**: No replies loaded."
+    end
   end
 
   describe "generate_multi_file_review_md/2" do


### PR DESCRIPTION
## Summary
- `format_comment/1` now includes author display name and nested replies
- Resolved comments are filtered out of the markdown export
- Agents consuming `/api/export/:token/review` now see full thread context and only actionable comments

## Test plan
- Unit tests for format_comment with author, replies, and resolved filtering
- Tests for anonymous author fallback and multiline bodies
- Tests for resolved comment exclusion in generate_review_md
- All 195 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)