### PR TITLE
feat: settings panel and content width toggle (crit parity)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -30,6 +30,7 @@
 :root {
   --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Consolas', monospace;
+  --crit-content-width: 840px;
   --crit-bg-primary: #1a1b26;
   --crit-bg-secondary: #16171f;
   --crit-bg-tertiary: #262940;
@@ -74,6 +75,11 @@
   --crit-yellow-bg: rgba(224, 175, 104, 0.14);
   --crit-yellow-border: rgba(224, 175, 104, 0.2);
 }
+
+/* Content width toggle (matches crit local) */
+[data-width="compact"] { --crit-content-width: 840px; }
+[data-width="default"] { --crit-content-width: 1040px; }
+[data-width="wide"]    { --crit-content-width: 1280px; }
 
 [data-theme="dark"] {
   --crit-bg-primary: #1a1b26;
@@ -478,7 +484,7 @@
 
 /* ===== Document wrapper ===== */
 #document-renderer {
-  max-width: 840px;
+  max-width: var(--crit-content-width);
   margin: 0 auto;
   padding: 32px 0 120px;
 }
@@ -2095,7 +2101,6 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
     padding-top: 8px;
   }
   .crit-header-filename { display: none; }
-  #shortcuts-btn { display: none !important; }
   .crit-viewed-count { display: none !important; }
 
   .comment-block { padding: 0 6px; }
@@ -2258,6 +2263,257 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
 .shortcuts-table td:first-child {
   width: 180px;
   white-space: nowrap;
+}
+
+/* ===== Settings Panel Overlay ===== */
+.settings-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 400;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(2px);
+}
+.settings-overlay.active {
+  display: flex;
+  animation: settings-overlay-in 0.18s ease-out;
+}
+@keyframes settings-overlay-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.settings-dialog {
+  background: var(--crit-bg-secondary);
+  border: 1px solid var(--crit-border);
+  border-radius: 12px;
+  max-width: 620px;
+  width: 90vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.24);
+  animation: settings-dialog-in 0.18s ease-out;
+}
+@keyframes settings-dialog-in {
+  from { opacity: 0; transform: scale(0.97) translateY(4px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* Tab bar */
+.settings-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--crit-border);
+  padding: 0 20px;
+  flex-shrink: 0;
+  position: relative;
+}
+.settings-tab-underline {
+  position: absolute;
+  bottom: -1px;
+  height: 2px;
+  background: var(--crit-accent);
+  border-radius: 1px;
+  transition: left 0.2s ease, width 0.2s ease;
+  pointer-events: none;
+}
+.settings-tab {
+  padding: 12px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--crit-fg-muted);
+  cursor: pointer;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s;
+}
+.settings-tab:hover { color: var(--crit-fg-primary); }
+.settings-tab.active {
+  color: var(--crit-accent);
+  border-bottom-color: transparent;
+}
+.settings-tab-close {
+  margin-left: auto;
+  padding: 8px;
+  font-size: 18px;
+  color: var(--crit-fg-muted);
+  cursor: pointer;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  line-height: 1;
+  min-width: 32px;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
+  align-self: center;
+}
+.settings-tab-close:hover { color: var(--crit-fg-primary); background: var(--crit-bg-hover); }
+
+/* Tab content */
+.settings-content {
+  overflow-y: auto;
+  padding: 20px;
+  flex: 1;
+  min-height: 0;
+}
+.settings-pane { display: none; }
+.settings-pane.active { display: block; }
+
+/* Section headers */
+.settings-section-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--crit-fg-muted);
+  letter-spacing: 0.6px;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+.settings-section-label:not(:first-child) {
+  margin-top: 28px;
+}
+
+/* Display preference rows */
+.settings-display-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.settings-display-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  margin-bottom: 0;
+}
+.settings-display-row:not(:last-child) {
+  border-bottom: 1px solid var(--crit-border);
+}
+.settings-display-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--crit-fg-primary);
+}
+
+/* Pill toggles for theme and width inside the panel */
+.settings-pill {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--crit-border);
+  background: var(--crit-bg-secondary);
+  border-radius: 9999px;
+}
+.settings-pill-indicator {
+  position: absolute;
+  height: 100%;
+  border-radius: 9999px;
+  background: var(--crit-bg-hover);
+  border: 1px solid var(--crit-border);
+  transition: left 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  pointer-events: none;
+}
+.settings-pill-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: var(--crit-fg-muted);
+  position: relative;
+  z-index: 1;
+  transition: color 0.15s;
+  font-size: 13px;
+  font-weight: 500;
+}
+.settings-pill-btn:hover { color: var(--crit-fg-primary); }
+.settings-pill-btn.active { color: var(--crit-accent); }
+
+/* Theme pill: 3 icon buttons */
+.settings-pill--theme .settings-pill-indicator { width: 33.333%; }
+.settings-pill--theme .settings-pill-btn { width: 32px; padding: 8px 0; }
+.settings-pill--theme .settings-pill-btn svg { width: 16px; height: 16px; display: block; }
+
+/* Width pill: 3 equal-width text buttons */
+.settings-pill--width .settings-pill-indicator { width: 33.333%; }
+.settings-pill--width .settings-pill-btn { padding: 6px 0; width: 72px; text-align: center; }
+
+/* Shortcuts table (inside settings panel) */
+.shortcuts-group-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--crit-fg-muted);
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+  margin-top: 16px;
+}
+.shortcuts-group-label:first-child { margin-top: 0; }
+.shortcut-mode-badge {
+  display: inline-block;
+  font-size: 11px;
+  color: var(--crit-fg-muted);
+  background: var(--crit-bg-tertiary);
+  border: 1px solid var(--crit-border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  margin-left: 6px;
+  font-weight: 500;
+}
+
+/* About tab */
+.about-header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+.about-header h2 {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--crit-fg-primary);
+  margin-bottom: 4px;
+}
+.about-version {
+  font-size: 13px;
+  color: var(--crit-fg-secondary);
+}
+.about-links {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.about-link {
+  color: var(--crit-fg-muted);
+  text-decoration: none;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--crit-border);
+  transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.15s;
+}
+.about-link:hover {
+  background: var(--crit-bg-hover);
+  color: var(--crit-fg-primary);
+  border-color: var(--crit-fg-muted);
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+.about-link:active {
+  transform: translateY(0);
+}
+.about-link svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
 }
 
 /* ===== Changelog body (Earmark-rendered markdown) ===== */

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3568,6 +3568,245 @@ function navigateToComment(ctx, direction) {
   setTimeout(() => target.classList.remove('comment-nav-highlight'), 1000)
 }
 
+// ---- Content Width ----------------------------------------------------------
+
+function initWidth() {
+  const saved = localStorage.getItem('crit-width') || 'default'
+  applyWidth(saved)
+}
+
+function applyWidth(choice) {
+  localStorage.setItem('crit-width', choice)
+  if (choice === 'compact') document.documentElement.setAttribute('data-width', 'compact')
+  else if (choice === 'wide') document.documentElement.setAttribute('data-width', 'wide')
+  else document.documentElement.setAttribute('data-width', 'default')
+}
+
+// ---- Settings Panel ---------------------------------------------------------
+
+let settingsPanelOpen = false
+let settingsPanelTab = 'settings'
+
+function openSettingsPanel(tab) {
+  settingsPanelTab = tab || 'settings'
+  settingsPanelOpen = true
+  const overlay = document.getElementById('settingsOverlay')
+  if (!overlay) return
+  overlay.classList.add('active')
+  // Ensure the sliding underline element exists
+  if (!overlay.querySelector('.settings-tab-underline')) {
+    const underline = document.createElement('div')
+    underline.className = 'settings-tab-underline'
+    overlay.querySelector('.settings-tabs').appendChild(underline)
+  }
+  switchSettingsTab(settingsPanelTab)
+  renderShortcutsPane()
+}
+
+function closeSettingsPanel() {
+  settingsPanelOpen = false
+  const overlay = document.getElementById('settingsOverlay')
+  if (overlay) overlay.classList.remove('active')
+}
+
+function switchSettingsTab(tab) {
+  settingsPanelTab = tab
+  let activeBtn = null
+  document.querySelectorAll('.settings-tab[data-tab]').forEach(function(t) {
+    const isActive = t.dataset.tab === tab
+    t.classList.toggle('active', isActive)
+    if (isActive) activeBtn = t
+  })
+  document.querySelectorAll('.settings-pane').forEach(function(p) {
+    p.classList.toggle('active', p.dataset.pane === tab)
+  })
+  // Position the sliding underline
+  const underline = document.querySelector('.settings-tab-underline')
+  if (underline && activeBtn) {
+    const tabsRect = activeBtn.parentElement.getBoundingClientRect()
+    const btnRect = activeBtn.getBoundingClientRect()
+    underline.style.left = (btnRect.left - tabsRect.left) + 'px'
+    underline.style.width = btnRect.width + 'px'
+  }
+  // Render the active pane content
+  if (tab === 'settings') renderSettingsPane()
+  else if (tab === 'about') renderAboutPane()
+}
+
+function updatePillIndicator(indicatorId, values, current) {
+  const indicator = document.getElementById(indicatorId)
+  if (!indicator) return
+  const idx = values.indexOf(current)
+  if (idx >= 0) {
+    indicator.style.left = (idx * (100 / values.length)) + '%'
+    indicator.style.width = (100 / values.length) + '%'
+  }
+}
+
+function renderSettingsPane() {
+  const pane = document.getElementById('settingsPane')
+  if (!pane) return
+
+  const currentTheme = localStorage.getItem('phx:theme') || 'system'
+  const currentWidth = localStorage.getItem('crit-width') || 'default'
+
+  let html = ''
+
+  // Display section
+  html += '<div class="settings-section-label">Display</div>'
+  html += '<div class="settings-display-group">'
+
+  // Theme row
+  html += '<div class="settings-display-row">'
+  html += '<span class="settings-display-label">Theme</span>'
+  html += '<div class="settings-pill settings-pill--theme" id="settingsThemePill" role="group" aria-label="Theme">'
+  html += '<div class="settings-pill-indicator" id="settingsThemeIndicator"></div>'
+  const themeIcons = {
+    system: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M2 4.25A2.25 2.25 0 0 1 4.25 2h7.5A2.25 2.25 0 0 1 14 4.25v5.5A2.25 2.25 0 0 1 11.75 12h-1.312c.1.128.21.248.328.36a.75.75 0 0 1 .234.545v.345a.75.75 0 0 1-.75.75h-4.5a.75.75 0 0 1-.75-.75v-.345a.75.75 0 0 1 .234-.545c.118-.111.228-.232.328-.36H4.25A2.25 2.25 0 0 1 2 9.75v-5.5Zm2.25-.75a.75.75 0 0 0-.75.75v4.5c0 .414.336.75.75.75h7.5a.75.75 0 0 0 .75-.75v-4.5a.75.75 0 0 0-.75-.75h-7.5Z" clip-rule="evenodd"/></svg>',
+    light: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 1ZM10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0ZM12.95 4.11a.75.75 0 1 0-1.06-1.06l-1.062 1.06a.75.75 0 0 0 1.061 1.062l1.06-1.061ZM15 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 15 8ZM11.89 12.95a.75.75 0 0 0 1.06-1.06l-1.06-1.062a.75.75 0 0 0-1.062 1.061l1.061 1.06ZM8 12a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 12ZM5.172 11.89a.75.75 0 0 0-1.061-1.062L3.05 11.89a.75.75 0 1 0 1.06 1.06l1.06-1.06ZM4 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 4 8ZM4.11 5.172A.75.75 0 0 0 5.173 4.11L4.11 3.05a.75.75 0 1 0-1.06 1.06l1.06 1.06Z"/></svg>',
+    dark: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="M14.438 10.148c.19-.425-.321-.787-.748-.601A5.5 5.5 0 0 1 6.453 2.31c.186-.427-.176-.938-.6-.748a6.501 6.501 0 1 0 8.585 8.586Z"/></svg>'
+  }
+  ;['system', 'light', 'dark'].forEach(function(theme) {
+    const active = theme === currentTheme ? ' active' : ''
+    html += '<button class="settings-pill-btn' + active + '" data-settings-theme="' + theme + '" title="' + theme.charAt(0).toUpperCase() + theme.slice(1) + ' theme">' + themeIcons[theme] + '</button>'
+  })
+  html += '</div></div>'
+
+  // Width row
+  html += '<div class="settings-display-row">'
+  html += '<span class="settings-display-label">Content Width</span>'
+  html += '<div class="settings-pill settings-pill--width" id="settingsWidthPill" role="group" aria-label="Content width">'
+  html += '<div class="settings-pill-indicator" id="settingsWidthIndicator"></div>'
+  ;['compact', 'default', 'wide'].forEach(function(w) {
+    const active = w === currentWidth ? ' active' : ''
+    html += '<button class="settings-pill-btn' + active + '" data-settings-width="' + w + '">' + w.charAt(0).toUpperCase() + w.slice(1) + '</button>'
+  })
+  html += '</div></div>'
+  html += '</div>' // close settings-display-group
+
+  pane.innerHTML = html
+
+  // Wire up theme pill clicks — call the same setTheme that app.js uses
+  pane.querySelectorAll('[data-settings-theme]').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      const theme = btn.dataset.settingsTheme
+      // Dispatch the same event that the header theme pill uses
+      const event = new CustomEvent('phx:set-theme', { bubbles: true })
+      btn.dataset.phxTheme = theme
+      btn.dispatchEvent(event)
+      pane.querySelectorAll('[data-settings-theme]').forEach(function(b) { b.classList.toggle('active', b.dataset.settingsTheme === theme) })
+      updatePillIndicator('settingsThemeIndicator', ['system', 'light', 'dark'], theme)
+    })
+  })
+  updatePillIndicator('settingsThemeIndicator', ['system', 'light', 'dark'], currentTheme)
+
+  // Wire up width pill clicks
+  pane.querySelectorAll('[data-settings-width]').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      const w = btn.dataset.settingsWidth
+      applyWidth(w)
+      pane.querySelectorAll('[data-settings-width]').forEach(function(b) { b.classList.toggle('active', b.dataset.settingsWidth === w) })
+      updatePillIndicator('settingsWidthIndicator', ['compact', 'default', 'wide'], w)
+    })
+  })
+  updatePillIndicator('settingsWidthIndicator', ['compact', 'default', 'wide'], currentWidth)
+}
+
+function renderShortcutsPane() {
+  const pane = document.getElementById('shortcutsPane')
+  if (!pane) return
+
+  const groups = [
+    { label: 'Navigation', shortcuts: [
+      { key: '<kbd>j</kbd>', action: 'Next block' },
+      { key: '<kbd>k</kbd>', action: 'Previous block' },
+      { key: '<kbd>]</kbd>', action: 'Next comment' },
+      { key: '<kbd>[</kbd>', action: 'Previous comment' },
+    ]},
+    { label: 'Comments', shortcuts: [
+      { key: '<kbd>c</kbd>', action: 'Comment on focused block' },
+      { key: '<kbd>e</kbd>', action: 'Edit comment on focused block' },
+      { key: '<kbd>d</kbd>', action: 'Delete comment on focused block' },
+      { key: '<kbd>Shift</kbd>+<kbd>G</kbd>', action: 'General comment' },
+      { key: '<kbd>Ctrl</kbd>+<kbd>Enter</kbd>', action: 'Submit comment' },
+    ]},
+    { label: 'Review', shortcuts: [
+      { key: '<kbd>Shift</kbd>+<kbd>C</kbd>', action: 'Toggle comments panel' },
+    ]},
+    { label: 'View', shortcuts: [
+      { key: '<kbd>t</kbd>', action: 'Toggle table of contents' },
+      { key: '<kbd>Esc</kbd>', action: 'Cancel / clear focus' },
+      { key: '<kbd>?</kbd>', action: 'Toggle shortcuts' },
+    ]},
+  ]
+
+  let html = ''
+  groups.forEach(function(group) {
+    html += '<div class="shortcuts-group-label">' + group.label + '</div>'
+    html += '<table class="shortcuts-table">'
+    group.shortcuts.forEach(function(s) {
+      const modeTag = s.mode ? '<span class="shortcut-mode-badge">' + s.mode + '</span>' : ''
+      html += '<tr><td>' + s.key + '</td><td>' + s.action + modeTag + '</td></tr>'
+    })
+    html += '</table>'
+  })
+
+  pane.innerHTML = html
+}
+
+function renderAboutPane() {
+  const pane = document.getElementById('aboutPane')
+  if (!pane) return
+
+  let html = ''
+
+  // Header
+  html += '<div class="about-header">'
+  html += '<h2>Crit Web</h2>'
+  html += '<div class="about-version">Your feedback loop with the agent.</div>'
+  html += '</div>'
+
+  // Links
+  html += '<div class="settings-section-label">Links</div>'
+  html += '<div class="about-links">'
+  html += '<a class="about-link" href="https://crit.md" target="_blank" rel="noopener"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 1v4M5.5 3h5M3 7h10v6.5a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5V7Z"/></svg>Homepage</a>'
+  html += '<a class="about-link" href="https://github.com/tomasz-tomczyk/crit-web" target="_blank" rel="noopener"><svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/></svg>GitHub</a>'
+  html += '<a class="about-link" href="https://crit.md/changelog" target="_blank" rel="noopener"><svg viewBox="0 0 16 16" fill="currentColor"><path d="M1 7.775V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 0 1 0 2.474l-5.026 5.026a1.75 1.75 0 0 1-2.474 0l-6.25-6.25A1.752 1.752 0 0 1 1 7.775Zm1.5 0c0 .066.026.13.073.177l6.25 6.25a.25.25 0 0 0 .354 0l5.025-5.025a.25.25 0 0 0 0-.354l-6.25-6.25a.25.25 0 0 0-.177-.073H2.75a.25.25 0 0 0-.25.25ZM6 5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z"/></svg>Changelog</a>'
+  html += '</div>'
+
+  pane.innerHTML = html
+}
+
+function initSettingsPanel() {
+  // Gear icon opens Settings tab
+  const settingsToggle = document.getElementById('settingsToggle')
+  if (settingsToggle) {
+    settingsToggle.addEventListener('click', function() {
+      if (settingsPanelOpen) closeSettingsPanel()
+      else openSettingsPanel('settings')
+    })
+  }
+
+  // Close button
+  const settingsClose = document.getElementById('settingsClose')
+  if (settingsClose) {
+    settingsClose.addEventListener('click', closeSettingsPanel)
+  }
+
+  // Click outside to close
+  const overlay = document.getElementById('settingsOverlay')
+  if (overlay) {
+    overlay.addEventListener('click', function(e) {
+      if (e.target === overlay) closeSettingsPanel()
+    })
+  }
+
+  // Tab switching
+  document.querySelectorAll('.settings-tab[data-tab]').forEach(function(tab) {
+    tab.addEventListener('click', function() { switchSettingsTab(tab.dataset.tab) })
+  })
+}
+
 // ---- Phoenix LiveView hook --------------------------------------------------
 
 export const DocumentRenderer = {
@@ -3591,6 +3830,10 @@ export const DocumentRenderer = {
     ctx.showRoundDiff = false
     ctx.diffMode = 'split'
     ctx._navCommentId = null
+
+    // Initialize content width and settings panel
+    initWidth()
+    initSettingsPanel()
 
     const rawContent = ctx.el.dataset.content || ""
     ctx.rawContent = rawContent
@@ -3657,42 +3900,6 @@ export const DocumentRenderer = {
       })
     }
     window.addEventListener("scroll", ctx._scrollHandler, { passive: true })
-
-    // Keyboard shortcuts overlay
-    const shortcutsOverlay = document.createElement('div')
-    shortcutsOverlay.className = 'shortcuts-overlay'
-    shortcutsOverlay.innerHTML = `
-      <div class="shortcuts-dialog">
-        <h3>Keyboard Shortcuts</h3>
-        <table class="shortcuts-table">
-          <tr><td><kbd>j</kbd></td><td>Next block</td></tr>
-          <tr><td><kbd>k</kbd></td><td>Previous block</td></tr>
-          <tr><td><kbd>]</kbd></td><td>Next comment</td></tr>
-          <tr><td><kbd>[</kbd></td><td>Previous comment</td></tr>
-          <tr><td><kbd>c</kbd></td><td>Comment on focused block</td></tr>
-          <tr><td><kbd>e</kbd></td><td>Edit comment on focused block</td></tr>
-          <tr><td><kbd>d</kbd></td><td>Delete comment on focused block</td></tr>
-          <tr><td><kbd>t</kbd></td><td>Toggle table of contents</td></tr>
-          <tr><td><kbd>Shift</kbd>+<kbd>C</kbd></td><td>Toggle comments panel</td></tr>
-          <tr><td><kbd>Shift</kbd>+<kbd>G</kbd></td><td>Add review comment</td></tr>
-          <tr><td><kbd>Ctrl</kbd>+<kbd>Enter</kbd></td><td>Submit comment</td></tr>
-          <tr><td><kbd>Esc</kbd></td><td>Cancel / clear focus</td></tr>
-          <tr><td><kbd>?</kbd></td><td>Toggle this help</td></tr>
-        </table>
-      </div>
-    `
-    shortcutsOverlay.addEventListener('click', (e) => {
-      if (e.target === shortcutsOverlay) shortcutsOverlay.classList.remove('visible')
-    })
-    document.body.appendChild(shortcutsOverlay)
-    ctx._shortcutsOverlay = shortcutsOverlay
-
-    const shortcutsBtn = document.getElementById('shortcuts-btn')
-    if (shortcutsBtn) {
-      shortcutsBtn.addEventListener('click', () => {
-        ctx._shortcutsOverlay.classList.toggle('visible')
-      })
-    }
 
     const prevBtn = document.getElementById('comment-nav-prev')
     if (prevBtn) prevBtn.addEventListener('click', () => navigateToComment(ctx, -1))
@@ -4015,16 +4222,17 @@ export const DocumentRenderer = {
       // Allow Shift (for Shift+C) but block other modifiers
       if (e.metaKey || e.ctrlKey || e.altKey) return
 
-      // Shortcuts overlay
+      // Settings panel (shortcuts tab via ?)
       if (e.key === '?') {
         e.preventDefault()
-        ctx._shortcutsOverlay.classList.toggle('visible')
+        if (settingsPanelOpen) closeSettingsPanel()
+        else openSettingsPanel('shortcuts')
         return
       }
-      if (ctx._shortcutsOverlay.classList.contains('visible')) {
+      if (settingsPanelOpen) {
         if (e.key === 'Escape') {
           e.preventDefault()
-          ctx._shortcutsOverlay.classList.remove('visible')
+          closeSettingsPanel()
         }
         return
       }
@@ -4151,9 +4359,8 @@ export const DocumentRenderer = {
     if (this._resizeHandler) {
       window.removeEventListener("resize", this._resizeHandler)
     }
-    if (this._shortcutsOverlay) {
-      this._shortcutsOverlay.remove()
-    }
+    // Close settings panel if open
+    closeSettingsPanel()
     if (this._commentsPanel) {
       this._commentsPanel.remove()
     }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -409,6 +409,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -470,6 +471,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -870,6 +872,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }

--- a/lib/crit_web/controllers/page_html/home.html.heex
+++ b/lib/crit_web/controllers/page_html/home.html.heex
@@ -621,8 +621,7 @@
             </p>
           </div>
           <p class="relative font-mono text-xs text-(--crit-fg-muted)">
-            &mdash;
-            <a
+            &mdash; <a
               href={testimonial.link}
               class="text-(--crit-fg-dimmed) hover:text-(--crit-accent) transition-colors"
               target="_blank"

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -183,26 +183,6 @@
         </div>
         <button
           class="crit-toc-toggle"
-          id="shortcuts-btn"
-          title="Keyboard shortcuts (?)"
-          aria-label="Keyboard shortcuts"
-        >
-          <svg
-            viewBox="0 0 16 16"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.25"
-            aria-hidden="true"
-          >
-            <circle cx="8" cy="8" r="6.5" /><path
-              d="M6.75 6.5a1.25 1.25 0 0 1 2.5 0c0 .69-.56 1.25-1.25 1.25V9"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            /><circle cx="8" cy="11.25" r="0.625" fill="currentColor" stroke="none" />
-          </svg>
-        </button>
-        <button
-          class="crit-toc-toggle"
           id="crit-toc-toggle"
           title="Table of contents"
           aria-label="Table of contents"
@@ -217,7 +197,24 @@
             <path d="M2.5 4h11M2.5 8h11M2.5 12h11" stroke-linecap="round" />
           </svg>
         </button>
-        <Layouts.theme_toggle />
+        <button
+          class="crit-toc-toggle"
+          id="settingsToggle"
+          title="Settings"
+          aria-label="Settings"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M7.429 1.525a3.5 3.5 0 0 1 1.142 0c.036.003.108.036.137.146l.289 1.105c.147.56.55.967.997 1.189.174.086.341.183.501.29.417.278.97.423 1.53.27l1.102-.303c.11-.03.175.016.195.046.219.31.41.641.573.989.014.031.022.11-.059.19l-.815.806c-.411.406-.562.957-.53 1.456a4.6 4.6 0 0 1 0 .582c-.032.499.119 1.05.53 1.456l.815.806c.08.08.073.159.059.19a6 6 0 0 1-.573.99c-.02.029-.086.074-.195.045l-1.103-.303c-.559-.153-1.112-.008-1.529.27-.16.107-.327.204-.5.29-.449.222-.851.628-.998 1.189l-.289 1.105c-.029.11-.101.143-.137.146a3.5 3.5 0 0 1-1.142 0c-.036-.003-.108-.037-.137-.146l-.289-1.105c-.147-.56-.55-.967-.997-1.189a4 4 0 0 1-.501-.29c-.417-.278-.97-.423-1.53-.27l-1.102.303c-.11.03-.175-.016-.195-.046a6 6 0 0 1-.573-.989c-.014-.031-.022-.11.059-.19l.815-.806c.411-.406.562-.957.53-1.456a4.6 4.6 0 0 1 0-.582c.032-.499-.119-1.05-.53-1.456l-.815-.806c-.08-.08-.073-.159-.059-.19a6 6 0 0 1 .573-.99c.02-.029.086-.074.195-.045l1.103.303c.559.153 1.112.008 1.529-.27.16-.107.327-.204.5-.29.449-.222.851-.628.998-1.189l.289-1.105c.029-.11.101-.143.137-.146M8 0a4.5 4.5 0 0 0-1.46.243 1.5 1.5 0 0 0-1.088 1.158l-.289 1.105a1 1 0 0 1-.249.432 3 3 0 0 0-.37.215 1 1 0 0 1-.473.083l-1.103-.303a1.5 1.5 0 0 0-1.53.463 7 7 0 0 0-.688 1.186 1.5 1.5 0 0 0 .442 1.621l.815.806a1 1 0 0 1 .168.474 3.6 3.6 0 0 0 0 .428 1 1 0 0 1-.168.474l-.815.806a1.5 1.5 0 0 0-.442 1.621c.17.434.378.846.618 1.236a1.5 1.5 0 0 0 1.6.413l1.103-.303a1 1 0 0 1 .473.083c.121.065.24.137.37.215a1 1 0 0 1 .249.432l.289 1.105a1.5 1.5 0 0 0 1.088 1.158A4.5 4.5 0 0 0 8 16a4.5 4.5 0 0 0 1.46-.243 1.5 1.5 0 0 0 1.088-1.158l.289-1.105a1 1 0 0 1 .249-.432 3 3 0 0 0 .37-.215 1 1 0 0 1 .473-.083l1.103.303a1.5 1.5 0 0 0 1.53-.463c.24-.39.447-.802.617-1.236a1.5 1.5 0 0 0-.442-1.621l-.815-.806a1 1 0 0 1-.168-.474 3.6 3.6 0 0 0 0-.428 1 1 0 0 1 .168-.474l.815-.806a1.5 1.5 0 0 0 .442-1.621 7 7 0 0 0-.688-1.186 1.5 1.5 0 0 0-1.53-.463l-1.103.303a1 1 0 0 1-.473-.083 3 3 0 0 0-.37-.215 1 1 0 0 1-.249-.432l-.289-1.105A1.5 1.5 0 0 0 9.46.243 4.5 4.5 0 0 0 8 0M5.5 8a2.5 2.5 0 1 1 5 0 2.5 2.5 0 0 1-5 0M8 6.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
         <div class="crit-split-btn" id="prompt-split-btn">
           <button
             class="btn btn-primary crit-split-btn-main"
@@ -271,6 +268,23 @@
             </button>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+
+  <%!-- Settings panel modal --%>
+  <div id="settingsOverlay" class="settings-overlay">
+    <div class="settings-dialog">
+      <div class="settings-tabs">
+        <button class="settings-tab active" data-tab="settings">Settings</button>
+        <button class="settings-tab" data-tab="shortcuts">Shortcuts</button>
+        <button class="settings-tab" data-tab="about">About</button>
+        <button class="settings-tab-close" id="settingsClose" aria-label="Close">&#x2715;</button>
+      </div>
+      <div class="settings-content">
+        <div class="settings-pane active" data-pane="settings" id="settingsPane"></div>
+        <div class="settings-pane" data-pane="shortcuts" id="shortcutsPane"></div>
+        <div class="settings-pane" data-pane="about" id="aboutPane"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Ports the settings panel and content width toggle from crit v0.9.0+, closing the parity gap between the local CLI and web interface.

### Changes

**New Features:**
- ⚙️ Settings modal with three tabs: Settings, Shortcuts, About
- 📏 Content width toggle (Compact 840px / Default 1040px / Wide 1280px)
- 🎨 Theme toggle moved into Settings tab
- 💾 Width preference persists in localStorage

**Removed from Header:**
- Theme toggle component (now in settings)
- Shortcuts (?) button (now in settings modal)

**Preserved:**
- Theme toggle remains on marketing pages via main layout
- Keyboard shortcut `?` opens settings → Shortcuts tab

### Files Changed

- `lib/crit_web/live/review_live.html.heex` — added settings button + modal HTML
- `assets/css/app.css` — added content width vars, settings modal styling
- `assets/js/document-renderer.js` — added width/theme/settings logic

### Testing

- [ ] Settings modal opens/closes correctly
- [ ] Tab switching works (Settings → Shortcuts → About)
- [ ] Theme toggle in panel applies immediately
- [ ] Width toggle applies and persists across page reloads
- [ ] Keyboard shortcuts work (`?` opens settings, Esc closes)
- [ ] No console errors
- [ ] CI passes

### Parity Status

Aligns crit-web's review page with crit v0.9.0+ feature set. Closes #__ (parity tracking).