### PR TITLE
feat: add DB_SSL and DB_SSL_CA_CERT for SSL database connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ export CRIT_SHARE_URL=https://reviews.yourdomain.com
 | `DB_PASSWORD` | Yes* | — | Database password |
 | `DB_NAME` | Yes* | — | Database name |
 | `DB_PORT` | No | `5432` | Database port (only used with `DB_HOST`) |
-| `DB_SSL` | No | — | Set to `require` for an encrypted connection without certificate verification (typical for AWS RDS) |
-| `DB_SSL_CA_CERT` | No | — | Path to a CA certificate file. Enables SSL with full `verify_peer` verification (requires volume mount in Docker) |
+| `DB_SSL` | No | — | Set to `true` to enable SSL. Without `DB_SSL_CA_CERT`, connects encrypted without certificate verification (typical for AWS RDS) |
+| `DB_SSL_CA_CERT` | No | — | Path to a CA certificate file. When set alongside `DB_SSL=true`, enables full `verify_peer` verification (requires volume mount in Docker) |
 | `SECRET_KEY_BASE` | Yes | — | Session signing key. Generate with `openssl rand -base64 64` |
 | `SELFHOSTED` | Yes | — | Set to `true` to enable self-hosted mode (dashboard, no marketing pages) |
 | `ADMIN_PASSWORD` | No | — | Password for the `/dashboard` admin panel. If unset, the dashboard is accessible without authentication |

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -60,15 +60,13 @@ if config_env() == :prod do
   maybe_ipv6 = if System.get_env("ECTO_IPV6") in ~w(true 1), do: [:inet6], else: []
 
   ssl_opts =
-    cond do
-      ca_cert = System.get_env("DB_SSL_CA_CERT") ->
-        [verify: :verify_peer, cacertfile: ca_cert]
-
-      System.get_env("DB_SSL") == "require" ->
-        [verify: :verify_none]
-
-      true ->
-        false
+    if System.get_env("DB_SSL") in ~w(true 1) do
+      case System.get_env("DB_SSL_CA_CERT") do
+        nil -> [verify: :verify_none]
+        path -> [verify: :verify_peer, cacertfile: path]
+      end
+    else
+      false
     end
 
   config :crit, Crit.Repo,

--- a/lib/crit_web/controllers/page_html/self_hosting.html.heex
+++ b/lib/crit_web/controllers/page_html/self_hosting.html.heex
@@ -271,9 +271,9 @@
             </code>
             <div class="flex-1 min-w-0">
               <p class="text-sm text-(--crit-fg-secondary)">
-                Set to <code class="text-[0.9em]">require</code>
-                for an encrypted connection without
-                certificate verification — recommended for AWS RDS without a CA bundle
+                Set to <code class="text-[0.9em]">true</code>
+                to enable SSL. Without <code class="text-[0.9em]">DB_SSL_CA_CERT</code>, connects
+                encrypted without certificate verification — recommended for AWS RDS
               </p>
             </div>
             <span class="text-xs font-mono text-(--crit-fg-muted) shrink-0">optional</span>
@@ -284,7 +284,7 @@
             </code>
             <div class="flex-1 min-w-0">
               <p class="text-sm text-(--crit-fg-secondary)">
-                Path to a CA certificate file. Enables SSL with full
+                Path to a CA certificate file. When set alongside <code class="text-[0.9em]">DB_SSL=true</code>, enables full
                 <code class="text-[0.9em]">verify_peer</code>
                 verification. In Docker, mount the file as a volume and pass the container path
               </p>


### PR DESCRIPTION
## What changed

Adds two new optional environment variables for SSL database connections:

- `DB_SSL=true` — enables SSL with full certificate verification (Postgrex secure defaults)
- `DB_SSL=require` — enables SSL but skips certificate verification (recommended for AWS RDS without a CA bundle)
- `DB_SSL_CA_CERT=/path/to/ca.pem` — path to a CA certificate file, used alongside `DB_SSL=true` for custom or RDS CAs

Documented in README and self-hosting page.

## Why

AWS RDS (and other managed Postgres providers) enforce SSL connections. Previously there was no way to configure SSL without modifying the source.