### PR TITLE
docs: add no-analytics privacy note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ mix precommit   # Full CI check before submitting
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
+## Privacy
+
+Crit Web collects no analytics or tracking data. There is no telemetry, no usage stats, and no phone-home. If we ever add anonymous usage statistics in the future, they will be explicitly opt-in.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Adds a "Privacy" section to the README noting that crit-web collects no analytics or tracking data
- States that if anonymous usage stats are ever added, they will be explicitly opt-in

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)