### PR TITLE
docs: update plugin install instructions to claude CLI syntax

### DIFF
--- a/lib/crit_web/controllers/page_html.ex
+++ b/lib/crit_web/controllers/page_html.ex
@@ -145,10 +145,10 @@ defmodule CritWeb.PageHTML do
     %{
       id: "claude-code",
       name: "Claude Code",
-      copy: "/plugin marketplace add tomasz-tomczyk/crit\n/plugin install crit",
+      copy: "claude plugin marketplace add tomasz-tomczyk/crit\nclaude plugin install crit@crit",
       lines: [
-        %{type: :cmd, prompt: "> ", text: "/plugin marketplace add tomasz-tomczyk/crit"},
-        %{type: :cmd, prompt: "> ", text: "/plugin install crit"},
+        %{type: :cmd, prompt: "$ ", text: "claude plugin marketplace add tomasz-tomczyk/crit"},
+        %{type: :cmd, prompt: "$ ", text: "claude plugin install crit@crit"},
         %{type: :output, text: "Installed crit (skills: crit, crit-cli)"}
       ]
     },


### PR DESCRIPTION
## Summary
- Update Claude Code install commands on homepage from `/plugin` slash commands to `claude plugin` CLI syntax
- Changed terminal prompt from `> ` to `$ ` (now terminal commands, not slash commands)

## Test plan
- Docs-only change, no functional impact
- See also: tomasz-tomczyk/crit#351

🤖 Generated with [Claude Code](https://claude.com/claude-code)