### PR TITLE
fix: port frontend parity from crit v0.6.0..HEAD

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -60,6 +60,10 @@
   --crit-diff-del-line-bg: rgba(247, 118, 142, 0.14);
   --crit-diff-word-add-bg: rgba(63, 185, 80, 0.4);
   --crit-diff-word-del-bg: rgba(248, 81, 73, 0.4);
+  --crit-diff-add-gutter: rgba(158, 206, 106, 0.12);
+  --crit-diff-del-gutter: rgba(247, 118, 142, 0.08);
+  --crit-scrollbar-bg: #1a1b26;
+  --crit-scrollbar-thumb: #3b4261;
   --crit-orange: #ff9e64;
   --crit-badge-resolved-bg: rgba(158, 206, 106, 0.12);
   --crit-badge-unresolved-bg: rgba(255, 158, 100, 0.14);
@@ -96,6 +100,10 @@
   --crit-diff-del-line-bg: rgba(247, 118, 142, 0.14);
   --crit-diff-word-add-bg: rgba(63, 185, 80, 0.4);
   --crit-diff-word-del-bg: rgba(248, 81, 73, 0.4);
+  --crit-diff-add-gutter: rgba(158, 206, 106, 0.12);
+  --crit-diff-del-gutter: rgba(247, 118, 142, 0.08);
+  --crit-scrollbar-bg: #1a1b26;
+  --crit-scrollbar-thumb: #3b4261;
   --crit-orange: #ff9e64;
   --crit-badge-resolved-bg: rgba(158, 206, 106, 0.12);
   --crit-badge-unresolved-bg: rgba(255, 158, 100, 0.14);
@@ -132,6 +140,10 @@
   --crit-diff-del-line-bg: rgba(207, 34, 46, 0.1);
   --crit-diff-word-add-bg: rgba(26, 127, 55, 0.25);
   --crit-diff-word-del-bg: rgba(207, 34, 46, 0.25);
+  --crit-diff-add-gutter: rgba(26, 127, 55, 0.1);
+  --crit-diff-del-gutter: rgba(207, 34, 46, 0.06);
+  --crit-scrollbar-bg: #fafafa;
+  --crit-scrollbar-thumb: #d0d0d0;
   --crit-orange: #bc4c00;
   --crit-badge-resolved-bg: rgba(26, 127, 55, 0.1);
   --crit-badge-unresolved-bg: rgba(188, 76, 0, 0.1);
@@ -169,6 +181,10 @@
     --crit-diff-del-line-bg: rgba(207, 34, 46, 0.1);
     --crit-diff-word-add-bg: rgba(26, 127, 55, 0.25);
     --crit-diff-word-del-bg: rgba(207, 34, 46, 0.25);
+    --crit-diff-add-gutter: rgba(26, 127, 55, 0.1);
+    --crit-diff-del-gutter: rgba(207, 34, 46, 0.06);
+    --crit-scrollbar-bg: #fafafa;
+    --crit-scrollbar-thumb: #d0d0d0;
     --crit-orange: #bc4c00;
     --crit-badge-resolved-bg: rgba(26, 127, 55, 0.1);
     --crit-badge-unresolved-bg: rgba(188, 76, 0, 0.1);
@@ -248,6 +264,12 @@
   line-height: 1.7;
   -webkit-font-smoothing: antialiased;
 }
+
+/* ===== Scrollbar ===== */
+.crit-page ::-webkit-scrollbar { width: 8px; height: 8px; }
+.crit-page ::-webkit-scrollbar-track { background: var(--crit-scrollbar-bg); }
+.crit-page ::-webkit-scrollbar-thumb { background: var(--crit-scrollbar-thumb); border-radius: 4px; }
+.crit-page ::-webkit-scrollbar-thumb:hover { background: var(--crit-fg-muted); }
 
 .crit-header {
   position: sticky;
@@ -589,6 +611,15 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
 }
 .diff-word-add { background: var(--crit-diff-word-add-bg); border-radius: 2px; padding: 0 1px; }
 .diff-word-del { background: var(--crit-diff-word-del-bg); border-radius: 2px; padding: 0 1px; }
+
+/* ===== Diff Gutter Backgrounds ===== */
+/* Unified diff */
+.diff-container.unified .addition .diff-gutter-num:last-child { background: var(--crit-diff-add-gutter); }
+.diff-container.unified .deletion .diff-gutter-num:first-child { background: var(--crit-diff-del-gutter); }
+/* Split diff */
+.diff-split-side.deletion .diff-gutter-num { background: var(--crit-diff-del-gutter); }
+.diff-split-side.addition .diff-gutter-num { background: var(--crit-diff-add-gutter); }
+
 .comment-body a { color: var(--crit-accent); text-decoration: none; border-bottom: 1px solid var(--crit-accent-subtle); }
 .comment-body a:hover { color: var(--crit-accent-hover); }
 .comment-time { font-size: 11px; color: var(--crit-fg-dimmed); }
@@ -1025,40 +1056,71 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
   border-top: 1px solid var(--crit-border);
 }
 
-/* ===== highlight.js Dark Theme ===== */
-[data-theme="dark"] .hljs,html:not([data-theme]) .hljs{color:#adbac7;background:#22272e}
-[data-theme="dark"] .hljs-keyword,[data-theme="dark"] .hljs-type,[data-theme="dark"] .hljs-variable.language_,html:not([data-theme]) .hljs-keyword,html:not([data-theme]) .hljs-type,html:not([data-theme]) .hljs-variable.language_{color:#f47067}
-[data-theme="dark"] .hljs-title,[data-theme="dark"] .hljs-title.class_,[data-theme="dark"] .hljs-title.function_,html:not([data-theme]) .hljs-title,html:not([data-theme]) .hljs-title.class_,html:not([data-theme]) .hljs-title.function_{color:#dcbdfb}
-[data-theme="dark"] .hljs-attr,[data-theme="dark"] .hljs-number,[data-theme="dark"] .hljs-operator,[data-theme="dark"] .hljs-variable,html:not([data-theme]) .hljs-attr,html:not([data-theme]) .hljs-number,html:not([data-theme]) .hljs-operator,html:not([data-theme]) .hljs-variable{color:#6cb6ff}
-[data-theme="dark"] .hljs-string,[data-theme="dark"] .hljs-regexp,html:not([data-theme]) .hljs-string,html:not([data-theme]) .hljs-regexp{color:#96d0ff}
-[data-theme="dark"] .hljs-built_in,[data-theme="dark"] .hljs-symbol,html:not([data-theme]) .hljs-built_in,html:not([data-theme]) .hljs-symbol{color:#f69d50}
-[data-theme="dark"] .hljs-comment,html:not([data-theme]) .hljs-comment{color:#768390}
-[data-theme="dark"] .hljs-name,[data-theme="dark"] .hljs-selector-tag,html:not([data-theme]) .hljs-name,html:not([data-theme]) .hljs-selector-tag{color:#8ddb8c}
-[data-theme="dark"] .hljs-addition,html:not([data-theme]) .hljs-addition{color:#b4f1b4;background-color:#1b4721}
-[data-theme="dark"] .hljs-deletion,html:not([data-theme]) .hljs-deletion{color:#ffd8d3;background-color:#78191b}
+/* ===== highlight.js Dark Theme (default + explicit dark) ===== */
+.hljs{color:#adbac7;background:#22272e}
+.hljs-doctag,.hljs-keyword,.hljs-meta .hljs-keyword,.hljs-template-tag,.hljs-template-variable,.hljs-type,.hljs-variable.language_{color:#f47067}
+.hljs-title,.hljs-title.class_,.hljs-title.class_.inherited__,.hljs-title.function_{color:#dcbdfb}
+.hljs-attr,.hljs-attribute,.hljs-literal,.hljs-meta,.hljs-number,.hljs-operator,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id,.hljs-variable{color:#6cb6ff}
+.hljs-meta .hljs-string,.hljs-regexp,.hljs-string{color:#96d0ff}
+.hljs-built_in,.hljs-symbol{color:#f69d50}
+.hljs-code,.hljs-comment,.hljs-formula{color:#768390}
+.hljs-name,.hljs-quote,.hljs-selector-pseudo,.hljs-selector-tag{color:#8ddb8c}
+.hljs-subst{color:#adbac7}
+.hljs-section{color:#316dca;font-weight:700}
+.hljs-bullet{color:#eac55f}
+.hljs-emphasis{color:#adbac7;font-style:italic}
+.hljs-strong{color:#adbac7;font-weight:700}
+.hljs-addition{color:#b4f1b4;background-color:#1b4721}
+.hljs-deletion{color:#ffd8d3;background-color:#78191b}
+
+[data-theme="dark"] .hljs{color:#adbac7;background:#22272e}
+[data-theme="dark"] .hljs-doctag,[data-theme="dark"] .hljs-keyword,[data-theme="dark"] .hljs-meta .hljs-keyword,[data-theme="dark"] .hljs-template-tag,[data-theme="dark"] .hljs-template-variable,[data-theme="dark"] .hljs-type,[data-theme="dark"] .hljs-variable.language_{color:#f47067}
+[data-theme="dark"] .hljs-title,[data-theme="dark"] .hljs-title.class_,[data-theme="dark"] .hljs-title.class_.inherited__,[data-theme="dark"] .hljs-title.function_{color:#dcbdfb}
+[data-theme="dark"] .hljs-attr,[data-theme="dark"] .hljs-attribute,[data-theme="dark"] .hljs-literal,[data-theme="dark"] .hljs-meta,[data-theme="dark"] .hljs-number,[data-theme="dark"] .hljs-operator,[data-theme="dark"] .hljs-selector-attr,[data-theme="dark"] .hljs-selector-class,[data-theme="dark"] .hljs-selector-id,[data-theme="dark"] .hljs-variable{color:#6cb6ff}
+[data-theme="dark"] .hljs-meta .hljs-string,[data-theme="dark"] .hljs-regexp,[data-theme="dark"] .hljs-string{color:#96d0ff}
+[data-theme="dark"] .hljs-built_in,[data-theme="dark"] .hljs-symbol{color:#f69d50}
+[data-theme="dark"] .hljs-code,[data-theme="dark"] .hljs-comment,[data-theme="dark"] .hljs-formula{color:#768390}
+[data-theme="dark"] .hljs-name,[data-theme="dark"] .hljs-quote,[data-theme="dark"] .hljs-selector-pseudo,[data-theme="dark"] .hljs-selector-tag{color:#8ddb8c}
+[data-theme="dark"] .hljs-subst{color:#adbac7}
+[data-theme="dark"] .hljs-section{color:#316dca;font-weight:700}
+[data-theme="dark"] .hljs-bullet{color:#eac55f}
+[data-theme="dark"] .hljs-emphasis{color:#adbac7;font-style:italic}
+[data-theme="dark"] .hljs-strong{color:#adbac7;font-weight:700}
+[data-theme="dark"] .hljs-addition{color:#b4f1b4;background-color:#1b4721}
+[data-theme="dark"] .hljs-deletion{color:#ffd8d3;background-color:#78191b}
 
 /* ===== highlight.js Light Theme ===== */
 [data-theme="light"] .hljs{color:#24292e;background:#fff}
-[data-theme="light"] .hljs-keyword,[data-theme="light"] .hljs-type{color:#d73a49}
-[data-theme="light"] .hljs-title,[data-theme="light"] .hljs-title.function_{color:#6f42c1}
-[data-theme="light"] .hljs-attr,[data-theme="light"] .hljs-number,[data-theme="light"] .hljs-variable{color:#005cc5}
-[data-theme="light"] .hljs-string,[data-theme="light"] .hljs-regexp{color:#032f62}
-[data-theme="light"] .hljs-built_in{color:#e36209}
-[data-theme="light"] .hljs-comment{color:#6a737d}
-[data-theme="light"] .hljs-name{color:#22863a}
+[data-theme="light"] .hljs-doctag,[data-theme="light"] .hljs-keyword,[data-theme="light"] .hljs-meta .hljs-keyword,[data-theme="light"] .hljs-template-tag,[data-theme="light"] .hljs-template-variable,[data-theme="light"] .hljs-type,[data-theme="light"] .hljs-variable.language_{color:#d73a49}
+[data-theme="light"] .hljs-title,[data-theme="light"] .hljs-title.class_,[data-theme="light"] .hljs-title.class_.inherited__,[data-theme="light"] .hljs-title.function_{color:#6f42c1}
+[data-theme="light"] .hljs-attr,[data-theme="light"] .hljs-attribute,[data-theme="light"] .hljs-literal,[data-theme="light"] .hljs-meta,[data-theme="light"] .hljs-number,[data-theme="light"] .hljs-operator,[data-theme="light"] .hljs-selector-attr,[data-theme="light"] .hljs-selector-class,[data-theme="light"] .hljs-selector-id,[data-theme="light"] .hljs-variable{color:#005cc5}
+[data-theme="light"] .hljs-meta .hljs-string,[data-theme="light"] .hljs-regexp,[data-theme="light"] .hljs-string{color:#032f62}
+[data-theme="light"] .hljs-built_in,[data-theme="light"] .hljs-symbol{color:#e36209}
+[data-theme="light"] .hljs-code,[data-theme="light"] .hljs-comment,[data-theme="light"] .hljs-formula{color:#6a737d}
+[data-theme="light"] .hljs-name,[data-theme="light"] .hljs-quote,[data-theme="light"] .hljs-selector-pseudo,[data-theme="light"] .hljs-selector-tag{color:#22863a}
+[data-theme="light"] .hljs-subst{color:#24292e}
+[data-theme="light"] .hljs-section{color:#005cc5;font-weight:700}
+[data-theme="light"] .hljs-bullet{color:#735c0f}
+[data-theme="light"] .hljs-emphasis{color:#24292e;font-style:italic}
+[data-theme="light"] .hljs-strong{color:#24292e;font-weight:700}
 [data-theme="light"] .hljs-addition{color:#22863a;background-color:#f0fff4}
 [data-theme="light"] .hljs-deletion{color:#b31d28;background-color:#ffeef0}
 
 /* ===== highlight.js System Theme (light OS preference override) ===== */
 @media (prefers-color-scheme: light) {
   html:not([data-theme]) .hljs{color:#24292e;background:#fff}
-  html:not([data-theme]) .hljs-keyword,html:not([data-theme]) .hljs-type,html:not([data-theme]) .hljs-variable.language_{color:#d73a49}
-  html:not([data-theme]) .hljs-title,html:not([data-theme]) .hljs-title.class_,html:not([data-theme]) .hljs-title.function_{color:#6f42c1}
-  html:not([data-theme]) .hljs-attr,html:not([data-theme]) .hljs-number,html:not([data-theme]) .hljs-operator,html:not([data-theme]) .hljs-variable{color:#005cc5}
-  html:not([data-theme]) .hljs-string,html:not([data-theme]) .hljs-regexp{color:#032f62}
+  html:not([data-theme]) .hljs-doctag,html:not([data-theme]) .hljs-keyword,html:not([data-theme]) .hljs-meta .hljs-keyword,html:not([data-theme]) .hljs-template-tag,html:not([data-theme]) .hljs-template-variable,html:not([data-theme]) .hljs-type,html:not([data-theme]) .hljs-variable.language_{color:#d73a49}
+  html:not([data-theme]) .hljs-title,html:not([data-theme]) .hljs-title.class_,html:not([data-theme]) .hljs-title.class_.inherited__,html:not([data-theme]) .hljs-title.function_{color:#6f42c1}
+  html:not([data-theme]) .hljs-attr,html:not([data-theme]) .hljs-attribute,html:not([data-theme]) .hljs-literal,html:not([data-theme]) .hljs-meta,html:not([data-theme]) .hljs-number,html:not([data-theme]) .hljs-operator,html:not([data-theme]) .hljs-selector-attr,html:not([data-theme]) .hljs-selector-class,html:not([data-theme]) .hljs-selector-id,html:not([data-theme]) .hljs-variable{color:#005cc5}
+  html:not([data-theme]) .hljs-meta .hljs-string,html:not([data-theme]) .hljs-regexp,html:not([data-theme]) .hljs-string{color:#032f62}
   html:not([data-theme]) .hljs-built_in,html:not([data-theme]) .hljs-symbol{color:#e36209}
-  html:not([data-theme]) .hljs-comment{color:#6a737d}
-  html:not([data-theme]) .hljs-name,html:not([data-theme]) .hljs-selector-tag{color:#22863a}
+  html:not([data-theme]) .hljs-code,html:not([data-theme]) .hljs-comment,html:not([data-theme]) .hljs-formula{color:#6a737d}
+  html:not([data-theme]) .hljs-name,html:not([data-theme]) .hljs-quote,html:not([data-theme]) .hljs-selector-pseudo,html:not([data-theme]) .hljs-selector-tag{color:#22863a}
+  html:not([data-theme]) .hljs-subst{color:#24292e}
+  html:not([data-theme]) .hljs-section{color:#005cc5;font-weight:700}
+  html:not([data-theme]) .hljs-bullet{color:#735c0f}
+  html:not([data-theme]) .hljs-emphasis{color:#24292e;font-style:italic}
+  html:not([data-theme]) .hljs-strong{color:#24292e;font-weight:700}
   html:not([data-theme]) .hljs-addition{color:#22863a;background-color:#f0fff4}
   html:not([data-theme]) .hljs-deletion{color:#b31d28;background-color:#ffeef0}
 }

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1491,7 +1491,17 @@ function highlightQuotesInSection(sectionEl, file, activeForms) {
     var fullText = textNodes.map(function(n) { return n.textContent }).join('')
     var normalizedQuote = comment.quote.replace(/\s+/g, ' ')
     var normalizedFull = fullText.replace(/\s+/g, ' ')
-    var quoteIdx = normalizedFull.indexOf(normalizedQuote)
+    var quoteIdx = -1
+    // Use quote_offset when available to disambiguate duplicate substrings
+    if (comment.quote_offset != null) {
+      var candidateIdx = comment.quote_offset
+      if (normalizedFull.substring(candidateIdx, candidateIdx + normalizedQuote.length) === normalizedQuote) {
+        quoteIdx = candidateIdx
+      }
+    }
+    if (quoteIdx === -1) {
+      quoteIdx = normalizedFull.indexOf(normalizedQuote)
+    }
     if (quoteIdx === -1) {
       quoteIdx = normalizedFull.toLowerCase().indexOf(normalizedQuote.toLowerCase())
     }


### PR DESCRIPTION
## Summary
Post-release audit of crit (v0.6.0..HEAD) found 4 frontend features/fixes that weren't ported to crit-web.

**P0 — Visible UX difference:**
- `quote_offset` disambiguation: when the same text appears multiple times in a code range, crit-web now highlights the correct occurrence instead of always the first

**P1 — Functional gaps:**
- Diff gutter backgrounds now use `--crit-diff-add-gutter`/`--crit-diff-del-gutter` CSS vars
- Highlight.js theme expanded from ~31 to ~61 rules for full dark/light parity with crit
- Global scrollbar theming added (scoped to `.crit-page`)

## Test plan
- [ ] Comments on duplicate text highlight the correct occurrence
- [ ] Diff gutters show colored backgrounds in both themes
- [ ] Syntax highlighting matches crit local in both dark and light themes
- [ ] Scrollbars are styled consistently on the review page

🤖 Generated with [Claude Code](https://claude.com/claude-code)