### PR TITLE
fix: handle Cloud SQL unix socket DATABASE_URL format

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -96,13 +96,49 @@ if config_env() == :prod do
       false
     end
 
-  config :crit, Crit.Repo,
-    ssl: ssl_opts,
-    url: database_url,
-    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-    # For machines with several cores, consider starting multiple pools of `pool_size`
-    # pool_count: 4,
-    socket_options: maybe_ipv6
+  # Handle Cloud SQL unix socket format used by Taskforce Vibe:
+  #   postgresql://role:pw@/dbname?host=/cloudsql/project:region:instance
+  # Ecto's URL parser rejects URLs without a hostname (host: nil),
+  # so for Cloud SQL we parse the URL ourselves into individual options.
+  repo_opts =
+    case URI.parse(database_url) do
+      %URI{query: query} = uri when is_binary(query) ->
+        params = URI.decode_query(query)
+
+        case params["host"] do
+          "/cloudsql/" <> _ = socket_path ->
+            [user, password] =
+              case uri.userinfo do
+                nil -> [nil, nil]
+                info -> String.split(info, ":", parts: 2)
+              end
+
+            database = String.trim_leading(uri.path || "", "/")
+
+            [
+              username: user,
+              password: password,
+              database: database,
+              socket_dir: socket_path
+            ]
+
+          _ ->
+            [url: database_url]
+        end
+
+      _ ->
+        [url: database_url]
+    end
+
+  repo_opts =
+    repo_opts ++
+      [
+        ssl: ssl_opts,
+        pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+        socket_options: maybe_ipv6
+      ]
+
+  config :crit, Crit.Repo, repo_opts
 
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -96,21 +96,29 @@ if config_env() == :prod do
       false
     end
 
-  # Handle Cloud SQL unix socket format used by Taskforce Vibe:
+  # Handle unix socket DATABASE_URLs (e.g. Cloud SQL on Google Cloud Run):
   #   postgresql://role:pw@/dbname?host=/cloudsql/project:region:instance
   # Ecto's URL parser rejects URLs without a hostname (host: nil),
-  # so for Cloud SQL we parse the URL ourselves into individual options.
+  # so we parse the URL ourselves and pass options directly to Postgrex.
+  pool_size = String.to_integer(System.get_env("POOL_SIZE") || "10")
+
   repo_opts =
     case URI.parse(database_url) do
       %URI{query: query} = uri when is_binary(query) ->
         params = URI.decode_query(query)
 
         case params["host"] do
-          "/cloudsql/" <> _ = socket_path ->
-            [user, password] =
+          "/" <> _ = socket_path ->
+            {user, password} =
               case uri.userinfo do
-                nil -> [nil, nil]
-                info -> String.split(info, ":", parts: 2)
+                nil ->
+                  {nil, nil}
+
+                info ->
+                  case String.split(info, ":", parts: 2) do
+                    [u, p] -> {URI.decode(u), URI.decode(p)}
+                    [u] -> {URI.decode(u), nil}
+                  end
               end
 
             database = String.trim_leading(uri.path || "", "/")
@@ -119,24 +127,18 @@ if config_env() == :prod do
               username: user,
               password: password,
               database: database,
-              socket_dir: socket_path
+              socket_dir: socket_path,
+              ssl: false,
+              pool_size: pool_size
             ]
 
           _ ->
-            [url: database_url]
+            [url: database_url, ssl: ssl_opts, pool_size: pool_size, socket_options: maybe_ipv6]
         end
 
       _ ->
-        [url: database_url]
+        [url: database_url, ssl: ssl_opts, pool_size: pool_size, socket_options: maybe_ipv6]
     end
-
-  repo_opts =
-    repo_opts ++
-      [
-        ssl: ssl_opts,
-        pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-        socket_options: maybe_ipv6
-      ]
 
   config :crit, Crit.Repo, repo_opts
 


### PR DESCRIPTION
## Problem

When self-hosting crit-web on Google Cloud Run with Cloud SQL, the auto-injected `DATABASE_URL` uses a unix socket format:

```
postgresql://user:pw@/dbname?host=/cloudsql/project:region:instance
```

This URL has **no hostname** — the database is accessed via a unix domain socket at the path specified by the `?host=` query parameter. However, Ecto's `Repo.Supervisor.parse_url/1` requires a non-nil `host` in the parsed URI and raises `Ecto.InvalidURLError`:

```
** (Ecto.InvalidURLError) invalid URL postgresql://...@/dbname?host=/cloudsql/..., host is not present.
   The parsed URL is: %URI{host: nil, ...}
```

This crashes both the migration script and the application startup (`Crit.Repo` fails to start), making self-hosted deployments on Cloud Run with Cloud SQL impossible without manually rewriting the `DATABASE_URL`.

## Solution

Detect the Cloud SQL socket pattern (`/cloudsql/` prefix in the URL's `?host=` query parameter) and bypass Ecto's URL parser entirely. Instead, parse the URL ourselves with `URI.parse/1` and pass individual connection options directly to Postgrex:

- `username` and `password` — extracted from `URI.userinfo`
- `database` — extracted from `URI.path`
- `socket_dir` — the `/cloudsql/...` path from the query parameter (Postgrex uses this to connect via unix domain socket)

Standard `DATABASE_URL` formats (with a hostname like `postgresql://user:pw@localhost:5432/dbname`) are **unaffected** — they continue through the existing `url:` code path.

## Testing

Deployed and verified on Google Cloud Run with Cloud SQL (PostgreSQL). Migrations run successfully and the application starts and serves traffic on the configured port.