### PR TITLE
fix: add seed-reply endpoint for share integration testing

### DIFF
--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -225,6 +225,25 @@ defmodule CritWeb.ApiController do
           json(conn, Reviews.serialize_comment(comment))
       end
     end
+
+    def seed_reply(conn, %{"token" => token, "comment_id" => comment_id} = params) do
+      case Reviews.get_by_token(token) do
+        nil ->
+          not_found(conn)
+
+        review ->
+          {:ok, reply} =
+            Reviews.create_reply(
+              comment_id,
+              %{"body" => params["body"] || "web reviewer reply"},
+              "integration-test",
+              params["author"] || "WebReviewer",
+              review.id
+            )
+
+          json(conn, Reviews.serialize_reply(reply))
+      end
+    end
   end
 
   # Handled by LocalhostCors plug — this action is never reached.

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -128,6 +128,7 @@ defmodule CritWeb.Router do
 
     if Mix.env() in [:test, :dev] do
       post "/reviews/:token/seed-comment", ApiController, :seed_comment
+      post "/reviews/:token/seed-reply/:comment_id", ApiController, :seed_reply
     end
   end
 


### PR DESCRIPTION
## Summary
- Add `POST /api/reviews/:token/seed-reply/:comment_id` endpoint (dev/test only)
- Enables integration testing of reply fetching in the crit CLI `fetch` command
- Companion to tomasz-tomczyk/crit#351 which fixes reply sync

## Test plan
- Endpoint only available in dev/test (`Mix.env() in [:test, :dev]`)
- Used by `TestShareSyncFetchReplies` and `TestShareSyncFetchRepliesOnExistingComments` in crit's share integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)