### PR TITLE
docs: replace .crit.json references with review file

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,3 @@
+# Copy build caches from source branch worktree
+[pre-start]
+copy = "wt step copy-ignored --from {{ base }}"

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+deps/
+_build/
+assets/node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ crit-web/
 
 1. **Review page rendering** — the LiveView loads review data, then `document-renderer.js` (a Phoenix hook) renders the markdown client-side using markdown-it + highlight.js + mermaid. This mirrors how `crit` local renders.
 2. **API for CLI uploads** — `POST /api/reviews` accepts `{document, comments, metadata}` from the CLI's Share button. Returns `{url, delete_token}`.
-3. **Delete via token** — reviews are deleted by passing the `delete_token` (not auth). The CLI stores this in `.crit.json`.
+3. **Delete via token** — reviews are deleted by passing the `delete_token` (not auth). The CLI stores this in the review file.
 4. **Rate limiting** — Hammer-based, applied to API create/delete endpoints.
 5. **Identity** — session-based visitor ID via `Plugs.Identity`, used for display names on comments.
 6. **Comment threading** — comments support nested replies (`parent_id` self-referential FK) and a `resolved` boolean. The review LiveView handles reply CRUD and resolve/unresolve via `push_event`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ The `POST /api/reviews` endpoint is intentionally open (no API key required). Th
 
 ### Token-based deletion
 
-Reviews are deleted by presenting a `delete_token` (returned at creation time). The crit CLI stores this in `.crit.json`. There are no user accounts.
+Reviews are deleted by presenting a `delete_token` (returned at creation time). The crit CLI stores this in the review file (`~/.crit/reviews/`). There are no user accounts.
 
 ### Identity
 

--- a/lib/crit/output.ex
+++ b/lib/crit/output.ex
@@ -95,7 +95,7 @@ defmodule Crit.Output do
     |> Enum.join("\n\n---\n\n")
   end
 
-  @doc "Serialize review + comments to .crit.json shape for agent consumption."
+  @doc "Serialize review + comments to review file shape for agent consumption."
   def multi_file_comments_json(review, files, comments, base_url) do
     comments_by_file =
       comments

--- a/lib/crit_web/controllers/page_controller.ex
+++ b/lib/crit_web/controllers/page_controller.ex
@@ -15,7 +15,7 @@ defmodule CritWeb.PageController do
       ],
       why_this_matters: [
         "AI coding agents are fast, but they're also opaque. When Claude Code or Cursor rewrites a function, you don't get a natural place to say \"this is wrong at line 12\" unless you're already in a PR workflow. Most people end up pasting chunks of code into the chat and hoping the agent understands which part they mean. That's slow and error-prone.",
-        "Inline comments let you anchor feedback to the exact lines that need it. Instead of writing \"the error handling in the auth function looks wrong,\" you select lines 34-41 and leave a comment there. The agent reads `.crit.json` (the review state file) and knows precisely what you're reacting to. No ambiguity, no re-explaining context.",
+        "Inline comments let you anchor feedback to the exact lines that need it. Instead of writing \"the error handling in the auth function looks wrong,\" you select lines 34-41 and leave a comment there. The agent reads the review file and knows precisely what you're reacting to. No ambiguity, no re-explaining context.",
         "This also matters when reviewing plans, not just code. If your agent writes a markdown spec or a step-by-step plan before executing, you can review that document the same way you'd review a PR. Comment on the parts that need changing, approve the parts that look right, and hand it back."
       ],
       how_crit_compares:
@@ -44,17 +44,17 @@ defmodule CritWeb.PageController do
       title: "AI Review Loop",
       tagline: "Review, hand off to your agent, iterate",
       description:
-        "Leave comments, click Finish Review, and your agent is notified automatically via `crit listen`. The agent reads `.crit.json`, makes edits, and runs `crit go <port>` when done. Crit reloads with a diff, and you review again.",
+        "Leave comments, click Finish Review, and your agent is notified automatically via `crit listen`. The agent reads the review file, makes edits, and runs `crit go <port>` when done. Crit reloads with a diff, and you review again.",
       details: [
-        "When you click \"Finish Review\", Crit writes `.crit.json` - structured comment data with per-file sections. Your agent is notified automatically if it was listening via `crit listen`.",
-        "The prompt tells the agent to read `.crit.json`, address unresolved comments, and run `crit go <port>` when done. No copy-paste needed — `crit listen` delivers it directly.",
+        "When you click \"Finish Review\", Crit writes the review file — structured comment data with per-file sections. Your agent is notified automatically if it was listening via `crit listen`.",
+        "The prompt tells the agent to read the review file, address unresolved comments, and run `crit go <port>` when done. No copy-paste needed — `crit listen` delivers it directly.",
         "When the agent runs `crit go`, the browser starts a new round with a diff of what changed. Previous comments show as resolved or still open.",
         "Add new comments on the updated version and repeat. When all comments are resolved, Crit detects it and generates a clean confirmation prompt — the loop ends when you're satisfied."
       ],
       why_this_matters: [
         "The default interaction with AI coding agents is conversational: you type, it responds, you type again. That works for small tasks. For anything involving real code changes across multiple files, it breaks down because the conversation history gets long, context is lost, and you can't easily point back to \"that thing you changed in round 2.\"",
         "Crit replaces the conversation loop with a structured review loop. You review the output, leave comments on specific lines, submit Finish Review, and `crit listen` notifies the agent. The agent reads exactly what you wrote and where you wrote it, then runs `crit go` when it's done. You get a diff. You review again. The loop has a clear state at each step.",
-        "This structure also makes it easier to stop and resume. The state lives in `.crit.json`, so if you close your terminal and come back the next day, the review is still there. You're not reconstructing context from a chat thread."
+        "This structure also makes it easier to stop and resume. The state lives in the review file, so if you close your terminal and come back the next day, the review is still there. You're not reconstructing context from a chat thread."
       ],
       how_crit_compares:
         "Most AI agent workflows treat human feedback as a free-text prompt injected into the conversation. That works, but it's informal — there's no enforced structure around what the human reviewed, what they approved, and what they asked to change. Crit externalizes that state into a file the agent reads directly, which is more reliable and easier to audit after the fact."

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -67,8 +67,9 @@ defmodule CritWeb.ReviewLive do
           end
 
         local_prompt_text =
-          "Run `crit fetch` in the project directory to pull the latest review comments into .crit.json. " <>
-            "Read each unresolved comment, address it in the relevant file at the referenced location, " <>
+          "Run `crit fetch` to pull the latest review comments (it prints the review file path and each comment). " <>
+            "If you need the full comment text, read the review file — run `crit status` to find its path. " <>
+            "Address each unresolved comment in the relevant file at the referenced location, " <>
             "then reply with `crit comment --reply-to <id> --author 'Claude Code' '<what you did>'`. " <>
             "When all comments are addressed, run `crit share #{file_paths}` to post the updated files and replies back."
 

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -142,7 +142,7 @@ defmodule CritWeb.ApiControllerTest do
   end
 
   describe "GET /api/export/:token/comments" do
-    test "returns .crit.json compatible shape with top-level fields", %{conn: conn} do
+    test "returns review file compatible shape with top-level fields", %{conn: conn} do
       {:ok, review} =
         Reviews.create_review(
           [%{"path" => "plan.md", "content" => "# Plan"}],
@@ -162,7 +162,7 @@ defmodule CritWeb.ApiControllerTest do
       conn = get(conn, ~p"/api/export/#{review.token}/comments")
       body = json_response(conn, 200)
 
-      # Top-level .crit.json fields
+      # Top-level review file fields
       assert body["review_round"] == 1
       assert body["share_url"] =~ review.token
       assert body["delete_token"] == review.delete_token


### PR DESCRIPTION
## Summary
- Replace all `.crit.json` references with "the review file" across marketing copy, prompts, and docs
- The CLI now stores review data centrally at `~/.crit/reviews/<key>.json`, making `.crit.json` references misleading
- Update the "Send to Agent" prompt in `review_live.ex` to reference `crit fetch` output and `crit status` instead of a hardcoded file path

## Review
- [x] Code review: passed (via crit)
- [x] Parity audit: N/A (copy-only changes)

## Test plan
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format --check-formatted` — clean
- [x] Sobelow — no new findings
- See also: tomasz-tomczyk/crit#341 — companion CLI change (`crit fetch` now prints review file path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)