### PR TITLE
fix: pre-release audit — align font stack and content width

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -29,8 +29,8 @@
    always wins. */
 :root {
   --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Consolas', monospace;
-  --crit-content-width: 840px;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+  --crit-content-width: 1040px;
   --crit-bg-primary: #1a1b26;
   --crit-bg-secondary: #16171f;
   --crit-bg-tertiary: #262940;


### PR DESCRIPTION
## Summary

Pre-release parity audit found two CSS drifts from crit local (v0.9.0..HEAD):

- Add `Cascadia Code` to `--font-mono` fallback stack (matches crit local's position after SF Mono)
- Change `--crit-content-width` default from `840px` to `1040px` (matches crit local)

File picker autocomplete was intentionally **not** ported — crit-web only has shared review files, making @-mention file picker nearly useless. Keyboard shortcuts (G, C, ], [, ?) were already wired.

## Test plan

- [x] Independent parity review confirmed file picker fully reverted
- [x] Font stack position verified against crit local source
- [x] Content width value verified against crit local source
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)