### PR TITLE
feat: store cli_args and include in prompt for local session refresh

### DIFF
--- a/lib/crit/review.ex
+++ b/lib/crit/review.ex
@@ -6,6 +6,7 @@ defmodule Crit.Review do
     field :delete_token, :string
     field :last_activity_at, :utc_datetime
     field :review_round, :integer, default: 0
+    field :cli_args, {:array, :string}, default: []
 
     belongs_to :user, Crit.User, type: :binary_id
 
@@ -20,7 +21,7 @@ defmodule Crit.Review do
   @doc "Changeset for creating a new review."
   def create_changeset(review, attrs) do
     review
-    |> cast(attrs, [:review_round])
+    |> cast(attrs, [:review_round, :cli_args])
     |> put_token()
     |> put_delete_token()
     |> put_last_activity_at()

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -130,13 +130,14 @@ defmodule Crit.Reviews do
       ) do
     total_size = files_attrs |> Enum.map(&byte_size(&1["content"] || "")) |> Enum.sum()
     user_id = Keyword.get(opts, :user_id)
+    cli_args = Keyword.get(opts, :cli_args) || []
 
     if total_size > @max_total_size do
       {:error, :total_size_exceeded}
     else
       review_changeset =
         %Review{}
-        |> Review.create_changeset(%{"review_round" => review_round || 0})
+        |> Review.create_changeset(%{"review_round" => review_round || 0, "cli_args" => cli_args})
         |> then(fn cs ->
           if user_id, do: Ecto.Changeset.put_change(cs, :user_id, user_id), else: cs
         end)
@@ -199,9 +200,14 @@ defmodule Crit.Reviews do
     with {:ok, review} <- fetch_review_for_update(token, delete_token) do
       files = payload["files"] || []
       comments = payload["comments"] || []
+      cli_args = payload["cli_args"]
+
+      review_changes =
+        if cli_args, do: %{cli_args: cli_args}, else: %{}
 
       if content_changed?(review, files) do
         new_round = review.review_round + 1
+        review_changes = Map.put(review_changes, :review_round, new_round)
 
         Ecto.Multi.new()
         |> Ecto.Multi.run(:snapshots, fn _repo, _changes ->
@@ -216,7 +222,7 @@ defmodule Crit.Reviews do
             {:error, _} = error -> error
           end
         end)
-        |> Ecto.Multi.update(:review, Ecto.Changeset.change(review, review_round: new_round))
+        |> Ecto.Multi.update(:review, Ecto.Changeset.change(review, review_changes))
         |> Repo.transaction()
         |> case do
           {:ok, %{review: updated}} ->
@@ -234,15 +240,27 @@ defmodule Crit.Reviews do
             {:error, reason}
         end
       else
-        Ecto.Multi.new()
-        |> Ecto.Multi.run(:comments, fn _repo, _changes ->
-          case replace_comments(review, comments) do
-            :ok -> {:ok, :ok}
-            {:error, _} = error -> error
+        multi = Ecto.Multi.new()
+
+        multi =
+          Ecto.Multi.run(multi, :comments, fn _repo, _changes ->
+            case replace_comments(review, comments) do
+              :ok -> {:ok, :ok}
+              {:error, _} = error -> error
+            end
+          end)
+
+        multi =
+          if review_changes != %{} do
+            Ecto.Multi.update(multi, :review, Ecto.Changeset.change(review, review_changes))
+          else
+            multi
           end
-        end)
+
+        multi
         |> Repo.transaction()
         |> case do
+          {:ok, %{review: updated}} -> {:ok, :no_changes, updated}
           {:ok, _} -> {:ok, :no_changes, review}
           {:error, _step, reason, _changes} -> {:error, reason}
         end

--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -11,6 +11,7 @@ defmodule CritWeb.ApiController do
 
   def create(conn, %{"files" => files} = params) when is_list(files) and files != [] do
     review_round = params["review_round"]
+    cli_args = params["cli_args"]
     comments = params["comments"] || []
     review_comments = params["review_comments"] || []
     user_id = conn.assigns[:current_user] && conn.assigns[:current_user].id
@@ -24,7 +25,8 @@ defmodule CritWeb.ApiController do
 
       true ->
         case Reviews.create_review(files, review_round, comments, review_comments,
-               user_id: user_id
+               user_id: user_id,
+               cli_args: cli_args
              ) do
           {:ok, review} ->
             url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
@@ -43,6 +45,7 @@ defmodule CritWeb.ApiController do
   def create(conn, %{"content" => content} = params) do
     filename = params["filename"]
     review_round = params["review_round"]
+    cli_args = params["cli_args"]
     comments = params["comments"] || []
     review_comments = params["review_comments"] || []
     user_id = conn.assigns[:current_user] && conn.assigns[:current_user].id
@@ -59,7 +62,8 @@ defmodule CritWeb.ApiController do
 
       true ->
         case Reviews.create_review(files, review_round, comments_with_file, review_comments,
-               user_id: user_id
+               user_id: user_id,
+               cli_args: cli_args
              ) do
           {:ok, review} ->
             url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
@@ -153,7 +157,7 @@ defmodule CritWeb.ApiController do
 
   def update(conn, %{"token" => token} = params) do
     delete_token = params["delete_token"]
-    payload = Map.take(params, ["files", "comments", "review_round"])
+    payload = Map.take(params, ["files", "comments", "review_round", "cli_args"])
 
     case Reviews.upsert_review(token, delete_token, payload) do
       {:ok, :updated, review} ->

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -66,12 +66,19 @@ defmodule CritWeb.ReviewLive do
             ""
           end
 
+        cli_args = review.cli_args || []
+
         local_prompt_text =
           "Run `crit fetch` to pull the latest review comments (it prints the review file path and each comment). " <>
             "If you need the full comment text, read the review file — run `crit status` to find its path. " <>
             "Address each unresolved comment in the relevant file at the referenced location, " <>
             "then reply with `crit comment --reply-to <id> --author 'Claude Code' '<what you did>'`. " <>
-            "When all comments are addressed, run `crit share #{file_paths}` to post the updated files and replies back."
+            "When all comments are addressed, run `crit share #{file_paths}` to post the updated files and replies back." <>
+            if(cli_args != [],
+              do:
+                " Then run `crit #{Enum.join(cli_args, " ")}` to refresh the local review session with your changes.",
+              else: ""
+            )
 
         export_url = CritWeb.Endpoint.url() <> ~p"/api/export/#{review.token}/review"
 

--- a/priv/repo/migrations/20260424155639_add_cli_args_to_reviews.exs
+++ b/priv/repo/migrations/20260424155639_add_cli_args_to_reviews.exs
@@ -1,0 +1,9 @@
+defmodule Crit.Repo.Migrations.AddCliArgsToReviews do
+  use Ecto.Migration
+
+  def change do
+    alter table(:reviews) do
+      add :cli_args, {:array, :string}, default: []
+    end
+  end
+end

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -270,6 +270,105 @@ defmodule CritWeb.ApiControllerTest do
     end
   end
 
+  describe "POST /api/reviews with cli_args" do
+    test "stores cli_args through multi-file create", %{conn: conn} do
+      payload = %{
+        "files" => [%{"path" => "plan.md", "content" => "# Plan"}],
+        "review_round" => 1,
+        "cli_args" => ["plan.md", "design.md"]
+      }
+
+      conn = post(conn, ~p"/api/reviews", payload)
+      assert %{"url" => url} = json_response(conn, 201)
+      token = url |> String.split("/") |> List.last()
+
+      review = Reviews.get_by_token(token)
+      assert review.cli_args == ["plan.md", "design.md"]
+    end
+
+    test "stores cli_args through single-file create", %{conn: conn} do
+      payload = %{
+        "content" => "# Plan",
+        "filename" => "plan.md",
+        "cli_args" => ["plan.md"]
+      }
+
+      conn = post(conn, ~p"/api/reviews", payload)
+      assert %{"url" => url} = json_response(conn, 201)
+      token = url |> String.split("/") |> List.last()
+
+      review = Reviews.get_by_token(token)
+      assert review.cli_args == ["plan.md"]
+    end
+
+    test "defaults cli_args to empty list when not provided", %{conn: conn} do
+      payload = %{
+        "files" => [%{"path" => "plan.md", "content" => "# Plan"}]
+      }
+
+      conn = post(conn, ~p"/api/reviews", payload)
+      assert %{"url" => url} = json_response(conn, 201)
+      token = url |> String.split("/") |> List.last()
+
+      review = Reviews.get_by_token(token)
+      assert review.cli_args == []
+    end
+  end
+
+  describe "PUT /api/reviews/:token with cli_args" do
+    test "updates cli_args on content change", %{conn: conn} do
+      {:ok, review} =
+        Reviews.create_review(
+          [%{"path" => "plan.md", "content" => "# v1"}],
+          1,
+          [],
+          []
+        )
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put("/api/reviews/#{review.token}", %{
+          delete_token: review.delete_token,
+          files: [%{path: "plan.md", content: "# v2"}],
+          comments: [],
+          review_round: 1,
+          cli_args: ["plan.md"]
+        })
+
+      assert %{"changed" => true} = json_response(conn, 200)
+
+      updated = Reviews.get_by_token(review.token)
+      assert updated.cli_args == ["plan.md"]
+    end
+
+    test "updates cli_args even when content unchanged", %{conn: conn} do
+      {:ok, review} =
+        Reviews.create_review(
+          [%{"path" => "plan.md", "content" => "same"}],
+          1,
+          [],
+          []
+        )
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put("/api/reviews/#{review.token}", %{
+          delete_token: review.delete_token,
+          files: [%{path: "plan.md", content: "same"}],
+          comments: [],
+          review_round: 1,
+          cli_args: ["plan.md"]
+        })
+
+      assert %{"changed" => false} = json_response(conn, 200)
+
+      updated = Reviews.get_by_token(review.token)
+      assert updated.cli_args == ["plan.md"]
+    end
+  end
+
   describe "POST /api/reviews multi-file" do
     test "creates a multi-file review", %{conn: conn} do
       payload = %{

--- a/test/crit_web/live/review_live_test.exs
+++ b/test/crit_web/live/review_live_test.exs
@@ -306,6 +306,38 @@ defmodule CritWeb.ReviewLiveTest do
       assert html =~ "crit fetch"
       assert html =~ "Act on comments"
     end
+
+    test "local prompt includes cli_args when present", %{conn: conn} do
+      {:ok, review} =
+        Reviews.create_review(
+          [%{"path" => "plan.md", "content" => "# Test"}],
+          1,
+          [],
+          [],
+          cli_args: ["plan.md", "design.md"]
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+      html =
+        view
+        |> element("#crit-prompt-panel")
+        |> render()
+
+      assert html =~ "crit plan.md design.md"
+      assert html =~ "refresh the local review session"
+    end
+
+    test "local prompt omits refresh instruction when no cli_args", %{conn: conn, review: review} do
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+      html =
+        view
+        |> element("#crit-prompt-panel")
+        |> render()
+
+      refute html =~ "refresh the local review session"
+    end
   end
 
   describe "PubSub handle_info forwarding" do


### PR DESCRIPTION
## Summary
- Adds `cli_args` column (string array) to reviews table via migration
- API controller extracts and passes `cli_args` through on create and update
- `upsert_review` persists cli_args even when file content hasn't changed
- Local prompt appends "Then run `crit <args>` to refresh the local review session" when cli_args are present

Companion PR: tomasz-tomczyk/crit#349

Closes tomasz-tomczyk/crit#342

## Test plan
- [x] API controller tests: cli_args in create (multi-file, single-file, default empty) and update (content changed, content unchanged)
- [x] LiveView tests: prompt includes cli_args when present, omits when absent
- [x] All 427 existing tests pass
- [x] Share integration tests pass (`make e2e-share`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)