### PR TITLE
feat: split dashboard into personal + admin views

### DIFF
--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -491,6 +491,46 @@ defmodule Crit.Reviews do
   end
 
   @doc """
+  Returns reviews for a specific user as plain maps with comment/file counts.
+  Same as `list_reviews_with_counts/0` but filtered to the given user_id.
+  """
+  def list_user_reviews_with_counts(user_id) do
+    first_file_subquery =
+      from(rf in ReviewRoundSnapshot,
+        where: rf.review_id == parent_as(:review).id,
+        order_by: [asc: rf.position],
+        limit: 1,
+        select: rf.file_path
+      )
+
+    from(r in Review, as: :review)
+    |> where([r], r.user_id == ^user_id)
+    |> join(:left, [r], c in Comment, on: c.review_id == r.id)
+    |> join(:left, [r, _c], rf in ReviewRoundSnapshot, on: rf.review_id == r.id)
+    |> join(:left_lateral, [r, _c, _rf], fp in subquery(first_file_subquery), on: true)
+    |> group_by([r, _c, _rf, fp], [
+      r.id,
+      r.token,
+      r.inserted_at,
+      r.last_activity_at,
+      r.user_id,
+      fp.file_path
+    ])
+    |> select([r, c, rf, fp], %{
+      id: r.id,
+      token: r.token,
+      inserted_at: r.inserted_at,
+      last_activity_at: r.last_activity_at,
+      user_id: r.user_id,
+      comment_count: count(c.id, :distinct),
+      file_count: count(rf.id, :distinct),
+      first_file_path: fp.file_path
+    })
+    |> order_by([r], desc: r.last_activity_at)
+    |> Repo.all()
+  end
+
+  @doc """
   Delete a review by its id.
 
   Accepts an optional `owner_id` keyword argument. When provided, deletion is

--- a/lib/crit_web/components/layouts.ex
+++ b/lib/crit_web/components/layouts.ex
@@ -87,6 +87,8 @@ defmodule CritWeb.Layouts do
   @doc """
   Shared site header with navigation links, used across all public pages.
   """
+  attr :current_user, :any, default: nil
+
   def site_header(assigns) do
     ~H"""
     <header class="border-b border-[var(--crit-border)] bg-[var(--crit-bg-secondary)]">
@@ -131,6 +133,43 @@ defmodule CritWeb.Layouts do
             </svg>
             GitHub
           </a>
+          <%= if @current_user do %>
+            <a
+              href={~p"/dashboard"}
+              class="text-sm text-[var(--crit-fg-muted)] no-underline hover:text-[var(--crit-fg-primary)] transition-colors"
+            >
+              Dashboard
+            </a>
+            <div class="flex items-center gap-3">
+              <%= if @current_user.avatar_url do %>
+                <img
+                  src={@current_user.avatar_url}
+                  alt={@current_user.name}
+                  class="h-6 w-6 rounded-full"
+                />
+              <% end %>
+              <a
+                href={~p"/settings"}
+                class="text-sm text-[var(--crit-fg-primary)] no-underline hover:text-[var(--crit-accent)] transition-colors"
+              >
+                {@current_user.name || @current_user.email}
+              </a>
+              <.link
+                href={~p"/auth/logout"}
+                method="delete"
+                class="text-sm text-[var(--crit-fg-muted)] hover:text-[var(--crit-fg-primary)] transition-colors"
+              >
+                Sign out
+              </.link>
+            </div>
+          <% else %>
+            <a
+              href={~p"/auth/login?return_to=/dashboard"}
+              class="text-sm text-[var(--crit-fg-muted)] no-underline hover:text-[var(--crit-fg-primary)] transition-colors"
+            >
+              Sign in
+            </a>
+          <% end %>
           <.theme_toggle />
         </nav>
         <%!-- Mobile: theme toggle + hamburger --%>
@@ -181,6 +220,43 @@ defmodule CritWeb.Layouts do
             </svg>
             GitHub
           </a>
+          <%= if @current_user do %>
+            <a
+              href={~p"/dashboard"}
+              class="text-sm text-[var(--crit-fg-muted)] no-underline hover:text-[var(--crit-fg-primary)] py-1.5"
+            >
+              Dashboard
+            </a>
+            <a
+              href={~p"/settings"}
+              class="flex items-center gap-2 py-1.5 no-underline"
+            >
+              <%= if @current_user.avatar_url do %>
+                <img
+                  src={@current_user.avatar_url}
+                  alt={@current_user.name}
+                  class="h-5 w-5 rounded-full"
+                />
+              <% end %>
+              <span class="text-sm text-[var(--crit-fg-primary)] hover:text-[var(--crit-accent)]">
+                {@current_user.name || @current_user.email}
+              </span>
+            </a>
+            <.link
+              href={~p"/auth/logout"}
+              method="delete"
+              class="text-sm text-red-400 hover:text-red-300 no-underline py-1.5"
+            >
+              Sign out
+            </.link>
+          <% else %>
+            <a
+              href={~p"/auth/login?return_to=/dashboard"}
+              class="text-sm text-[var(--crit-fg-muted)] no-underline hover:text-[var(--crit-fg-primary)] py-1.5"
+            >
+              Sign in
+            </a>
+          <% end %>
         </div>
       </div>
     </header>
@@ -188,11 +264,15 @@ defmodule CritWeb.Layouts do
   end
 
   @doc """
-  Simplified header for self-hosted dashboard. No marketing nav links.
+  Header for dashboard and admin pages. No marketing nav links.
+  Used in both public and selfhosted modes.
   """
-  attr :authenticated, :boolean, default: false
+  attr :authenticated, :boolean, default: true
   attr :password_required, :boolean, default: false
   attr :current_user, :any, default: nil
+  attr :show_admin_link, :boolean, default: false
+  attr :show_my_reviews_link, :boolean, default: false
+  attr :show_settings_link, :boolean, default: false
 
   def dashboard_header(assigns) do
     ~H"""
@@ -205,101 +285,109 @@ defmodule CritWeb.Layouts do
           >
             Crit
           </a>
-          <span class="text-xs text-[var(--crit-fg-muted)] border border-[var(--crit-border)] px-2 py-0.5 rounded">
-            self-hosted
-          </span>
         </div>
         <nav class="flex items-center gap-4">
-          <%= if @password_required do %>
-            <%= if @authenticated do %>
-              <%= if @current_user do %>
-                <div class="flex items-center gap-3">
-                  <%= if @current_user.avatar_url do %>
-                    <img
-                      src={@current_user.avatar_url}
-                      alt={@current_user.name}
-                      class="h-8 w-8 rounded-full"
-                    />
-                  <% end %>
-                  <span class="text-sm text-[var(--crit-fg-primary)] max-sm:hidden">
-                    {@current_user.name || @current_user.email}
-                  </span>
-                  <.link
-                    href={~p"/settings"}
-                    class="text-sm text-[var(--crit-fg-muted)] hover:text-[var(--crit-fg-primary)] max-sm:hidden"
-                  >
-                    Settings
-                  </.link>
-                  <.link
-                    href={~p"/auth/logout"}
-                    method="delete"
-                    class="text-sm text-[var(--crit-fg-muted)] hover:text-[var(--crit-fg-primary)] max-sm:hidden"
-                  >
-                    Sign out
-                  </.link>
-                </div>
-              <% else %>
-                <.form
-                  for={%{}}
-                  action={~p"/auth/logout"}
-                  method="post"
-                  id="logout-form"
-                  class="max-sm:hidden"
-                >
-                  <button
-                    type="submit"
-                    class="text-sm text-red-400 hover:text-red-300 transition-colors cursor-pointer"
-                  >
-                    Sign out
-                  </button>
-                </.form>
+          <%= if @current_user do %>
+            <div class="flex items-center gap-3 max-sm:hidden">
+              <%= if @current_user.avatar_url do %>
+                <img
+                  src={@current_user.avatar_url}
+                  alt={@current_user.name}
+                  class="h-8 w-8 rounded-full"
+                />
               <% end %>
-            <% else %>
+              <span class="text-sm text-[var(--crit-fg-primary)]">
+                {@current_user.name || @current_user.email}
+              </span>
+              <%= if @show_my_reviews_link do %>
+                <.link
+                  href={~p"/dashboard"}
+                  class="text-sm text-[var(--crit-fg-muted)] hover:text-[var(--crit-fg-primary)]"
+                >
+                  My Reviews
+                </.link>
+              <% end %>
+              <%= if @show_admin_link do %>
+                <.link
+                  href={~p"/admin"}
+                  class="text-sm text-[var(--crit-fg-muted)] hover:text-[var(--crit-fg-primary)]"
+                >
+                  Admin
+                </.link>
+              <% end %>
+              <%= if @show_settings_link do %>
+                <.link
+                  navigate={~p"/settings"}
+                  class="text-sm text-[var(--crit-fg-muted)] hover:text-[var(--crit-fg-primary)]"
+                >
+                  Settings
+                </.link>
+              <% end %>
+              <.link
+                href={~p"/auth/logout"}
+                method="delete"
+                class="text-sm text-[var(--crit-fg-muted)] hover:text-[var(--crit-fg-primary)]"
+              >
+                Sign out
+              </.link>
+            </div>
+          <% else %>
+            <%= if @password_required and not @authenticated do %>
               <a
                 href="#login"
-                class="text-sm text-[var(--crit-fg-muted)] hover:text-[var(--crit-fg-primary)] transition-colors"
+                class="text-sm text-[var(--crit-fg-muted)] hover:text-[var(--crit-fg-primary)] transition-colors max-sm:hidden"
               >
                 Sign in
               </a>
             <% end %>
           <% end %>
           <.theme_toggle />
-          <%= if @authenticated do %>
-            <button
-              id="dashboard-nav-toggle"
-              class="sm:hidden p-1 text-[var(--crit-fg-muted)] hover:text-[var(--crit-fg-primary)] cursor-pointer"
-              aria-label="Toggle menu"
-            >
-              <.icon name="hero-bars-3" class="size-5" />
-            </button>
-          <% end %>
+          <button
+            id="dashboard-nav-toggle"
+            class="sm:hidden p-1 text-[var(--crit-fg-muted)] hover:text-[var(--crit-fg-primary)] cursor-pointer"
+            aria-label="Toggle menu"
+          >
+            <.icon name="hero-bars-3" class="size-5" />
+          </button>
         </nav>
       </div>
       <%!-- Mobile nav dropdown --%>
-      <%= if @authenticated do %>
-        <div id="dashboard-nav" class="hidden sm:hidden border-t border-[var(--crit-border)]">
-          <div class="flex flex-col px-5 py-2">
+      <div id="dashboard-nav" class="hidden sm:hidden border-t border-[var(--crit-border)]">
+        <div class="flex flex-col px-5 py-2">
+          <%= if @show_my_reviews_link do %>
             <.link
               href={~p"/dashboard"}
               class="text-sm text-[var(--crit-fg-muted)] no-underline hover:text-[var(--crit-fg-primary)] py-2"
             >
-              Dashboard
+              My Reviews
             </.link>
-            <%= if @current_user do %>
-              <.link
-                href={~p"/settings"}
-                class="text-sm text-[var(--crit-fg-muted)] no-underline hover:text-[var(--crit-fg-primary)] py-2"
-              >
-                Settings
-              </.link>
-              <.link
-                href={~p"/auth/logout"}
-                method="delete"
-                class="text-sm text-red-400 hover:text-red-300 no-underline py-2"
-              >
-                Sign out
-              </.link>
-            <% else %>
+          <% end %>
+          <%= if @show_admin_link do %>
+            <.link
+              href={~p"/admin"}
+              class="text-sm text-[var(--crit-fg-muted)] no-underline hover:text-[var(--crit-fg-primary)] py-2"
+            >
+              Admin
+            </.link>
+          <% end %>
+          <%= if @show_settings_link do %>
+            <.link
+              navigate={~p"/settings"}
+              class="text-sm text-[var(--crit-fg-muted)] no-underline hover:text-[var(--crit-fg-primary)] py-2"
+            >
+              Settings
+            </.link>
+          <% end %>
+          <%= if @current_user do %>
+            <.link
+              href={~p"/auth/logout"}
+              method="delete"
+              class="text-sm text-red-400 hover:text-red-300 no-underline py-2"
+            >
+              Sign out
+            </.link>
+          <% else %>
+            <%= if @password_required and @authenticated do %>
               <.form for={%{}} action={~p"/auth/logout"} method="post" id="logout-form-mobile">
                 <button
                   type="submit"
@@ -309,9 +397,9 @@ defmodule CritWeb.Layouts do
                 </button>
               </.form>
             <% end %>
-          </div>
+          <% end %>
         </div>
-      <% end %>
+      </div>
     </header>
     """
   end

--- a/lib/crit_web/controllers/oauth_controller.ex
+++ b/lib/crit_web/controllers/oauth_controller.ex
@@ -17,7 +17,7 @@ defmodule CritWeb.OAuthController do
       {:error, _reason} ->
         conn
         |> put_flash(:error, "Could not reach OAuth provider.")
-        |> redirect(to: ~p"/dashboard")
+        |> redirect(to: ~p"/")
     end
   end
 
@@ -36,12 +36,7 @@ defmodule CritWeb.OAuthController do
           {:ok, user} ->
             device_code_id = get_session(conn, :device_code_id)
 
-            default_redirect =
-              if Application.get_env(:crit, :selfhosted),
-                do: ~p"/dashboard",
-                else: ~p"/settings"
-
-            return_to = get_session(conn, :oauth_return_to) || default_redirect
+            return_to = get_session(conn, :oauth_return_to) || ~p"/dashboard"
 
             conn =
               conn
@@ -62,13 +57,13 @@ defmodule CritWeb.OAuthController do
           {:error, _changeset} ->
             conn
             |> put_flash(:error, "Could not complete sign-in. Please try again.")
-            |> redirect(to: ~p"/dashboard")
+            |> redirect(to: ~p"/")
         end
 
       {:error, _reason} ->
         conn
         |> put_flash(:error, "OAuth callback failed. Please try again.")
-        |> redirect(to: ~p"/dashboard")
+        |> redirect(to: ~p"/")
     end
   end
 

--- a/lib/crit_web/controllers/page_html/changelog.html.heex
+++ b/lib/crit_web/controllers/page_html/changelog.html.heex
@@ -1,5 +1,5 @@
 <div class="min-h-screen bg-(--crit-bg-primary) text-(--crit-fg-primary) font-sans antialiased">
-  <Layouts.site_header />
+  <Layouts.site_header current_user={@current_user} />
   <div class="max-w-[1100px] mx-auto w-full px-10 mt-10 pb-20 max-sm:px-5 max-sm:pb-10">
     <header class="mb-14 max-sm:mt-10 max-sm:mb-10">
       <p class="font-mono text-xs tracking-widest uppercase text-(--crit-fg-muted) mb-3">

--- a/lib/crit_web/controllers/page_html/feature.html.heex
+++ b/lib/crit_web/controllers/page_html/feature.html.heex
@@ -1,7 +1,7 @@
 <Layouts.flash_group flash={@flash} />
 
 <div class="min-h-screen bg-(--crit-bg-primary) text-(--crit-fg-primary) font-sans flex flex-col">
-  <Layouts.site_header />
+  <Layouts.site_header current_user={@current_user} />
   
 <!-- Breadcrumb -->
   <div class="max-w-[1100px] mx-auto w-full px-10 mt-10 max-sm:px-5 max-sm:mt-5">

--- a/lib/crit_web/controllers/page_html/features.html.heex
+++ b/lib/crit_web/controllers/page_html/features.html.heex
@@ -1,7 +1,7 @@
 <Layouts.flash_group flash={@flash} />
 
 <div class="min-h-screen bg-(--crit-bg-primary) text-(--crit-fg-primary) font-sans flex flex-col">
-  <Layouts.site_header />
+  <Layouts.site_header current_user={@current_user} />
 
   <section class="max-w-[1100px] mx-auto w-full px-10 mt-10 max-sm:px-5 max-sm:mt-10">
     <p class="font-mono text-xs tracking-widest uppercase text-(--crit-accent) mb-3">

--- a/lib/crit_web/controllers/page_html/getting_started.html.heex
+++ b/lib/crit_web/controllers/page_html/getting_started.html.heex
@@ -1,5 +1,5 @@
 <div class="min-h-screen bg-(--crit-bg-primary) text-(--crit-fg-primary) font-sans antialiased">
-  <Layouts.site_header />
+  <Layouts.site_header current_user={@current_user} />
   <div class="max-w-[1100px] mx-auto mt-10 px-10 pb-20 max-sm:px-5 max-sm:pb-12">
     <%!-- Hero --%>
     <section class="mb-14 max-sm:mt-10 max-sm:mb-10">

--- a/lib/crit_web/controllers/page_html/home.html.heex
+++ b/lib/crit_web/controllers/page_html/home.html.heex
@@ -1,7 +1,7 @@
 <Layouts.flash_group flash={@flash} />
 
 <div class="min-h-screen bg-(--crit-bg-primary) text-(--crit-fg-primary) font-sans flex flex-col">
-  <Layouts.site_header />
+  <Layouts.site_header current_user={@current_user} />
 
   <section class="max-w-[1100px] mx-auto my-10 px-10 w-full max-sm:px-5 max-sm:mt-12">
     <div class="flex items-start gap-14 max-lg:flex-col max-lg:gap-10">

--- a/lib/crit_web/controllers/page_html/integrations.html.heex
+++ b/lib/crit_web/controllers/page_html/integrations.html.heex
@@ -1,7 +1,7 @@
 <Layouts.flash_group flash={@flash} />
 
 <div class="min-h-screen bg-(--crit-bg-primary) text-(--crit-fg-primary) font-sans flex flex-col">
-  <Layouts.site_header />
+  <Layouts.site_header current_user={@current_user} />
   
 <!-- Breadcrumb -->
   <div class="max-w-[1100px] mx-auto w-full px-10 mt-8 max-sm:px-5 max-sm:mt-5">

--- a/lib/crit_web/controllers/page_html/privacy.html.heex
+++ b/lib/crit_web/controllers/page_html/privacy.html.heex
@@ -1,5 +1,5 @@
 <div class="min-h-screen bg-(--crit-bg-primary) text-(--crit-fg-primary) font-sans antialiased">
-  <Layouts.site_header />
+  <Layouts.site_header current_user={@current_user} />
   <div class="max-w-[900px] mx-auto px-10 pb-15 max-sm:px-5 max-sm:pb-10">
     <main class="mt-12">
       <h1 class="text-3xl font-bold tracking-tight mb-2">Privacy Policy</h1>

--- a/lib/crit_web/controllers/page_html/self_hosting.html.heex
+++ b/lib/crit_web/controllers/page_html/self_hosting.html.heex
@@ -1,5 +1,5 @@
 <div class="min-h-screen bg-(--crit-bg-primary) text-(--crit-fg-primary) font-sans antialiased">
-  <Layouts.site_header />
+  <Layouts.site_header current_user={@current_user} />
   <div class="max-w-[1100px] mx-auto px-10 pb-20 max-sm:px-5 max-sm:pb-12">
     <%!-- Hero --%>
     <section class="mt-16 mb-14 max-sm:mt-10 max-sm:mb-10">

--- a/lib/crit_web/controllers/page_html/terms.html.heex
+++ b/lib/crit_web/controllers/page_html/terms.html.heex
@@ -1,5 +1,5 @@
 <div class="min-h-screen bg-(--crit-bg-primary) text-(--crit-fg-primary) font-sans antialiased">
-  <Layouts.site_header />
+  <Layouts.site_header current_user={@current_user} />
   <div class="max-w-[900px] mx-auto px-10 pb-15 max-sm:px-5 max-sm:pb-10">
     <main class="mt-12">
       <h1 class="text-3xl font-bold tracking-tight mb-2">Terms of Service</h1>

--- a/lib/crit_web/live/admin_live.ex
+++ b/lib/crit_web/live/admin_live.ex
@@ -1,0 +1,72 @@
+defmodule CritWeb.AdminLive do
+  use CritWeb, :live_view
+
+  alias Crit.{Reviews, Statistics}
+
+  import CritWeb.Helpers, only: [time_ago: 1]
+
+  @impl true
+  def mount(_params, _session, socket) do
+    %{authenticated: authenticated} = socket.assigns
+
+    stats = Statistics.dashboard_stats()
+    chart_data = Statistics.activity_chart(30)
+    max_count = chart_data |> Enum.map(&elem(&1, 1)) |> Enum.max(fn -> 1 end)
+
+    socket =
+      socket
+      |> assign(:stats, stats)
+      |> assign(:chart_data, chart_data)
+      |> assign(:max_count, max_count)
+      |> assign(:page_title, "Admin - Crit")
+      |> assign(:noindex, true)
+
+    socket =
+      if authenticated do
+        reviews = Reviews.list_reviews_with_counts()
+
+        socket
+        |> stream(:reviews, reviews)
+        |> assign(:review_count, length(reviews))
+      else
+        socket
+        |> assign(:review_count, 0)
+      end
+
+    {:ok, socket, layout: false}
+  end
+
+  @impl true
+  def handle_event("delete_review", %{"id" => id}, socket) do
+    %{oauth_configured: oauth_configured, current_user: current_user} = socket.assigns
+
+    opts =
+      if oauth_configured && current_user do
+        [owner_id: current_user.id]
+      else
+        []
+      end
+
+    case Reviews.delete_review(id, opts) do
+      :ok ->
+        reviews = Reviews.list_reviews_with_counts()
+        stats = Statistics.dashboard_stats()
+
+        {:noreply,
+         socket
+         |> stream(:reviews, reviews, reset: true)
+         |> assign(:review_count, length(reviews))
+         |> assign(:stats, stats)}
+
+      {:error, :unauthorized} ->
+        {:noreply, put_flash(socket, :error, "You can only delete your own reviews.")}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Failed to delete review.")}
+    end
+  end
+
+  defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
+  defp format_bytes(bytes) when bytes < 1_048_576, do: "#{Float.round(bytes / 1024, 1)} KB"
+  defp format_bytes(bytes), do: "#{Float.round(bytes / 1_048_576, 1)} MB"
+end

--- a/lib/crit_web/live/admin_live.html.heex
+++ b/lib/crit_web/live/admin_live.html.heex
@@ -1,0 +1,200 @@
+<Layouts.flash_group flash={@flash} />
+
+<div class="min-h-screen bg-(--crit-bg-primary) text-(--crit-fg-primary) font-sans flex flex-col">
+  <Layouts.dashboard_header
+    authenticated={@authenticated}
+    password_required={@password_required}
+    current_user={@current_user}
+    show_admin_link={false}
+    show_my_reviews_link={true}
+  />
+
+  <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">
+    <%!-- Stats cards --%>
+    <%!-- Desktop: 3 separate cards. Mobile: single unified strip with dividers. --%>
+    <div class="sm:grid sm:grid-cols-3 sm:gap-4 hidden">
+      <div class="border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg p-5">
+        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)]">Reviews</div>
+        <div class="text-3xl font-bold text-[var(--crit-fg-primary)] mt-1">
+          {@stats.total_reviews}
+        </div>
+        <div class="text-xs text-green-400 mt-1">+{@stats.reviews_this_week} this week</div>
+      </div>
+      <div class="border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg p-5">
+        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)]">Comments</div>
+        <div class="text-3xl font-bold text-[var(--crit-fg-primary)] mt-1">
+          {@stats.total_comments}
+        </div>
+        <div class="text-xs text-green-400 mt-1">
+          ~{Float.round(@stats.avg_comments_per_review, 1)} per review
+        </div>
+      </div>
+      <div class="border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg p-5">
+        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)]">Files</div>
+        <div class="text-3xl font-bold text-[var(--crit-fg-primary)] mt-1">
+          {@stats.total_files}
+        </div>
+        <div class="text-xs text-[var(--crit-fg-muted)] mt-1">
+          {format_bytes(@stats.total_storage_bytes)} total
+        </div>
+      </div>
+    </div>
+    <%!-- Mobile strip --%>
+    <div class="flex sm:hidden border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg overflow-hidden">
+      <div class="flex-1 px-4 py-3">
+        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)] mb-1">
+          Reviews
+        </div>
+        <div class="text-2xl font-bold text-[var(--crit-fg-primary)]">{@stats.total_reviews}</div>
+        <div class="text-xs text-green-400 mt-0.5">+{@stats.reviews_this_week} wk</div>
+      </div>
+      <div class="w-px bg-[var(--crit-border)]"></div>
+      <div class="flex-1 px-4 py-3">
+        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)] mb-1">
+          Comments
+        </div>
+        <div class="text-2xl font-bold text-[var(--crit-fg-primary)]">
+          {@stats.total_comments}
+        </div>
+        <div class="text-xs text-green-400 mt-0.5">
+          ~{Float.round(@stats.avg_comments_per_review, 1)}/review
+        </div>
+      </div>
+      <div class="w-px bg-[var(--crit-border)]"></div>
+      <div class="flex-1 px-4 py-3">
+        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)] mb-1">Files</div>
+        <div class="text-2xl font-bold text-[var(--crit-fg-primary)]">{@stats.total_files}</div>
+        <div class="text-xs text-[var(--crit-fg-muted)] mt-0.5">
+          {format_bytes(@stats.total_storage_bytes)}
+        </div>
+      </div>
+    </div>
+
+    <%!-- Activity chart --%>
+    <div class="border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg p-5 mt-4">
+      <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)] mb-3">
+        Activity &middot; Last 30 days
+      </div>
+      <div class="flex items-end gap-[3px] h-16">
+        <div
+          :for={{_date, count} <- @chart_data}
+          class="flex-1 rounded-sm min-h-[2px]"
+          style={"height: #{if @max_count > 0, do: max(round(count / @max_count * 100), 3), else: 3}%; background: color-mix(in srgb, var(--crit-accent) #{if @max_count > 0, do: max(round(count / @max_count * 100), 15), else: 15}%, transparent);"}
+          title={"#{count} reviews"}
+        />
+      </div>
+    </div>
+
+    <%!-- Review list or login prompt --%>
+    <%= if not @authenticated do %>
+      <div
+        id="login"
+        class="border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg p-8 mt-6 text-center"
+      >
+        <div class="text-[var(--crit-fg-muted)] text-sm mb-4">
+          <.icon name="hero-lock-closed" class="size-4 inline-block mr-1 -mt-0.5" />
+          Sign in to view and manage reviews
+        </div>
+        <%= if @oauth_configured do %>
+          <a
+            href={~p"/auth/login"}
+            class="inline-flex items-center gap-2 rounded-lg bg-gray-800 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700"
+          >
+            Sign in with OAuth
+          </a>
+        <% end %>
+        <%= if not @oauth_configured do %>
+          <.form
+            for={%{}}
+            action={~p"/auth/login"}
+            method="post"
+            class="flex items-center justify-center gap-3 max-w-sm mx-auto"
+            id="login-form"
+          >
+            <input
+              type="password"
+              name="password"
+              placeholder="Admin password"
+              class="flex-1 bg-[var(--crit-bg-primary)] border border-[var(--crit-border)] rounded-md px-3 py-2 text-sm text-[var(--crit-fg-primary)] placeholder-[var(--crit-fg-muted)] focus:outline-none focus:border-[var(--crit-accent)]"
+            />
+            <button
+              type="submit"
+              class="px-5 py-2 bg-[var(--crit-accent)] text-[var(--crit-bg-primary)] rounded-md text-sm font-semibold hover:opacity-90 transition-opacity cursor-pointer"
+            >
+              Sign in
+            </button>
+          </.form>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="mt-6">
+        <div class="flex justify-between items-center mb-3">
+          <span class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)]">
+            All Reviews ({@review_count})
+          </span>
+          <span class="text-xs text-[var(--crit-fg-muted)]">sorted by recent activity</span>
+        </div>
+        <div id="reviews-list" class="flex flex-col gap-2" phx-update="stream">
+          <div
+            :for={{dom_id, review} <- @streams.reviews}
+            id={dom_id}
+            class="flex items-center justify-between p-3 border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg hover:border-[var(--crit-accent)] transition-colors group"
+          >
+            <div class="min-w-0">
+              <a
+                href={~p"/r/#{review.token}"}
+                class="text-sm font-semibold text-[var(--crit-accent)] no-underline hover:underline truncate block"
+              >
+                {review.first_file_path || "Untitled"}
+              </a>
+              <div class="text-xs text-[var(--crit-fg-muted)] mt-0.5 flex items-center gap-3 flex-wrap">
+                <span class="flex items-center gap-1">
+                  <.icon name="hero-chat-bubble-left-micro" class="size-3.5" />{review.comment_count} {if review.comment_count ==
+                                                                                                            1,
+                                                                                                          do:
+                                                                                                            "comment",
+                                                                                                          else:
+                                                                                                            "comments"}
+                </span>
+                <span class="flex items-center gap-1">
+                  <.icon name="hero-document-text-micro" class="size-3.5" />{review.file_count} {if review.file_count ==
+                                                                                                      1,
+                                                                                                    do:
+                                                                                                      "file",
+                                                                                                    else:
+                                                                                                      "files"}
+                </span>
+                <span class="flex items-center gap-1 text-[var(--crit-fg-dimmed)]">
+                  <.icon name="hero-plus-circle-micro" class="size-3.5" />created {time_ago(
+                    review.inserted_at
+                  )}
+                </span>
+                <span class="flex items-center gap-1 text-[var(--crit-fg-dimmed)]">
+                  <.icon name="hero-clock-micro" class="size-3.5" />active {time_ago(
+                    review.last_activity_at
+                  )}
+                </span>
+              </div>
+            </div>
+            <%= if not @oauth_configured or (not is_nil(@current_user) and (is_nil(review.user_id) or review.user_id == @current_user.id)) do %>
+              <button
+                phx-click="delete_review"
+                phx-value-id={review.id}
+                data-confirm="Delete this review? This cannot be undone."
+                class="text-[var(--crit-fg-muted)] hover:text-red-400 transition-colors cursor-pointer shrink-0 ml-4"
+              >
+                <.icon name="hero-trash" class="size-4" />
+              </button>
+            <% end %>
+          </div>
+        </div>
+
+        <%= if @review_count == 0 do %>
+          <div class="text-center py-12 text-[var(--crit-fg-muted)] text-sm">
+            No reviews yet. Share a review from the Crit CLI to see it here.
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/lib/crit_web/live/dashboard_live.ex
+++ b/lib/crit_web/live/dashboard_live.ex
@@ -1,64 +1,39 @@
 defmodule CritWeb.DashboardLive do
   use CritWeb, :live_view
 
-  alias Crit.{Reviews, Statistics}
+  alias Crit.Reviews
 
   import CritWeb.Helpers, only: [time_ago: 1]
 
-  on_mount {CritWeb.Live.Hooks, :require_authenticated_user}
-
   @impl true
   def mount(_params, _session, socket) do
-    %{authenticated: authenticated} = socket.assigns
+    current_user = socket.assigns.current_user
 
-    stats = Statistics.dashboard_stats()
-    chart_data = Statistics.activity_chart(30)
-    max_count = chart_data |> Enum.map(&elem(&1, 1)) |> Enum.max(fn -> 1 end)
+    reviews = Reviews.list_user_reviews_with_counts(current_user.id)
 
     socket =
       socket
-      |> assign(:stats, stats)
-      |> assign(:chart_data, chart_data)
-      |> assign(:max_count, max_count)
       |> assign(:page_title, "Dashboard - Crit")
       |> assign(:noindex, true)
-
-    socket =
-      if authenticated do
-        reviews = Reviews.list_reviews_with_counts()
-
-        socket
-        |> stream(:reviews, reviews)
-        |> assign(:review_count, length(reviews))
-      else
-        socket
-        |> assign(:review_count, 0)
-      end
+      |> assign(:selfhosted, Application.get_env(:crit, :selfhosted) == true)
+      |> stream(:reviews, reviews)
+      |> assign(:review_count, length(reviews))
 
     {:ok, socket, layout: false}
   end
 
   @impl true
   def handle_event("delete_review", %{"id" => id}, socket) do
-    %{oauth_configured: oauth_configured, current_user: current_user} = socket.assigns
+    current_user = socket.assigns.current_user
 
-    opts =
-      if oauth_configured && current_user do
-        [owner_id: current_user.id]
-      else
-        []
-      end
-
-    case Reviews.delete_review(id, opts) do
+    case Reviews.delete_review(id, owner_id: current_user.id) do
       :ok ->
-        reviews = Reviews.list_reviews_with_counts()
-        stats = Statistics.dashboard_stats()
+        reviews = Reviews.list_user_reviews_with_counts(current_user.id)
 
         {:noreply,
          socket
          |> stream(:reviews, reviews, reset: true)
-         |> assign(:review_count, length(reviews))
-         |> assign(:stats, stats)}
+         |> assign(:review_count, length(reviews))}
 
       {:error, :unauthorized} ->
         {:noreply, put_flash(socket, :error, "You can only delete your own reviews.")}
@@ -67,16 +42,4 @@ defmodule CritWeb.DashboardLive do
         {:noreply, put_flash(socket, :error, "Failed to delete review.")}
     end
   end
-
-  @doc false
-  def session_opts(conn) do
-    %{
-      "admin_authenticated" => Plug.Conn.get_session(conn, "admin_authenticated"),
-      "user_id" => Plug.Conn.get_session(conn, "user_id")
-    }
-  end
-
-  defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
-  defp format_bytes(bytes) when bytes < 1_048_576, do: "#{Float.round(bytes / 1024, 1)} KB"
-  defp format_bytes(bytes), do: "#{Float.round(bytes / 1_048_576, 1)} MB"
 end

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -2,196 +2,74 @@
 
 <div class="min-h-screen bg-(--crit-bg-primary) text-(--crit-fg-primary) font-sans flex flex-col">
   <Layouts.dashboard_header
-    authenticated={@authenticated}
-    password_required={@password_required}
     current_user={@current_user}
+    show_admin_link={@selfhosted}
+    show_settings_link={true}
   />
 
   <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">
-    <%!-- Stats cards --%>
-    <%!-- Desktop: 3 separate cards. Mobile: single unified strip with dividers. --%>
-    <div class="sm:grid sm:grid-cols-3 sm:gap-4 hidden">
-      <div class="border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg p-5">
-        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)]">Reviews</div>
-        <div class="text-3xl font-bold text-[var(--crit-fg-primary)] mt-1">
-          {@stats.total_reviews}
-        </div>
-        <div class="text-xs text-green-400 mt-1">+{@stats.reviews_this_week} this week</div>
-      </div>
-      <div class="border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg p-5">
-        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)]">Comments</div>
-        <div class="text-3xl font-bold text-[var(--crit-fg-primary)] mt-1">
-          {@stats.total_comments}
-        </div>
-        <div class="text-xs text-green-400 mt-1">
-          ~{Float.round(@stats.avg_comments_per_review, 1)} per review
-        </div>
-      </div>
-      <div class="border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg p-5">
-        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)]">Files</div>
-        <div class="text-3xl font-bold text-[var(--crit-fg-primary)] mt-1">
-          {@stats.total_files}
-        </div>
-        <div class="text-xs text-[var(--crit-fg-muted)] mt-1">
-          {format_bytes(@stats.total_storage_bytes)} total
-        </div>
-      </div>
+    <div class="flex justify-between items-center mb-3">
+      <span class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)]">
+        My Reviews ({@review_count})
+      </span>
+      <span class="text-xs text-[var(--crit-fg-muted)]">sorted by recent activity</span>
     </div>
-    <%!-- Mobile strip --%>
-    <div class="flex sm:hidden border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg overflow-hidden">
-      <div class="flex-1 px-4 py-3">
-        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)] mb-1">
-          Reviews
-        </div>
-        <div class="text-2xl font-bold text-[var(--crit-fg-primary)]">{@stats.total_reviews}</div>
-        <div class="text-xs text-green-400 mt-0.5">+{@stats.reviews_this_week} wk</div>
-      </div>
-      <div class="w-px bg-[var(--crit-border)]"></div>
-      <div class="flex-1 px-4 py-3">
-        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)] mb-1">
-          Comments
-        </div>
-        <div class="text-2xl font-bold text-[var(--crit-fg-primary)]">
-          {@stats.total_comments}
-        </div>
-        <div class="text-xs text-green-400 mt-0.5">
-          ~{Float.round(@stats.avg_comments_per_review, 1)}/review
-        </div>
-      </div>
-      <div class="w-px bg-[var(--crit-border)]"></div>
-      <div class="flex-1 px-4 py-3">
-        <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)] mb-1">Files</div>
-        <div class="text-2xl font-bold text-[var(--crit-fg-primary)]">{@stats.total_files}</div>
-        <div class="text-xs text-[var(--crit-fg-muted)] mt-0.5">
-          {format_bytes(@stats.total_storage_bytes)}
-        </div>
-      </div>
-    </div>
-
-    <%!-- Activity chart --%>
-    <div class="border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg p-5 mt-4">
-      <div class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)] mb-3">
-        Activity &middot; Last 30 days
-      </div>
-      <div class="flex items-end gap-[3px] h-16">
-        <div
-          :for={{_date, count} <- @chart_data}
-          class="flex-1 rounded-sm min-h-[2px]"
-          style={"height: #{if @max_count > 0, do: max(round(count / @max_count * 100), 3), else: 3}%; background: color-mix(in srgb, var(--crit-accent) #{if @max_count > 0, do: max(round(count / @max_count * 100), 15), else: 15}%, transparent);"}
-          title={"#{count} reviews"}
-        />
-      </div>
-    </div>
-
-    <%!-- Review list or login prompt --%>
-    <%= if not @authenticated do %>
+    <div id="reviews-list" class="flex flex-col gap-2" phx-update="stream">
       <div
-        id="login"
-        class="border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg p-8 mt-6 text-center"
+        :for={{dom_id, review} <- @streams.reviews}
+        id={dom_id}
+        class="flex items-center justify-between p-3 border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg hover:border-[var(--crit-accent)] transition-colors group"
       >
-        <div class="text-[var(--crit-fg-muted)] text-sm mb-4">
-          <.icon name="hero-lock-closed" class="size-4 inline-block mr-1 -mt-0.5" />
-          Sign in to view and manage reviews
-        </div>
-        <%= if @oauth_configured do %>
+        <div class="min-w-0">
           <a
-            href={~p"/auth/login"}
-            class="inline-flex items-center gap-2 rounded-lg bg-gray-800 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700"
+            href={~p"/r/#{review.token}"}
+            class="text-sm font-semibold text-[var(--crit-accent)] no-underline hover:underline truncate block"
           >
-            Sign in with OAuth
+            {review.first_file_path || "Untitled"}
           </a>
-        <% end %>
-        <%= if not @oauth_configured do %>
-          <.form
-            for={%{}}
-            action={~p"/auth/login"}
-            method="post"
-            class="flex items-center justify-center gap-3 max-w-sm mx-auto"
-            id="login-form"
-          >
-            <input
-              type="password"
-              name="password"
-              placeholder="Admin password"
-              class="flex-1 bg-[var(--crit-bg-primary)] border border-[var(--crit-border)] rounded-md px-3 py-2 text-sm text-[var(--crit-fg-primary)] placeholder-[var(--crit-fg-muted)] focus:outline-none focus:border-[var(--crit-accent)]"
-            />
-            <button
-              type="submit"
-              class="px-5 py-2 bg-[var(--crit-accent)] text-[var(--crit-bg-primary)] rounded-md text-sm font-semibold hover:opacity-90 transition-opacity cursor-pointer"
-            >
-              Sign in
-            </button>
-          </.form>
-        <% end %>
+          <div class="text-xs text-[var(--crit-fg-muted)] mt-0.5 flex items-center gap-3 flex-wrap">
+            <span class="flex items-center gap-1">
+              <.icon name="hero-chat-bubble-left-micro" class="size-3.5" />{review.comment_count} {if review.comment_count ==
+                                                                                                        1,
+                                                                                                      do:
+                                                                                                        "comment",
+                                                                                                      else:
+                                                                                                        "comments"}
+            </span>
+            <span class="flex items-center gap-1">
+              <.icon name="hero-document-text-micro" class="size-3.5" />{review.file_count} {if review.file_count ==
+                                                                                                  1,
+                                                                                                do:
+                                                                                                  "file",
+                                                                                                else:
+                                                                                                  "files"}
+            </span>
+            <span class="flex items-center gap-1 text-[var(--crit-fg-dimmed)]">
+              <.icon name="hero-plus-circle-micro" class="size-3.5" />created {time_ago(
+                review.inserted_at
+              )}
+            </span>
+            <span class="flex items-center gap-1 text-[var(--crit-fg-dimmed)]">
+              <.icon name="hero-clock-micro" class="size-3.5" />active {time_ago(
+                review.last_activity_at
+              )}
+            </span>
+          </div>
+        </div>
+        <button
+          phx-click="delete_review"
+          phx-value-id={review.id}
+          data-confirm="Delete this review? This cannot be undone."
+          class="text-[var(--crit-fg-muted)] hover:text-red-400 transition-colors cursor-pointer shrink-0 ml-4"
+        >
+          <.icon name="hero-trash" class="size-4" />
+        </button>
       </div>
-    <% else %>
-      <div class="mt-6">
-        <div class="flex justify-between items-center mb-3">
-          <span class="text-xs uppercase tracking-wider text-[var(--crit-fg-muted)]">
-            All Reviews ({@review_count})
-          </span>
-          <span class="text-xs text-[var(--crit-fg-muted)]">sorted by recent activity</span>
-        </div>
-        <div id="reviews-list" class="flex flex-col gap-2" phx-update="stream">
-          <div
-            :for={{dom_id, review} <- @streams.reviews}
-            id={dom_id}
-            class="flex items-center justify-between p-3 border border-[var(--crit-border)] bg-[var(--crit-bg-secondary)] rounded-lg hover:border-[var(--crit-accent)] transition-colors group"
-          >
-            <div class="min-w-0">
-              <a
-                href={~p"/r/#{review.token}"}
-                class="text-sm font-semibold text-[var(--crit-accent)] no-underline hover:underline truncate block"
-              >
-                {review.first_file_path || "Untitled"}
-              </a>
-              <div class="text-xs text-[var(--crit-fg-muted)] mt-0.5 flex items-center gap-3 flex-wrap">
-                <span class="flex items-center gap-1">
-                  <.icon name="hero-chat-bubble-left-micro" class="size-3.5" />{review.comment_count} {if review.comment_count ==
-                                                                                                            1,
-                                                                                                          do:
-                                                                                                            "comment",
-                                                                                                          else:
-                                                                                                            "comments"}
-                </span>
-                <span class="flex items-center gap-1">
-                  <.icon name="hero-document-text-micro" class="size-3.5" />{review.file_count} {if review.file_count ==
-                                                                                                      1,
-                                                                                                    do:
-                                                                                                      "file",
-                                                                                                    else:
-                                                                                                      "files"}
-                </span>
-                <span class="flex items-center gap-1 text-[var(--crit-fg-dimmed)]">
-                  <.icon name="hero-plus-circle-micro" class="size-3.5" />created {time_ago(
-                    review.inserted_at
-                  )}
-                </span>
-                <span class="flex items-center gap-1 text-[var(--crit-fg-dimmed)]">
-                  <.icon name="hero-clock-micro" class="size-3.5" />active {time_ago(
-                    review.last_activity_at
-                  )}
-                </span>
-              </div>
-            </div>
-            <%= if not @oauth_configured or (not is_nil(@current_user) and (is_nil(review.user_id) or review.user_id == @current_user.id)) do %>
-              <button
-                phx-click="delete_review"
-                phx-value-id={review.id}
-                data-confirm="Delete this review? This cannot be undone."
-                class="text-[var(--crit-fg-muted)] hover:text-red-400 transition-colors cursor-pointer shrink-0 ml-4"
-              >
-                <.icon name="hero-trash" class="size-4" />
-              </button>
-            <% end %>
-          </div>
-        </div>
+    </div>
 
-        <%= if @review_count == 0 do %>
-          <div class="text-center py-12 text-[var(--crit-fg-muted)] text-sm">
-            No reviews yet. Share a review from the Crit CLI to see it here.
-          </div>
-        <% end %>
+    <%= if @review_count == 0 do %>
+      <div class="text-center py-12 text-[var(--crit-fg-muted)] text-sm">
+        No reviews yet. Share a review from the Crit CLI to see it here.
       </div>
     <% end %>
   </div>

--- a/lib/crit_web/live/hooks.ex
+++ b/lib/crit_web/live/hooks.ex
@@ -16,43 +16,44 @@ defmodule CritWeb.Live.Hooks do
   - `:load_current_user` — loads the current user from the session into socket assigns.
     Sets `current_user` to a `%Crit.User{}` or `nil`.
 
-  - `:require_authenticated_user` — requires an authenticated user on a self-hosted instance.
+  - `:require_user` — requires a logged-in user (via OAuth). Redirects to
+    `/auth/login?return_to=<current_path>` if not logged in. Redirects to `/` if
+    no OAuth configured.
+
+  - `:require_selfhosted_auth` — requires an authenticated user on a self-hosted instance.
     Assigns `authenticated`, `current_user`, `oauth_configured`, and `password_required`.
     Redirects to `/` if selfhosted mode is not enabled.
   """
   def on_mount(:load_current_user, _params, session, socket) do
-    current_user =
-      case Map.get(session, "user_id") do
-        nil ->
-          nil
-
-        user_id ->
-          case Accounts.get_user(user_id) do
-            {:ok, user} -> user
-            {:error, :not_found} -> nil
-          end
-      end
+    current_user = load_user(session)
 
     {:cont, assign(socket, :current_user, current_user)}
   end
 
-  def on_mount(:require_authenticated_user, _params, session, socket) do
+  def on_mount(:require_selfhosted_auth, _params, session, socket) do
+    selfhosted_auth(session, socket)
+  end
+
+  def on_mount(:require_user, _params, session, socket) do
+    current_user = load_user(session)
+
+    if current_user do
+      {:cont, assign(socket, :current_user, current_user)}
+    else
+      if Application.get_env(:crit, :oauth_provider) do
+        request_path = Map.get(session, "request_path", "/dashboard")
+        {:halt, redirect(socket, to: "/auth/login?return_to=#{request_path}")}
+      else
+        {:halt, redirect(socket, to: "/")}
+      end
+    end
+  end
+
+  defp selfhosted_auth(session, socket) do
     if Application.get_env(:crit, :selfhosted) do
       password_required = Application.get_env(:crit, :admin_password) != nil
       admin_authenticated = Map.get(session, "admin_authenticated", false) == true
-
-      current_user =
-        case Map.get(session, "user_id") do
-          nil ->
-            nil
-
-          user_id ->
-            case Accounts.get_user(user_id) do
-              {:ok, user} -> user
-              {:error, :not_found} -> nil
-            end
-        end
-
+      current_user = load_user(session)
       oauth_configured = Application.get_env(:crit, :oauth_provider) != nil
 
       authenticated =
@@ -73,27 +74,16 @@ defmodule CritWeb.Live.Hooks do
     end
   end
 
-  def on_mount(:require_user, _params, session, socket) do
-    current_user =
-      case Map.get(session, "user_id") do
-        nil ->
-          nil
+  defp load_user(session) do
+    case Map.get(session, "user_id") do
+      nil ->
+        nil
 
-        user_id ->
-          case Accounts.get_user(user_id) do
-            {:ok, user} -> user
-            {:error, :not_found} -> nil
-          end
-      end
-
-    if current_user do
-      {:cont, assign(socket, :current_user, current_user)}
-    else
-      if Application.get_env(:crit, :oauth_provider) do
-        {:halt, redirect(socket, to: "/auth/login?return_to=/settings")}
-      else
-        {:halt, redirect(socket, to: "/")}
-      end
+      user_id ->
+        case Accounts.get_user(user_id) do
+          {:ok, user} -> user
+          {:error, :not_found} -> nil
+        end
     end
   end
 end

--- a/lib/crit_web/live/session_helper.ex
+++ b/lib/crit_web/live/session_helper.ex
@@ -1,0 +1,31 @@
+defmodule CritWeb.Live.SessionHelper do
+  @moduledoc """
+  Shared session callbacks for live_sessions.
+  Extracts session data from the conn so LiveView hooks can read it.
+  """
+
+  import Plug.Conn
+
+  @doc """
+  Session callback for the :user live_session (dashboard + settings).
+  Passes user_id, admin_authenticated, and request_path.
+  """
+  def user_session_opts(conn) do
+    %{
+      "user_id" => get_session(conn, "user_id"),
+      "admin_authenticated" => get_session(conn, "admin_authenticated"),
+      "request_path" => conn.request_path
+    }
+  end
+
+  @doc """
+  Session callback for the :admin live_session.
+  Passes user_id and admin_authenticated.
+  """
+  def admin_session_opts(conn) do
+    %{
+      "user_id" => get_session(conn, "user_id"),
+      "admin_authenticated" => get_session(conn, "admin_authenticated")
+    }
+  end
+end

--- a/lib/crit_web/live/settings_live.ex
+++ b/lib/crit_web/live/settings_live.ex
@@ -5,8 +5,6 @@ defmodule CritWeb.SettingsLive do
 
   import CritWeb.Helpers, only: [time_ago: 1]
 
-  on_mount {CritWeb.Live.Hooks, :require_user}
-
   @impl true
   def mount(_params, _session, socket) do
     user = socket.assigns.current_user
@@ -89,10 +87,5 @@ defmodule CritWeb.SettingsLive do
 
   defp delete_confirmation_text(user) do
     user.email || user.name || "delete my account"
-  end
-
-  @doc false
-  def session_opts(conn) do
-    %{"user_id" => Plug.Conn.get_session(conn, "user_id")}
   end
 end

--- a/lib/crit_web/plugs/api_auth.ex
+++ b/lib/crit_web/plugs/api_auth.ex
@@ -5,19 +5,26 @@ defmodule CritWeb.Plugs.ApiAuth do
   def init(opts), do: opts
 
   def call(conn, _opts) do
-    if enforced?(conn) do
-      case get_req_header(conn, "authorization") do
-        ["Bearer " <> token] ->
-          case Accounts.verify_token(token) do
-            {:ok, user} -> assign(conn, :current_user, user)
-            {:error, :invalid} -> conn |> send_resp(401, ~s({"error":"invalid token"})) |> halt()
-          end
+    case get_req_header(conn, "authorization") do
+      ["Bearer " <> token] ->
+        case Accounts.verify_token(token) do
+          {:ok, user} ->
+            assign(conn, :current_user, user)
 
-        _ ->
+          {:error, :invalid} ->
+            if enforced?(conn) do
+              conn |> send_resp(401, ~s({"error":"invalid token"})) |> halt()
+            else
+              conn
+            end
+        end
+
+      _ ->
+        if enforced?(conn) do
           conn |> send_resp(401, ~s({"error":"authentication required"})) |> halt()
-      end
-    else
-      conn
+        else
+          conn
+        end
     end
   end
 

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -82,16 +82,17 @@ defmodule CritWeb.Router do
       live "/r/:token", ReviewLive, :show
     end
 
-    live_session :dashboard,
-      on_mount: [],
-      session: {CritWeb.DashboardLive, :session_opts, []} do
+    live_session :user,
+      on_mount: [{CritWeb.Live.Hooks, :require_user}],
+      session: {CritWeb.Live.SessionHelper, :user_session_opts, []} do
       live "/dashboard", DashboardLive, :index
+      live "/settings", SettingsLive, :index
     end
 
-    live_session :settings,
-      on_mount: [],
-      session: {CritWeb.SettingsLive, :session_opts, []} do
-      live "/settings", SettingsLive, :index
+    live_session :admin,
+      on_mount: [{CritWeb.Live.Hooks, :require_selfhosted_auth}],
+      session: {CritWeb.Live.SessionHelper, :admin_session_opts, []} do
+      live "/admin", AdminLive, :index
     end
   end
 

--- a/test/crit_web/controllers/oauth_controller_test.exs
+++ b/test/crit_web/controllers/oauth_controller_test.exs
@@ -42,13 +42,13 @@ defmodule CritWeb.OAuthControllerTest do
       :ok
     end
 
-    test "logs in user, sets session user_id, and redirects to settings" do
+    test "logs in user, sets session user_id, and redirects to dashboard" do
       conn =
         build_conn()
         |> init_test_session(%{oauth_session_params: %{}})
         |> get(~p"/auth/login/callback", %{"code" => "test_code"})
 
-      assert redirected_to(conn) == ~p"/settings"
+      assert redirected_to(conn) == ~p"/dashboard"
       assert get_session(conn, "user_id") != nil
     end
 

--- a/test/crit_web/live/admin_live_test.exs
+++ b/test/crit_web/live/admin_live_test.exs
@@ -1,0 +1,193 @@
+defmodule CritWeb.AdminLiveTest do
+  use CritWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Crit.ReviewsFixtures
+
+  setup do
+    Application.put_env(:crit, :selfhosted, true)
+
+    on_exit(fn ->
+      Application.delete_env(:crit, :selfhosted)
+      Application.delete_env(:crit, :admin_password)
+    end)
+  end
+
+  defp login_user(conn) do
+    {conn, _user} = login_user_with_record(conn)
+    conn
+  end
+
+  defp login_user_with_record(conn) do
+    {:ok, user} =
+      Crit.Accounts.find_or_create_from_oauth("github", %{
+        "sub" => "test_uid_#{System.unique_integer()}",
+        "email" => "test@example.com",
+        "name" => "Test User"
+      })
+
+    {init_test_session(conn, %{user_id: user.id}), user}
+  end
+
+  defp without_oauth(ctx) do
+    original = Application.get_env(:crit, :oauth_provider)
+    Application.delete_env(:crit, :oauth_provider)
+
+    on_exit(fn ->
+      if original,
+        do: Application.put_env(:crit, :oauth_provider, original),
+        else: Application.delete_env(:crit, :oauth_provider)
+    end)
+
+    ctx
+  end
+
+  describe "mount" do
+    test "redirects to / when not in selfhosted mode", %{conn: conn} do
+      Application.delete_env(:crit, :selfhosted)
+
+      assert {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/admin")
+    end
+
+    test "renders stats when selfhosted", %{conn: conn} do
+      review = review_fixture()
+      comment_fixture(review)
+
+      {:ok, _view, html} = live(conn, ~p"/admin")
+
+      assert html =~ "Reviews"
+      assert html =~ "Comments"
+      assert html =~ "Files"
+      assert html =~ "Activity"
+    end
+
+    test "shows all reviews regardless of user", %{conn: conn} do
+      without_oauth(%{})
+
+      review = review_fixture()
+      {:ok, _view, html} = live(conn, ~p"/admin")
+
+      assert html =~ "All Reviews"
+      assert html =~ hd(review.files).file_path
+    end
+  end
+
+  describe "with admin password" do
+    setup do
+      Application.put_env(:crit, :admin_password, "secret123")
+    end
+
+    test "shows login prompt when not authenticated", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/admin")
+
+      assert html =~ "Sign in to view and manage reviews"
+      refute html =~ "All Reviews"
+    end
+
+    test "shows password form when no OAuth configured", %{conn: conn} do
+      without_oauth(%{})
+
+      {:ok, _view, html} = live(conn, ~p"/admin")
+
+      assert html =~ "password"
+      refute html =~ "Sign in with OAuth"
+    end
+
+    test "shows OAuth button when OAuth configured", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/admin")
+
+      assert html =~ "Sign in with OAuth"
+      refute html =~ "login-form"
+    end
+
+    test "shows review list when authenticated via OAuth", %{conn: conn} do
+      review = review_fixture()
+      conn = login_user(conn)
+
+      {:ok, _view, html} = live(conn, ~p"/admin")
+
+      assert html =~ "All Reviews"
+      assert html =~ hd(review.files).file_path
+    end
+
+    test "shows stats even when not authenticated", %{conn: conn} do
+      _review = review_fixture()
+
+      {:ok, _view, html} = live(conn, ~p"/admin")
+
+      assert html =~ "Reviews"
+      assert html =~ "Comments"
+    end
+  end
+
+  describe "delete_review" do
+    setup :without_oauth
+
+    test "removes review from list", %{conn: conn} do
+      review = review_fixture()
+
+      {:ok, view, html} = live(conn, ~p"/admin")
+      assert html =~ hd(review.files).file_path
+
+      view
+      |> element("button[phx-value-id='#{review.id}']")
+      |> render_click()
+
+      html = render(view)
+      refute html =~ hd(review.files).file_path
+      assert html =~ "All Reviews (0)"
+    end
+  end
+
+  describe "delete_review with OAuth" do
+    test "owner can delete their own review", %{conn: conn} do
+      {conn, user} = login_user_with_record(conn)
+      review = review_fixture(user_id: user.id)
+
+      {:ok, view, html} = live(conn, ~p"/admin")
+      assert html =~ hd(review.files).file_path
+
+      view
+      |> element("button[phx-value-id='#{review.id}']")
+      |> render_click()
+
+      refute render(view) =~ hd(review.files).file_path
+    end
+
+    test "user cannot delete another user's review", %{conn: conn} do
+      {:ok, other_user} =
+        Crit.Accounts.find_or_create_from_oauth("github", %{
+          "sub" => "other_uid_#{System.unique_integer()}",
+          "email" => "other@example.com",
+          "name" => "Other User"
+        })
+
+      review = review_fixture(user_id: other_user.id)
+      conn = login_user(conn)
+
+      {:ok, view, _html} = live(conn, ~p"/admin")
+
+      refute has_element?(view, "button[phx-value-id='#{review.id}']")
+
+      # Also verify the server-side guard rejects a crafted event
+      view
+      |> render_hook("delete_review", %{"id" => review.id})
+
+      assert render(view) =~ hd(review.files).file_path
+    end
+
+    test "any authenticated user can delete an ownerless review", %{conn: conn} do
+      review = review_fixture()
+      conn = login_user(conn)
+
+      {:ok, view, html} = live(conn, ~p"/admin")
+      assert html =~ hd(review.files).file_path
+
+      view
+      |> element("button[phx-value-id='#{review.id}']")
+      |> render_click()
+
+      refute render(view) =~ hd(review.files).file_path
+    end
+  end
+end

--- a/test/crit_web/live/dashboard_live_test.exs
+++ b/test/crit_web/live/dashboard_live_test.exs
@@ -4,15 +4,6 @@ defmodule CritWeb.DashboardLiveTest do
   import Phoenix.LiveViewTest
   import Crit.ReviewsFixtures
 
-  setup do
-    Application.put_env(:crit, :selfhosted, true)
-
-    on_exit(fn ->
-      Application.delete_env(:crit, :selfhosted)
-      Application.delete_env(:crit, :admin_password)
-    end)
-  end
-
   defp login_user(conn) do
     {conn, _user} = login_user_with_record(conn)
     conn
@@ -29,132 +20,83 @@ defmodule CritWeb.DashboardLiveTest do
     {init_test_session(conn, %{user_id: user.id}), user}
   end
 
-  defp without_oauth(ctx) do
-    original = Application.get_env(:crit, :oauth_provider)
-    Application.delete_env(:crit, :oauth_provider)
-
-    on_exit(fn ->
-      if original,
-        do: Application.put_env(:crit, :oauth_provider, original),
-        else: Application.delete_env(:crit, :oauth_provider)
-    end)
-
-    ctx
-  end
-
-  describe "mount" do
-    test "redirects to / when not in selfhosted mode", %{conn: conn} do
-      Application.delete_env(:crit, :selfhosted)
-
-      assert {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/dashboard")
+  describe "mount requires user" do
+    test "redirects to /auth/login when not authenticated", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/auth/login?return_to=/dashboard"}}} =
+               live(conn, ~p"/dashboard")
     end
 
-    test "renders stats when selfhosted", %{conn: conn} do
-      review = review_fixture()
-      comment_fixture(review)
-
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
-
-      assert html =~ "Reviews"
-      assert html =~ "Comments"
-      assert html =~ "Files"
-      assert html =~ "Activity"
-    end
-
-    test "shows review list when no password and no oauth configured", %{conn: conn} do
-      without_oauth(%{})
-
-      review = review_fixture()
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
-
-      assert html =~ "All Reviews"
-      assert html =~ hd(review.files).file_path
-    end
-  end
-
-  describe "with admin password" do
-    setup do
-      Application.put_env(:crit, :admin_password, "secret123")
-    end
-
-    test "shows login prompt when not authenticated", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
-
-      assert html =~ "Sign in to view and manage reviews"
-      refute html =~ "All Reviews"
-    end
-
-    test "shows password form when no OAuth configured", %{conn: conn} do
+    test "redirects to / when no OAuth configured", %{conn: conn} do
+      original = Application.get_env(:crit, :oauth_provider)
       Application.delete_env(:crit, :oauth_provider)
 
       on_exit(fn ->
-        Application.put_env(:crit, :oauth_provider,
-          strategy: Assent.Strategy.Github,
-          client_id: "test_github_client_id",
-          client_secret: "test_github_client_secret"
-        )
+        if original,
+          do: Application.put_env(:crit, :oauth_provider, original),
+          else: Application.delete_env(:crit, :oauth_provider)
       end)
 
+      assert {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/dashboard")
+    end
+  end
+
+  describe "personal dashboard" do
+    test "shows only the current user's reviews", %{conn: conn} do
+      {conn, user} = login_user_with_record(conn)
+      review = review_fixture(user_id: user.id)
+
+      # Create another user's review that should NOT appear
+      {:ok, other_user} =
+        Crit.Accounts.find_or_create_from_oauth("github", %{
+          "sub" => "other_uid_#{System.unique_integer()}",
+          "email" => "other@example.com",
+          "name" => "Other User"
+        })
+
+      other_review =
+        review_fixture(
+          user_id: other_user.id,
+          files: [%{"path" => "other_file.md", "content" => "other content"}]
+        )
+
       {:ok, _view, html} = live(conn, ~p"/dashboard")
 
-      assert html =~ "password"
-      refute html =~ "Sign in with OAuth"
+      assert html =~ "My Reviews (1)"
+      assert html =~ hd(review.files).file_path
+      refute html =~ hd(other_review.files).file_path
     end
 
-    test "shows OAuth button and hides password form when OAuth configured", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
-
-      assert html =~ "Sign in with OAuth"
-      refute html =~ "login-form"
-    end
-
-    test "shows review list when authenticated via OAuth", %{conn: conn} do
-      review = review_fixture()
+    test "does not show stats cards or activity chart", %{conn: conn} do
       conn = login_user(conn)
 
       {:ok, _view, html} = live(conn, ~p"/dashboard")
 
-      assert html =~ "All Reviews"
-      assert html =~ hd(review.files).file_path
+      refute html =~ "Activity"
+      refute html =~ "this week"
     end
 
-    test "shows stats even when not authenticated", %{conn: conn} do
-      _review = review_fixture()
+    test "shows empty state when user has no reviews", %{conn: conn} do
+      conn = login_user(conn)
 
       {:ok, _view, html} = live(conn, ~p"/dashboard")
 
-      assert html =~ "Reviews"
-      assert html =~ "Comments"
+      assert html =~ "No reviews yet"
+      assert html =~ "Share a review from the Crit CLI"
     end
   end
 
-  describe "homepage redirect" do
-    test "/ redirects to /dashboard when selfhosted", %{conn: conn} do
-      conn = get(conn, ~p"/")
-      assert redirected_to(conn) == "/dashboard"
+  describe "review links" do
+    test "review rows link to /r/:token", %{conn: conn} do
+      {conn, user} = login_user_with_record(conn)
+      review = review_fixture(user_id: user.id)
+
+      {:ok, _view, html} = live(conn, ~p"/dashboard")
+
+      assert html =~ ~p"/r/#{review.token}"
     end
   end
 
   describe "delete_review" do
-    setup :without_oauth
-
-    test "removes review from list", %{conn: conn} do
-      review = review_fixture()
-
-      {:ok, view, html} = live(conn, ~p"/dashboard")
-      assert html =~ hd(review.files).file_path
-
-      view
-      |> element("button[phx-value-id='#{review.id}']")
-      |> render_click()
-
-      html = render(view)
-      refute html =~ hd(review.files).file_path
-      assert html =~ "All Reviews (0)"
-    end
-  end
-
-  describe "delete_review with OAuth" do
     test "owner can delete their own review", %{conn: conn} do
       {conn, user} = login_user_with_record(conn)
       review = review_fixture(user_id: user.id)
@@ -166,10 +108,14 @@ defmodule CritWeb.DashboardLiveTest do
       |> element("button[phx-value-id='#{review.id}']")
       |> render_click()
 
-      refute render(view) =~ hd(review.files).file_path
+      html = render(view)
+      refute html =~ hd(review.files).file_path
+      assert html =~ "My Reviews (0)"
     end
 
-    test "user cannot delete another user's review", %{conn: conn} do
+    test "cannot delete another user's review", %{conn: conn} do
+      {conn, _user} = login_user_with_record(conn)
+
       {:ok, other_user} =
         Crit.Accounts.find_or_create_from_oauth("github", %{
           "sub" => "other_uid_#{System.unique_integer()}",
@@ -178,53 +124,28 @@ defmodule CritWeb.DashboardLiveTest do
         })
 
       review = review_fixture(user_id: other_user.id)
-      conn = login_user(conn)
 
       {:ok, view, _html} = live(conn, ~p"/dashboard")
 
-      refute has_element?(view, "button[phx-value-id='#{review.id}']")
+      # The review shouldn't even show, but test the event handler too
+      view |> render_hook("delete_review", %{"id" => review.id})
 
-      # Also verify the server-side guard rejects a crafted event
-      view
-      |> render_hook("delete_review", %{"id" => review.id})
-
-      assert render(view) =~ hd(review.files).file_path
-    end
-
-    test "any authenticated user can delete an ownerless review", %{conn: conn} do
-      review = review_fixture()
-      conn = login_user(conn)
-
-      {:ok, view, html} = live(conn, ~p"/dashboard")
-      assert html =~ hd(review.files).file_path
-
-      view
-      |> element("button[phx-value-id='#{review.id}']")
-      |> render_click()
-
-      refute render(view) =~ hd(review.files).file_path
+      assert render(view) =~ "You can only delete your own reviews."
     end
   end
 
-  describe "review links" do
-    setup :without_oauth
+  describe "homepage redirect" do
+    setup do
+      Application.put_env(:crit, :selfhosted, true)
 
-    test "review rows link to /r/:token", %{conn: conn} do
-      review = review_fixture()
-
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
-
-      assert html =~ ~p"/r/#{review.token}"
+      on_exit(fn ->
+        Application.delete_env(:crit, :selfhosted)
+      end)
     end
-  end
 
-  describe "empty state" do
-    setup :without_oauth
-
-    test "shows message when no reviews", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
-
-      assert html =~ "No reviews yet"
+    test "/ redirects to /dashboard when selfhosted", %{conn: conn} do
+      conn = get(conn, ~p"/")
+      assert redirected_to(conn) == "/dashboard"
     end
   end
 end


### PR DESCRIPTION
## Summary

- Personal dashboard at `/dashboard` shows only the current user's reviews (requires OAuth login)
- Admin dashboard at `/admin` preserves the original global view with stats, chart, and all reviews (selfhosted only)
- Site header now shows "Dashboard" link and sign-in/sign-out UI for OAuth users across all public pages
- API auth plug always extracts bearer token identity so CLI-shared reviews get associated with users
- Merged `/dashboard` and `/settings` into a single `live_session` for seamless LiveView navigation
- Hooks moved from individual LiveView modules to router `live_session` (Phoenix 1.8 convention)

## Test plan

- [ ] Visit `/dashboard` logged out → redirects to `/auth/login`
- [ ] Visit `/dashboard` logged in → shows only your reviews
- [ ] Share a review via CLI with bearer token → appears in your dashboard
- [ ] Delete a review from personal dashboard → removed from list
- [ ] Visit `/admin` on selfhosted → shows global stats + all reviews
- [ ] Visit `/admin` on public → redirects to `/`
- [ ] Navigate between `/dashboard` and `/settings` → seamless (no full reload)
- [ ] Site header shows "Dashboard" + user name when logged in on public pages
- [ ] Click user name in header → goes to `/settings`
- [ ] "Sign in" link visible when logged out

🤖 Generated with [Claude Code](https://claude.com/claude-code)