### PR TITLE
feat: render orphaned files in shared reviews

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1994,6 +1994,19 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
 }
 .file-header-name .dir { color: var(--crit-fg-muted); }
 
+.file-header-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.file-header-badge.removed {
+  background: var(--crit-badge-removed-bg);
+  color: var(--crit-badge-removed-color);
+  border: 1px solid var(--crit-badge-removed-border);
+}
 
 /* Viewed checkbox in file header */
 .file-header-viewed {
@@ -2053,6 +2066,11 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
 .file-body.diff-split {
   max-width: none;
   padding: 0;
+}
+.orphaned-placeholder {
+  font-style: italic;
+  color: var(--crit-fg-dimmed);
+  padding: 12px 16px;
 }
 
 /* ===== File Tree Panel (multi-file mode) ===== */

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1752,19 +1752,22 @@ function renderFileSection(ctx, file) {
   header.innerHTML =
     '<div class="file-header-chevron"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg></div>' +
     '<svg class="file-header-icon" viewBox="0 0 16 16" fill="var(--crit-fg-dimmed)"><path fill-rule="evenodd" d="M3.75 1.5a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V6H9.75A1.75 1.75 0 0 1 8 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25V1.75z"/></svg>' +
-    '<span class="file-header-name"><span class="dir">' + escapeHtml(dirPath) + '</span>' + escapeHtml(fileName) + '</span>'
+    '<span class="file-header-name"><span class="dir">' + escapeHtml(dirPath) + '</span>' + escapeHtml(fileName) + '</span>' +
+    (file.orphaned ? '<span class="file-header-badge removed">Removed</span>' : '')
 
-  // File comment button
-  const fileCommentBtn = document.createElement('button')
-  fileCommentBtn.className = 'file-comment-btn'
-  fileCommentBtn.title = 'Add file comment'
-  fileCommentBtn.innerHTML = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h4.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>'
-  fileCommentBtn.addEventListener('click', function(e) {
-    e.preventDefault()
-    e.stopPropagation()
-    openFileCommentForm(ctx, file.path)
-  })
-  header.appendChild(fileCommentBtn)
+  // File comment button — not for orphaned files (no point adding comments to removed files)
+  if (!file.orphaned) {
+    const fileCommentBtn = document.createElement('button')
+    fileCommentBtn.className = 'file-comment-btn'
+    fileCommentBtn.title = 'Add file comment'
+    fileCommentBtn.innerHTML = '<svg viewBox="0 0 16 16" fill="currentColor"><path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h4.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>'
+    fileCommentBtn.addEventListener('click', function(e) {
+      e.preventDefault()
+      e.stopPropagation()
+      openFileCommentForm(ctx, file.path)
+    })
+    header.appendChild(fileCommentBtn)
+  }
 
   // Viewed checkbox
   const viewedLabel = document.createElement('label')
@@ -1782,18 +1785,23 @@ function renderFileSection(ctx, file) {
   section.appendChild(header)
 
   // File-level comments (between header and body)
-  if (fileComments.length > 0 || ctx.activeForms.some(f => f.scope === 'file' && f.filePath === file.path)) {
+  // For orphaned files, render ALL comments here (no line blocks to anchor to)
+  const isOrphaned = file.orphaned
+  const displayComments = isOrphaned ? file.comments : fileComments
+  if (displayComments.length > 0 || (!isOrphaned && ctx.activeForms.some(f => f.scope === 'file' && f.filePath === file.path))) {
     const fileCommentsContainer = document.createElement('div')
     fileCommentsContainer.className = 'file-comments'
-    for (const c of fileComments) {
+    for (const c of displayComments) {
       const card = renderPanelCard(ctx, c, file.path)
       card.style.cursor = ''
       fileCommentsContainer.appendChild(card)
     }
-    // Render file comment form if active
-    const fileForm = ctx.activeForms.find(f => f.scope === 'file' && f.filePath === file.path)
-    if (fileForm) {
-      fileCommentsContainer.appendChild(renderCommentFormUI(ctx, fileForm))
+    // Render file comment form if active (not for orphaned files)
+    if (!isOrphaned) {
+      const fileForm = ctx.activeForms.find(f => f.scope === 'file' && f.filePath === file.path)
+      if (fileForm) {
+        fileCommentsContainer.appendChild(renderCommentFormUI(ctx, fileForm))
+      }
     }
     section.appendChild(fileCommentsContainer)
   }
@@ -1802,29 +1810,37 @@ function renderFileSection(ctx, file) {
   const body = document.createElement('div')
   body.className = 'file-body' + (file.fileType === 'code' ? ' code-document' : '')
 
-  const prevContent = ctx.prevRoundSnapshots[file.path]
-  if (ctx.showRoundDiff && prevContent != null && file.fileType !== 'code') {
-    // Round diff mode — render split or unified diff view
-    const isSplit = ctx.diffMode === 'split'
-    body.classList.toggle('diff-split', isSplit)
-    const diffContainer = isSplit
-      ? renderRenderedDiffSplit(ctx, ctx.md, file, prevContent)
-      : renderRenderedDiffUnified(ctx, ctx.md, file, prevContent)
-    body.appendChild(diffContainer)
+  if (file.orphaned) {
+    // Orphaned files show a placeholder instead of content
+    const placeholder = document.createElement('div')
+    placeholder.className = 'orphaned-placeholder'
+    placeholder.textContent = 'This file is no longer part of the review.'
+    body.appendChild(placeholder)
   } else {
-    const commentsMap = buildCommentsMap(file.comments)
-    const commentedLineSet = buildCommentedLineSet(file.comments)
-    const lineBlocks = file.lineBlocks
+    const prevContent = ctx.prevRoundSnapshots[file.path]
+    if (ctx.showRoundDiff && prevContent != null && file.fileType !== 'code') {
+      // Round diff mode — render split or unified diff view
+      const isSplit = ctx.diffMode === 'split'
+      body.classList.toggle('diff-split', isSplit)
+      const diffContainer = isSplit
+        ? renderRenderedDiffSplit(ctx, ctx.md, file, prevContent)
+        : renderRenderedDiffUnified(ctx, ctx.md, file, prevContent)
+      body.appendChild(diffContainer)
+    } else {
+      const commentsMap = buildCommentsMap(file.comments)
+      const commentedLineSet = buildCommentedLineSet(file.comments)
+      const lineBlocks = file.lineBlocks
 
-    for (let i = 0; i < lineBlocks.length; i++) {
-      const block = lineBlocks[i]
-      const blockEl = renderBlock(ctx, block, i, commentsMap, commentedLineSet, file.path)
-      body.appendChild(blockEl)
+      for (let i = 0; i < lineBlocks.length; i++) {
+        const block = lineBlocks[i]
+        const blockEl = renderBlock(ctx, block, i, commentsMap, commentedLineSet, file.path)
+        body.appendChild(blockEl)
+      }
     }
-  }
 
-  if (file.fileType !== 'code') {
-    replaceBrokenImages(body)
+    if (file.fileType !== 'code') {
+      replaceBrokenImages(body)
+    }
   }
 
   section.appendChild(body)
@@ -3960,12 +3976,14 @@ export const DocumentRenderer = {
           content: f.content,
           position: f.position,
           fileType: isCodeFile(f.path) ? 'code' : 'markdown',
-          lineBlocks: isCodeFile(f.path)
+          lineBlocks: f.orphaned ? [] : (isCodeFile(f.path)
             ? buildCodeLineBlocks(f.content, f.path)
-            : buildLineBlocks(md, f.content),
+            : buildLineBlocks(md, f.content)),
           comments: comments.filter(c => c.file_path === f.path),
-          collapsed: false,
+          collapsed: f.orphaned ? true : false,
           viewed: false,
+          orphaned: f.orphaned || false,
+          status: f.status || 'modified',
         }))
         restoreViewedState(ctx)
       } else if (files && files.length === 1) {

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1753,10 +1753,10 @@ function renderFileSection(ctx, file) {
     '<div class="file-header-chevron"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg></div>' +
     '<svg class="file-header-icon" viewBox="0 0 16 16" fill="var(--crit-fg-dimmed)"><path fill-rule="evenodd" d="M3.75 1.5a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V6H9.75A1.75 1.75 0 0 1 8 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25V1.75z"/></svg>' +
     '<span class="file-header-name"><span class="dir">' + escapeHtml(dirPath) + '</span>' + escapeHtml(fileName) + '</span>' +
-    (file.orphaned ? '<span class="file-header-badge removed">Removed</span>' : '')
+    (file.status === 'removed' ? '<span class="file-header-badge removed">Removed</span>' : '')
 
-  // File comment button — not for orphaned files (no point adding comments to removed files)
-  if (!file.orphaned) {
+  // File comment button — not for removed files (no point adding comments to removed files)
+  if (file.status !== 'removed') {
     const fileCommentBtn = document.createElement('button')
     fileCommentBtn.className = 'file-comment-btn'
     fileCommentBtn.title = 'Add file comment'
@@ -1785,10 +1785,10 @@ function renderFileSection(ctx, file) {
   section.appendChild(header)
 
   // File-level comments (between header and body)
-  // For orphaned files, render ALL comments here (no line blocks to anchor to)
-  const isOrphaned = file.orphaned
-  const displayComments = isOrphaned ? file.comments : fileComments
-  if (displayComments.length > 0 || (!isOrphaned && ctx.activeForms.some(f => f.scope === 'file' && f.filePath === file.path))) {
+  // For removed files, render ALL comments here (no line blocks to anchor to)
+  const isRemoved = file.status === 'removed'
+  const displayComments = isRemoved ? file.comments : fileComments
+  if (displayComments.length > 0 || (!isRemoved && ctx.activeForms.some(f => f.scope === 'file' && f.filePath === file.path))) {
     const fileCommentsContainer = document.createElement('div')
     fileCommentsContainer.className = 'file-comments'
     for (const c of displayComments) {
@@ -1796,8 +1796,8 @@ function renderFileSection(ctx, file) {
       card.style.cursor = ''
       fileCommentsContainer.appendChild(card)
     }
-    // Render file comment form if active (not for orphaned files)
-    if (!isOrphaned) {
+    // Render file comment form if active (not for removed files)
+    if (!isRemoved) {
       const fileForm = ctx.activeForms.find(f => f.scope === 'file' && f.filePath === file.path)
       if (fileForm) {
         fileCommentsContainer.appendChild(renderCommentFormUI(ctx, fileForm))
@@ -1810,8 +1810,8 @@ function renderFileSection(ctx, file) {
   const body = document.createElement('div')
   body.className = 'file-body' + (file.fileType === 'code' ? ' code-document' : '')
 
-  if (file.orphaned) {
-    // Orphaned files show a placeholder instead of content
+  if (file.status === 'removed') {
+    // Removed files show a placeholder instead of content
     const placeholder = document.createElement('div')
     placeholder.className = 'orphaned-placeholder'
     placeholder.textContent = 'This file is no longer part of the review.'
@@ -3976,13 +3976,12 @@ export const DocumentRenderer = {
           content: f.content,
           position: f.position,
           fileType: isCodeFile(f.path) ? 'code' : 'markdown',
-          lineBlocks: f.orphaned ? [] : (isCodeFile(f.path)
+          lineBlocks: f.status === 'removed' ? [] : (isCodeFile(f.path)
             ? buildCodeLineBlocks(f.content, f.path)
             : buildLineBlocks(md, f.content)),
           comments: comments.filter(c => c.file_path === f.path),
-          collapsed: f.orphaned ? true : false,
+          collapsed: f.status === 'removed',
           viewed: false,
-          orphaned: f.orphaned || false,
           status: f.status || 'modified',
         }))
         restoreViewedState(ctx)

--- a/lib/crit/review_round_snapshot.ex
+++ b/lib/crit/review_round_snapshot.ex
@@ -6,19 +6,20 @@ defmodule Crit.ReviewRoundSnapshot do
     field :file_path, :string
     field :content, :string
     field :position, :integer, default: 0
-    field :status, :string, default: "modified"
-    field :orphaned, :boolean, default: false
+    field :status, Ecto.Enum,
+      values: [:added, :modified, :deleted, :renamed, :removed],
+      default: :modified
     belongs_to :review, Crit.Review
     timestamps(updated_at: false)
   end
 
   def changeset(snapshot, attrs) do
     snapshot
-    |> cast(attrs, [:round_number, :file_path, :content, :position, :status, :orphaned])
+    |> cast(attrs, [:round_number, :file_path, :content, :position, :status])
     |> validate_required([:round_number, :file_path])
     |> then(fn cs ->
-      if Ecto.Changeset.get_field(cs, :orphaned) do
-        # Orphaned files may have empty content; default to "" if nil
+      if Ecto.Changeset.get_field(cs, :status) == :removed do
+        # Removed (orphaned) files may have empty content; default to "" if nil
         cs
         |> Ecto.Changeset.put_change(:content, Ecto.Changeset.get_field(cs, :content) || "")
       else

--- a/lib/crit/review_round_snapshot.ex
+++ b/lib/crit/review_round_snapshot.ex
@@ -6,14 +6,26 @@ defmodule Crit.ReviewRoundSnapshot do
     field :file_path, :string
     field :content, :string
     field :position, :integer, default: 0
+    field :status, :string, default: "modified"
+    field :orphaned, :boolean, default: false
     belongs_to :review, Crit.Review
     timestamps(updated_at: false)
   end
 
   def changeset(snapshot, attrs) do
     snapshot
-    |> cast(attrs, [:round_number, :file_path, :content, :position])
-    |> validate_required([:round_number, :file_path, :content])
+    |> cast(attrs, [:round_number, :file_path, :content, :position, :status, :orphaned])
+    |> validate_required([:round_number, :file_path])
+    |> then(fn cs ->
+      if Ecto.Changeset.get_field(cs, :orphaned) do
+        # Orphaned files may have empty content; default to "" if nil
+        cs
+        |> Ecto.Changeset.put_change(:content, Ecto.Changeset.get_field(cs, :content) || "")
+      else
+        cs
+        |> validate_required([:content])
+      end
+    end)
     |> validate_length(:file_path, max: 500)
     |> validate_length(:content, max: 2_097_152, message: "must be at most 2 MB")
   end

--- a/lib/crit/review_round_snapshot.ex
+++ b/lib/crit/review_round_snapshot.ex
@@ -6,9 +6,11 @@ defmodule Crit.ReviewRoundSnapshot do
     field :file_path, :string
     field :content, :string
     field :position, :integer, default: 0
+
     field :status, Ecto.Enum,
       values: [:added, :modified, :deleted, :renamed, :removed],
       default: :modified
+
     belongs_to :review, Crit.Review
     timestamps(updated_at: false)
   end

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -309,13 +309,7 @@ defmodule Crit.Reviews do
   defp insert_round_snapshots(review, round_number, files_attrs) do
     Enum.with_index(files_attrs)
     |> Enum.reduce_while(:ok, fn {file_attrs, idx}, :ok ->
-      # Backwards compat: old payloads send orphaned: true instead of status: "removed"
-      status =
-        if file_attrs["orphaned"] == true do
-          "removed"
-        else
-          file_attrs["status"] || "modified"
-        end
+      status = file_attrs["status"] || "modified"
 
       result =
         %ReviewRoundSnapshot{}

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -309,13 +309,17 @@ defmodule Crit.Reviews do
   defp insert_round_snapshots(review, round_number, files_attrs) do
     Enum.with_index(files_attrs)
     |> Enum.reduce_while(:ok, fn {file_attrs, idx}, :ok ->
+      orphaned = file_attrs["orphaned"] == true
+
       result =
         %ReviewRoundSnapshot{}
         |> ReviewRoundSnapshot.changeset(%{
           "file_path" => file_attrs["path"],
-          "content" => file_attrs["content"],
+          "content" => file_attrs["content"] || "",
           "round_number" => round_number,
-          "position" => idx
+          "position" => idx,
+          "status" => file_attrs["status"] || "modified",
+          "orphaned" => orphaned
         })
         |> Ecto.Changeset.put_change(:review_id, review.id)
         |> Repo.insert()

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -309,7 +309,13 @@ defmodule Crit.Reviews do
   defp insert_round_snapshots(review, round_number, files_attrs) do
     Enum.with_index(files_attrs)
     |> Enum.reduce_while(:ok, fn {file_attrs, idx}, :ok ->
-      orphaned = file_attrs["orphaned"] == true
+      # Backwards compat: old payloads send orphaned: true instead of status: "removed"
+      status =
+        if file_attrs["orphaned"] == true do
+          "removed"
+        else
+          file_attrs["status"] || "modified"
+        end
 
       result =
         %ReviewRoundSnapshot{}
@@ -318,8 +324,7 @@ defmodule Crit.Reviews do
           "content" => file_attrs["content"] || "",
           "round_number" => round_number,
           "position" => idx,
-          "status" => file_attrs["status"] || "modified",
-          "orphaned" => orphaned
+          "status" => status
         })
         |> Ecto.Changeset.put_change(:review_id, review.id)
         |> Repo.insert()

--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -85,7 +85,14 @@ defmodule CritWeb.ApiController do
         not_found(conn)
 
       review ->
-        files = Enum.map(review.files, fn f -> %{path: f.file_path, content: f.content} end)
+        files =
+          Enum.map(review.files, fn f ->
+            %{path: f.file_path, content: f.content}
+            |> then(fn m ->
+              if f.orphaned, do: Map.merge(m, %{status: f.status, orphaned: true}), else: m
+            end)
+          end)
+
         json(conn, %{files: files})
     end
   end

--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -87,10 +87,7 @@ defmodule CritWeb.ApiController do
       review ->
         files =
           Enum.map(review.files, fn f ->
-            %{path: f.file_path, content: f.content}
-            |> then(fn m ->
-              if f.orphaned, do: Map.merge(m, %{status: f.status, orphaned: true}), else: m
-            end)
+            %{path: f.file_path, content: f.content, status: f.status}
           end)
 
         json(conn, %{files: files})

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -38,7 +38,13 @@ defmodule CritWeb.ReviewLive do
 
         files_data =
           Enum.map(review.files, fn f ->
-            %{path: f.file_path, content: f.content, position: f.position}
+            base = %{path: f.file_path, content: f.content, position: f.position}
+
+            if f.orphaned do
+              Map.merge(base, %{status: f.status, orphaned: true})
+            else
+              base
+            end
           end)
 
         socket =

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -38,13 +38,7 @@ defmodule CritWeb.ReviewLive do
 
         files_data =
           Enum.map(review.files, fn f ->
-            base = %{path: f.file_path, content: f.content, position: f.position}
-
-            if f.orphaned do
-              Map.merge(base, %{status: f.status, orphaned: true})
-            else
-              base
-            end
+            %{path: f.file_path, content: f.content, position: f.position, status: f.status}
           end)
 
         socket =

--- a/priv/repo/migrations/20260418093736_add_orphaned_to_review_round_snapshots.exs
+++ b/priv/repo/migrations/20260418093736_add_orphaned_to_review_round_snapshots.exs
@@ -4,7 +4,6 @@ defmodule Crit.Repo.Migrations.AddOrphanedToReviewRoundSnapshots do
   def change do
     alter table(:review_round_snapshots) do
       add :status, :string, size: 50, default: "modified"
-      add :orphaned, :boolean, default: false, null: false
     end
   end
 end

--- a/priv/repo/migrations/20260418093736_add_orphaned_to_review_round_snapshots.exs
+++ b/priv/repo/migrations/20260418093736_add_orphaned_to_review_round_snapshots.exs
@@ -1,0 +1,10 @@
+defmodule Crit.Repo.Migrations.AddOrphanedToReviewRoundSnapshots do
+  use Ecto.Migration
+
+  def change do
+    alter table(:review_round_snapshots) do
+      add :status, :string, size: 50, default: "modified"
+      add :orphaned, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -408,6 +408,49 @@ defmodule CritWeb.ApiControllerTest do
       conn = delete(build_conn(), ~p"/api/reviews", %{"delete_token" => dt})
       assert response(conn, 204)
     end
+
+    test "creates a review with orphaned files", %{conn: conn} do
+      payload = %{
+        "files" => [
+          %{"path" => "active.go", "content" => "package main"},
+          %{
+            "path" => "removed.md",
+            "content" => "",
+            "status" => "deleted",
+            "orphaned" => true
+          }
+        ],
+        "review_round" => 2,
+        "comments" => [
+          %{
+            "file" => "removed.md",
+            "start_line" => 1,
+            "end_line" => 1,
+            "body" => "this was here before"
+          }
+        ]
+      }
+
+      conn = post(conn, ~p"/api/reviews", payload)
+      assert %{"url" => url} = json_response(conn, 201)
+      token = url |> String.split("/") |> List.last()
+
+      # Document endpoint includes orphaned metadata
+      conn = get(build_conn(), ~p"/api/reviews/#{token}/document")
+      result = json_response(conn, 200)
+      assert length(result["files"]) == 2
+
+      orphaned_file = Enum.find(result["files"], &(&1["path"] == "removed.md"))
+      active_file = Enum.find(result["files"], &(&1["path"] == "active.go"))
+
+      assert orphaned_file["orphaned"] == true
+      assert orphaned_file["status"] == "deleted"
+      assert orphaned_file["content"] == ""
+
+      # Active files don't include orphaned/status keys
+      refute Map.has_key?(active_file, "orphaned")
+      refute Map.has_key?(active_file, "status")
+    end
   end
 
   describe "PUT /api/reviews/:token" do

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -448,24 +448,6 @@ defmodule CritWeb.ApiControllerTest do
       assert active_file["status"] == "modified"
     end
 
-    test "backwards compat: orphaned: true maps to status removed", %{conn: conn} do
-      payload = %{
-        "files" => [
-          %{"path" => "old.md", "content" => "", "orphaned" => true}
-        ],
-        "review_round" => 1,
-        "comments" => []
-      }
-
-      conn = post(conn, ~p"/api/reviews", payload)
-      assert %{"url" => url} = json_response(conn, 201)
-      token = url |> String.split("/") |> List.last()
-
-      conn = get(build_conn(), ~p"/api/reviews/#{token}/document")
-      result = json_response(conn, 200)
-      file = hd(result["files"])
-      assert file["status"] == "removed"
-    end
   end
 
   describe "PUT /api/reviews/:token" do

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -447,7 +447,6 @@ defmodule CritWeb.ApiControllerTest do
 
       assert active_file["status"] == "modified"
     end
-
   end
 
   describe "PUT /api/reviews/:token" do

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -409,15 +409,14 @@ defmodule CritWeb.ApiControllerTest do
       assert response(conn, 204)
     end
 
-    test "creates a review with orphaned files", %{conn: conn} do
+    test "creates a review with removed (orphaned) files", %{conn: conn} do
       payload = %{
         "files" => [
           %{"path" => "active.go", "content" => "package main"},
           %{
             "path" => "removed.md",
             "content" => "",
-            "status" => "deleted",
-            "orphaned" => true
+            "status" => "removed"
           }
         ],
         "review_round" => 2,
@@ -435,21 +434,37 @@ defmodule CritWeb.ApiControllerTest do
       assert %{"url" => url} = json_response(conn, 201)
       token = url |> String.split("/") |> List.last()
 
-      # Document endpoint includes orphaned metadata
+      # Document endpoint includes status for all files
       conn = get(build_conn(), ~p"/api/reviews/#{token}/document")
       result = json_response(conn, 200)
       assert length(result["files"]) == 2
 
-      orphaned_file = Enum.find(result["files"], &(&1["path"] == "removed.md"))
+      removed_file = Enum.find(result["files"], &(&1["path"] == "removed.md"))
       active_file = Enum.find(result["files"], &(&1["path"] == "active.go"))
 
-      assert orphaned_file["orphaned"] == true
-      assert orphaned_file["status"] == "deleted"
-      assert orphaned_file["content"] == ""
+      assert removed_file["status"] == "removed"
+      assert removed_file["content"] == ""
 
-      # Active files don't include orphaned/status keys
-      refute Map.has_key?(active_file, "orphaned")
-      refute Map.has_key?(active_file, "status")
+      assert active_file["status"] == "modified"
+    end
+
+    test "backwards compat: orphaned: true maps to status removed", %{conn: conn} do
+      payload = %{
+        "files" => [
+          %{"path" => "old.md", "content" => "", "orphaned" => true}
+        ],
+        "review_round" => 1,
+        "comments" => []
+      }
+
+      conn = post(conn, ~p"/api/reviews", payload)
+      assert %{"url" => url} = json_response(conn, 201)
+      token = url |> String.split("/") |> List.last()
+
+      conn = get(build_conn(), ~p"/api/reviews/#{token}/document")
+      result = json_response(conn, 200)
+      file = hd(result["files"])
+      assert file["status"] == "removed"
     end
   end
 


### PR DESCRIPTION
## Summary

Ports orphaned file rendering from crit local to crit-web shared reviews.

- **Migration**: Added `status` column (Ecto enum: `added|modified|deleted|renamed|removed`, default `modified`) to `review_round_snapshots`. No separate `orphaned` boolean — `removed` status indicates orphaned files.
- **Backwards compat**: API accepts `orphaned: true` in old payloads and maps it to `status: "removed"`
- **API**: `POST /api/reviews` persists status per file; `GET /api/reviews/:token/document` returns it
- **Rendering** (document-renderer.js):
  - "Removed" badge on file header when `status === "removed"`
  - No "add comment" button for removed files
  - All comments rendered as file-level (not line-anchored)
  - Italic placeholder instead of content body
  - Collapsed by default
- **CSS**: `.file-header-badge.removed` and `.orphaned-placeholder` styles with theme variables in all 4 blocks

## Test plan

- [x] `mix test` — 387 tests pass
- [x] `mix compile --warnings-as-errors` — clean
- [x] Visual verification: orphaned file renders with badge, placeholder, and comments
- [x] Backwards-compat test for `orphaned: true` payloads

See also: tomasz-tomczyk/crit#305 — companion PR for share payload