### PR TITLE
feat: redesign comments panel with segmented filter and collapsible groups

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,3 +1,6 @@
 # Copy build caches from source branch worktree
 [pre-start]
 copy = "wt step copy-ignored --from {{ base }}"
+
+[post-start]
+mise-trust = "mise trust ."

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1775,44 +1775,23 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
   padding: 10px 16px 12px;
 }
 
-/* Segmented pill filter (reuses settings-pill visual pattern) */
-.comments-filter-pill {
-  position: relative;
+/* Comments filter — reuses .scope-toggle + .toggle-btn pattern */
+.comments-filter-toggle {
   display: inline-flex;
-  align-items: center;
-  border: 1px solid var(--crit-border);
-  background: var(--crit-editor-bg-card);
-  border-radius: 9999px;
-}
-.comments-filter-pill-indicator {
-  position: absolute;
-  height: 100%;
-  border-radius: 9999px;
   background: var(--crit-editor-bg-elevated);
   border: 1px solid var(--crit-border);
-  transition: left 0.2s cubic-bezier(0.4, 0, 0.2, 1), width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  pointer-events: none;
+  border-radius: 6px;
+  padding: 2px;
+  gap: 1px;
 }
-.comments-filter-pill-btn {
+.comments-filter-toggle .toggle-btn {
+  font-size: 11px;
+  padding: 3px 10px;
   display: flex;
   align-items: center;
-  justify-content: center;
   gap: 4px;
-  padding: 4px 10px;
-  cursor: pointer;
-  background: none;
-  border: none;
-  color: var(--crit-editor-fg-muted);
-  position: relative;
-  z-index: 1;
-  transition: color 0.15s;
-  font-size: 12px;
-  font-weight: 500;
-  white-space: nowrap;
 }
-.comments-filter-pill-btn:hover { color: var(--crit-editor-fg); }
-.comments-filter-pill-btn.active { color: var(--crit-brand); }
-.comments-filter-pill-btn .filter-count {
+.comments-filter-toggle .filter-count {
   font-weight: 400;
   opacity: 0.7;
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1775,18 +1775,8 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
   padding: 10px 16px 12px;
 }
 
-/* Comments filter — reuses .scope-toggle + .toggle-btn pattern */
-.comments-filter-toggle {
-  display: inline-flex;
-  background: var(--crit-editor-bg-elevated);
-  border: 1px solid var(--crit-border);
-  border-radius: 6px;
-  padding: 2px;
-  gap: 1px;
-}
-.comments-filter-toggle .toggle-btn {
-  font-size: 11px;
-  padding: 3px 10px;
+/* Comments filter — reuses .crit-toggle-btn pattern */
+.comments-filter-toggle .crit-toggle-btn {
   display: flex;
   align-items: center;
   gap: 4px;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1701,26 +1701,46 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
   display: flex;
 }
 
+/* Two-row panel header */
 .comments-panel-header {
+  border-bottom: 1px solid var(--crit-border);
+  flex-shrink: 0;
+}
+.comments-panel-header-row1 {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 20px;
-  border-bottom: 1px solid var(--crit-border);
-  font-weight: 600;
-  font-size: 11px;
-  line-height: 1;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--crit-editor-fg-muted);
+  padding: 12px 16px 0;
 }
-
+.comments-panel-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.comments-panel-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--crit-editor-fg);
+}
+.comments-panel-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--crit-editor-fg-muted);
+  background: var(--crit-editor-bg-elevated);
+  border-radius: 9999px;
+  line-height: 1;
+}
 .comments-panel-header-actions {
   display: flex;
   align-items: center;
   gap: 8px;
 }
-
 .comments-panel-add-btn {
   background: none;
   border: 1px solid var(--crit-border);
@@ -1730,15 +1750,12 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
   padding: 3px 8px;
   border-radius: 4px;
   font-weight: 500;
-  text-transform: none;
-  letter-spacing: 0;
   line-height: 1;
 }
 .comments-panel-add-btn:hover {
   color: var(--crit-editor-fg);
   border-color: var(--crit-editor-fg-muted);
 }
-
 .comments-panel-close {
   background: none;
   border: none;
@@ -1751,56 +1768,74 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
 }
 .comments-panel-close:hover { background: var(--crit-editor-bg-elevated); color: var(--crit-editor-fg); }
 
+.comments-panel-header-row2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px 12px;
+}
+
+/* Segmented pill filter (reuses settings-pill visual pattern) */
+.comments-filter-pill {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--crit-border);
+  background: var(--crit-editor-bg-card);
+  border-radius: 9999px;
+}
+.comments-filter-pill-indicator {
+  position: absolute;
+  height: 100%;
+  border-radius: 9999px;
+  background: var(--crit-editor-bg-elevated);
+  border: 1px solid var(--crit-border);
+  transition: left 0.2s cubic-bezier(0.4, 0, 0.2, 1), width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  pointer-events: none;
+}
+.comments-filter-pill-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px 10px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: var(--crit-editor-fg-muted);
+  position: relative;
+  z-index: 1;
+  transition: color 0.15s;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.comments-filter-pill-btn:hover { color: var(--crit-editor-fg); }
+.comments-filter-pill-btn.active { color: var(--crit-brand); }
+.comments-filter-pill-btn .filter-count {
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+/* Expand all / Collapse all link */
+.comments-panel-expand-all {
+  background: none;
+  border: none;
+  color: var(--crit-editor-fg-muted);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+  transition: color 0.15s;
+  white-space: nowrap;
+}
+.comments-panel-expand-all:hover { color: var(--crit-editor-fg); }
+
 .comments-panel-body {
   flex: 1;
   overflow-y: auto;
-}
-
-/* Show resolved toggle */
-.comments-panel-filter {
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--crit-border);
-  flex-shrink: 0;
-}
-.comments-panel-switch {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-  user-select: none;
-}
-.comments-panel-switch input { position: absolute; opacity: 0; width: 0; height: 0; }
-.comments-panel-switch-track {
-  position: relative;
-  width: 28px;
-  height: 16px;
-  background: var(--crit-editor-bg-elevated);
-  border-radius: 8px;
-  border: 1px solid var(--crit-border);
-  transition: background 0.2s, border-color 0.2s;
-  flex-shrink: 0;
-}
-.comments-panel-switch-thumb {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 10px;
-  height: 10px;
-  background: var(--crit-editor-fg-muted);
-  border-radius: 50%;
-  transition: transform 0.2s, background 0.2s;
-}
-.comments-panel-switch input:checked + .comments-panel-switch-track {
-  background: var(--crit-brand-subtle);
-  border-color: var(--crit-brand);
-}
-.comments-panel-switch input:checked + .comments-panel-switch-track .comments-panel-switch-thumb {
-  transform: translateX(12px);
-  background: var(--crit-brand);
-}
-.comments-panel-switch-text {
-  font-size: 12px;
-  color: var(--crit-editor-fg-muted);
 }
 
 .comments-panel-empty {
@@ -1815,13 +1850,43 @@ body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
   border-top: 1px solid var(--crit-border);
 }
 .comments-panel-file-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   padding: 10px 12px 2px;
   font-family: var(--crit-font-mono);
   font-size: 11px;
   color: var(--crit-editor-fg-muted);
+  cursor: pointer;
+  user-select: none;
+}
+.comments-panel-file-name:hover {
+  color: var(--crit-editor-fg);
+}
+.comments-panel-file-chevron {
+  flex-shrink: 0;
+  font-size: 9px;
+  transition: transform 0.15s;
+  display: inline-block;
+}
+.comments-panel-file-group.collapsed .comments-panel-file-chevron {
+  transform: rotate(-90deg);
+}
+.comments-panel-file-name-text {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
+}
+.comments-panel-file-count {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: var(--crit-editor-fg-muted);
+  opacity: 0.6;
+  margin-left: auto;
+}
+.comments-panel-file-group.collapsed .comments-panel-file-cards {
+  display: none;
 }
 
 /* Panel comment blocks — reuse inline .comment-card inside panel */

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3266,7 +3266,7 @@ function renderCommentsPanel(ctx) {
   if (badge) badge.textContent = totalCount
 
   // Update pill counts
-  const pillBtns = panel.querySelectorAll('.toggle-btn')
+  const pillBtns = panel.querySelectorAll('.crit-toggle-btn')
   pillBtns.forEach(btn => {
     const countEl = btn.querySelector('.filter-count')
     if (!countEl) return
@@ -4038,10 +4038,10 @@ export const DocumentRenderer = {
           </div>
         </div>
         <div class="comments-panel-header-row2">
-          <div class="comments-filter-toggle" id="commentsFilterPill" role="group" aria-label="Filter comments">
-            <button class="toggle-btn active" data-filter="all">All <span class="filter-count">0</span></button>
-            <button class="toggle-btn" data-filter="open">Open <span class="filter-count">0</span></button>
-            <button class="toggle-btn" data-filter="resolved">Resolved <span class="filter-count">0</span></button>
+          <div class="comments-filter-toggle crit-toggle-group" id="commentsFilterPill" role="group" aria-label="Filter comments">
+            <button class="crit-toggle-btn crit-toggle-btn--active" data-filter="all">All <span class="filter-count">0</span></button>
+            <button class="crit-toggle-btn" data-filter="open">Open <span class="filter-count">0</span></button>
+            <button class="crit-toggle-btn" data-filter="resolved">Resolved <span class="filter-count">0</span></button>
           </div>
           <button class="comments-panel-expand-all" id="commentsPanelExpandAll">Expand all</button>
         </div>
@@ -4063,12 +4063,12 @@ export const DocumentRenderer = {
     // Segmented pill filter
     const filterPill = commentsPanel.querySelector('#commentsFilterPill')
     filterPill.addEventListener('click', (e) => {
-      const btn = e.target.closest('.toggle-btn')
+      const btn = e.target.closest('.crit-toggle-btn')
       if (!btn) return
       const filter = btn.dataset.filter
       commentsPanel._activeFilter = filter
-      filterPill.querySelectorAll('.toggle-btn').forEach(b => b.classList.remove('active'))
-      btn.classList.add('active')
+      filterPill.querySelectorAll('.crit-toggle-btn').forEach(b => b.classList.remove('crit-toggle-btn--active'))
+      btn.classList.add('crit-toggle-btn--active')
       renderCommentsPanel(ctx)
     })
 

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3266,7 +3266,7 @@ function renderCommentsPanel(ctx) {
   if (badge) badge.textContent = totalCount
 
   // Update pill counts
-  const pillBtns = panel.querySelectorAll('.comments-filter-pill-btn')
+  const pillBtns = panel.querySelectorAll('.toggle-btn')
   pillBtns.forEach(btn => {
     const countEl = btn.querySelector('.filter-count')
     if (!countEl) return
@@ -3275,7 +3275,7 @@ function renderCommentsPanel(ctx) {
     else if (f === 'open') countEl.textContent = openCount
     else if (f === 'resolved') countEl.textContent = resolvedCount
   })
-  updateCommentsFilterIndicator(panel)
+
 
   // Filter function based on active pill
   const visibleFilter = c => {
@@ -3399,19 +3399,7 @@ function createFileGroupHeader(label, count, groupEl) {
   return groupName
 }
 
-function updateCommentsFilterIndicator(panel) {
-  const indicator = panel.querySelector('#commentsFilterIndicator')
-  const pill = panel.querySelector('#commentsFilterPill')
-  if (!indicator || !pill) return
-  const btns = pill.querySelectorAll('.comments-filter-pill-btn')
-  const activeBtn = pill.querySelector('.comments-filter-pill-btn.active')
-  if (!activeBtn) return
-  // Calculate position relative to pill
-  const pillRect = pill.getBoundingClientRect()
-  const btnRect = activeBtn.getBoundingClientRect()
-  indicator.style.left = (btnRect.left - pillRect.left) + 'px'
-  indicator.style.width = btnRect.width + 'px'
-}
+
 
 function updateExpandAllLabel(ctx) {
   const panel = ctx._commentsPanel
@@ -4050,11 +4038,10 @@ export const DocumentRenderer = {
           </div>
         </div>
         <div class="comments-panel-header-row2">
-          <div class="comments-filter-pill" id="commentsFilterPill" role="group" aria-label="Filter comments">
-            <div class="comments-filter-pill-indicator" id="commentsFilterIndicator"></div>
-            <button class="comments-filter-pill-btn active" data-filter="all">All <span class="filter-count">0</span></button>
-            <button class="comments-filter-pill-btn" data-filter="open">Open <span class="filter-count">0</span></button>
-            <button class="comments-filter-pill-btn" data-filter="resolved">Resolved <span class="filter-count">0</span></button>
+          <div class="comments-filter-toggle" id="commentsFilterPill" role="group" aria-label="Filter comments">
+            <button class="toggle-btn active" data-filter="all">All <span class="filter-count">0</span></button>
+            <button class="toggle-btn" data-filter="open">Open <span class="filter-count">0</span></button>
+            <button class="toggle-btn" data-filter="resolved">Resolved <span class="filter-count">0</span></button>
           </div>
           <button class="comments-panel-expand-all" id="commentsPanelExpandAll">Expand all</button>
         </div>
@@ -4076,13 +4063,12 @@ export const DocumentRenderer = {
     // Segmented pill filter
     const filterPill = commentsPanel.querySelector('#commentsFilterPill')
     filterPill.addEventListener('click', (e) => {
-      const btn = e.target.closest('.comments-filter-pill-btn')
+      const btn = e.target.closest('.toggle-btn')
       if (!btn) return
       const filter = btn.dataset.filter
       commentsPanel._activeFilter = filter
-      filterPill.querySelectorAll('.comments-filter-pill-btn').forEach(b => b.classList.remove('active'))
+      filterPill.querySelectorAll('.toggle-btn').forEach(b => b.classList.remove('active'))
       btn.classList.add('active')
-      updateCommentsFilterIndicator(commentsPanel)
       renderCommentsPanel(ctx)
     })
 

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -4038,7 +4038,7 @@ export const DocumentRenderer = {
           </div>
         </div>
         <div class="comments-panel-header-row2">
-          <div class="comments-filter-toggle crit-toggle-group" id="commentsFilterPill" role="group" aria-label="Filter comments">
+          <div class="comments-filter-toggle crit-diff-mode-toggle" id="commentsFilterPill" role="group" aria-label="Filter comments">
             <button class="crit-toggle-btn crit-toggle-btn--active" data-filter="all">All <span class="filter-count">0</span></button>
             <button class="crit-toggle-btn" data-filter="open">Open <span class="filter-count">0</span></button>
             <button class="crit-toggle-btn" data-filter="resolved">Resolved <span class="filter-count">0</span></button>

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3254,7 +3254,7 @@ function renderCommentsPanel(ctx) {
   const savedScroll = body.scrollTop
   body.innerHTML = ''
 
-  const activeFilter = panel._activeFilter || 'all'
+  const activeFilter = ctx._commentsActiveFilter || 'all'
 
   // Compute counts for badge and pill
   const totalCount = ctx.comments.length
@@ -3392,8 +3392,22 @@ function createFileGroupHeader(label, count, groupEl) {
   countEl.textContent = count
   groupName.appendChild(countEl)
 
-  groupName.addEventListener('click', () => {
+  groupName.setAttribute('role', 'button')
+  groupName.setAttribute('tabindex', '0')
+  groupName.setAttribute('aria-expanded', 'true')
+
+  const toggleGroup = () => {
     groupEl.classList.toggle('collapsed')
+    const expanded = !groupEl.classList.contains('collapsed')
+    groupName.setAttribute('aria-expanded', String(expanded))
+  }
+
+  groupName.addEventListener('click', toggleGroup)
+  groupName.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      toggleGroup()
+    }
   })
 
   return groupName
@@ -4039,9 +4053,9 @@ export const DocumentRenderer = {
         </div>
         <div class="comments-panel-header-row2">
           <div class="comments-filter-toggle crit-diff-mode-toggle" id="commentsFilterPill" role="group" aria-label="Filter comments">
-            <button class="crit-toggle-btn crit-toggle-btn--active" data-filter="all">All <span class="filter-count">0</span></button>
-            <button class="crit-toggle-btn" data-filter="open">Open <span class="filter-count">0</span></button>
-            <button class="crit-toggle-btn" data-filter="resolved">Resolved <span class="filter-count">0</span></button>
+            <button class="crit-toggle-btn crit-toggle-btn--active" data-filter="all" aria-pressed="true">All <span class="filter-count">0</span></button>
+            <button class="crit-toggle-btn" data-filter="open" aria-pressed="false">Open <span class="filter-count">0</span></button>
+            <button class="crit-toggle-btn" data-filter="resolved" aria-pressed="false">Resolved <span class="filter-count">0</span></button>
           </div>
           <button class="comments-panel-expand-all" id="commentsPanelExpandAll">Expand all</button>
         </div>
@@ -4049,7 +4063,7 @@ export const DocumentRenderer = {
       <div class="comments-panel-body"></div>
     `
     // Track active filter: 'all', 'open', 'resolved'
-    commentsPanel._activeFilter = 'all'
+    ctx._commentsActiveFilter = 'all'
 
     commentsPanel.querySelector('.comments-panel-add-btn').addEventListener('click', () => {
       openReviewCommentForm(ctx)
@@ -4066,9 +4080,13 @@ export const DocumentRenderer = {
       const btn = e.target.closest('.crit-toggle-btn')
       if (!btn) return
       const filter = btn.dataset.filter
-      commentsPanel._activeFilter = filter
-      filterPill.querySelectorAll('.crit-toggle-btn').forEach(b => b.classList.remove('crit-toggle-btn--active'))
+      ctx._commentsActiveFilter = filter
+      filterPill.querySelectorAll('.crit-toggle-btn').forEach(b => {
+        b.classList.remove('crit-toggle-btn--active')
+        b.setAttribute('aria-pressed', 'false')
+      })
       btn.classList.add('crit-toggle-btn--active')
+      btn.setAttribute('aria-pressed', 'true')
       renderCommentsPanel(ctx)
     })
 

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3254,13 +3254,35 @@ function renderCommentsPanel(ctx) {
   const savedScroll = body.scrollTop
   body.innerHTML = ''
 
-  const showResolvedEl = panel.querySelector('#showResolvedToggle')
-  const showResolved = showResolvedEl ? showResolvedEl.checked : false
+  const activeFilter = panel._activeFilter || 'all'
 
-  // Show/hide filter bar based on whether any resolved comments exist
-  const hasResolved = ctx.comments.some(c => c.resolved)
-  const filterBar = panel.querySelector('.comments-panel-filter')
-  if (filterBar) filterBar.style.display = hasResolved ? '' : 'none'
+  // Compute counts for badge and pill
+  const totalCount = ctx.comments.length
+  const openCount = ctx.comments.filter(c => !c.resolved).length
+  const resolvedCount = ctx.comments.filter(c => c.resolved).length
+
+  // Update count badge
+  const badge = panel.querySelector('#commentsPanelCountBadge')
+  if (badge) badge.textContent = totalCount
+
+  // Update pill counts
+  const pillBtns = panel.querySelectorAll('.comments-filter-pill-btn')
+  pillBtns.forEach(btn => {
+    const countEl = btn.querySelector('.filter-count')
+    if (!countEl) return
+    const f = btn.dataset.filter
+    if (f === 'all') countEl.textContent = totalCount
+    else if (f === 'open') countEl.textContent = openCount
+    else if (f === 'resolved') countEl.textContent = resolvedCount
+  })
+  updateCommentsFilterIndicator(panel)
+
+  // Filter function based on active pill
+  const visibleFilter = c => {
+    if (activeFilter === 'open') return !c.resolved
+    if (activeFilter === 'resolved') return c.resolved
+    return true
+  }
 
   // Review comment form at top
   const reviewForm = ctx.activeForms.find(f => f.scope === 'review')
@@ -3269,12 +3291,20 @@ function renderCommentsPanel(ctx) {
   }
 
   // Separate and filter comments by scope
-  const visibleFilter = c => showResolved ? true : !c.resolved
   const reviewComments = ctx.comments.filter(c => c.scope === 'review').filter(visibleFilter)
   const fileAndLineComments = ctx.comments.filter(c => c.scope !== 'review').filter(visibleFilter)
 
   if (ctx.comments.length === 0 && !reviewForm) {
     body.innerHTML += '<div class="comments-panel-empty">No comments yet</div>'
+    updateExpandAllLabel(ctx)
+    return
+  }
+
+  const filteredTotal = reviewComments.length + fileAndLineComments.length
+  if (filteredTotal === 0 && !reviewForm) {
+    const emptyMsg = activeFilter === 'open' ? 'No open comments' : activeFilter === 'resolved' ? 'No resolved comments' : 'No comments yet'
+    body.innerHTML += '<div class="comments-panel-empty">' + emptyMsg + '</div>'
+    updateExpandAllLabel(ctx)
     return
   }
 
@@ -3283,14 +3313,15 @@ function renderCommentsPanel(ctx) {
     const group = document.createElement('div')
     group.className = 'comments-panel-file-group'
 
-    const groupName = document.createElement('div')
-    groupName.className = 'comments-panel-file-name'
-    groupName.textContent = 'Review'
+    const groupName = createFileGroupHeader('Review', reviewComments.length, group)
     group.appendChild(groupName)
 
+    const cards = document.createElement('div')
+    cards.className = 'comments-panel-file-cards'
     for (const c of reviewComments) {
-      group.appendChild(renderPanelCard(ctx, c, null))
+      cards.appendChild(renderPanelCard(ctx, c, null))
     }
+    group.appendChild(cards)
     body.appendChild(group)
   }
 
@@ -3313,27 +3344,108 @@ function renderCommentsPanel(ctx) {
         const group = document.createElement('div')
         group.className = 'comments-panel-file-group'
 
-        const groupName = document.createElement('div')
-        groupName.className = 'comments-panel-file-name'
-        groupName.textContent = file.path
+        const groupName = createFileGroupHeader(file.path, fileComments.length, group)
         group.appendChild(groupName)
 
+        const cards = document.createElement('div')
+        cards.className = 'comments-panel-file-cards'
         for (const c of fileComments) {
-          group.appendChild(renderPanelCard(ctx, c, file.path))
+          cards.appendChild(renderPanelCard(ctx, c, file.path))
         }
+        group.appendChild(cards)
         body.appendChild(group)
       }
     } else {
       const group = document.createElement('div')
       group.className = 'comments-panel-file-group'
+      const cards = document.createElement('div')
+      cards.className = 'comments-panel-file-cards'
       for (const c of sorted) {
-        group.appendChild(renderPanelCard(ctx, c, null))
+        cards.appendChild(renderPanelCard(ctx, c, null))
       }
+      group.appendChild(cards)
       body.appendChild(group)
     }
   }
 
   body.scrollTop = savedScroll
+  updateExpandAllLabel(ctx)
+}
+
+function createFileGroupHeader(label, count, groupEl) {
+  const groupName = document.createElement('div')
+  groupName.className = 'comments-panel-file-name'
+
+  const chevron = document.createElement('span')
+  chevron.className = 'comments-panel-file-chevron'
+  chevron.textContent = '\u25BC'
+  groupName.appendChild(chevron)
+
+  const nameText = document.createElement('span')
+  nameText.className = 'comments-panel-file-name-text'
+  nameText.textContent = label
+  nameText.title = label
+  groupName.appendChild(nameText)
+
+  const countEl = document.createElement('span')
+  countEl.className = 'comments-panel-file-count'
+  countEl.textContent = count
+  groupName.appendChild(countEl)
+
+  groupName.addEventListener('click', () => {
+    groupEl.classList.toggle('collapsed')
+  })
+
+  return groupName
+}
+
+function updateCommentsFilterIndicator(panel) {
+  const indicator = panel.querySelector('#commentsFilterIndicator')
+  const pill = panel.querySelector('#commentsFilterPill')
+  if (!indicator || !pill) return
+  const btns = pill.querySelectorAll('.comments-filter-pill-btn')
+  const activeBtn = pill.querySelector('.comments-filter-pill-btn.active')
+  if (!activeBtn) return
+  // Calculate position relative to pill
+  const pillRect = pill.getBoundingClientRect()
+  const btnRect = activeBtn.getBoundingClientRect()
+  indicator.style.left = (btnRect.left - pillRect.left) + 'px'
+  indicator.style.width = btnRect.width + 'px'
+}
+
+function updateExpandAllLabel(ctx) {
+  const panel = ctx._commentsPanel
+  if (!panel) return
+  const btn = panel.querySelector('#commentsPanelExpandAll')
+  if (!btn) return
+  // Check if any visible card is expanded (not collapsed)
+  const panelCards = panel.querySelectorAll('.comment-card')
+  const inlineCards = document.querySelectorAll('.comment-block:not(.panel-comment-block) .comment-card')
+  const allCards = [...panelCards, ...inlineCards]
+  const anyExpanded = allCards.some(c => !c.classList.contains('collapsed'))
+  btn.textContent = anyExpanded ? 'Collapse all' : 'Expand all'
+}
+
+function toggleExpandAllComments(ctx) {
+  const panel = ctx._commentsPanel
+  if (!panel) return
+  const panelCards = panel.querySelectorAll('.comment-card')
+  const inlineCards = document.querySelectorAll('.comment-block:not(.panel-comment-block) .comment-card')
+  const allCards = [...panelCards, ...inlineCards]
+  const anyExpanded = allCards.some(c => !c.classList.contains('collapsed'))
+
+  allCards.forEach(card => {
+    if (anyExpanded) {
+      card.classList.add('collapsed')
+    } else {
+      card.classList.remove('collapsed')
+    }
+    // Sync override state
+    const id = card.dataset.commentId
+    if (id) commentCollapseOverrides[id] = anyExpanded
+  })
+
+  updateExpandAllLabel(ctx)
 }
 
 function renderPanelCard(ctx, comment, filePath) {
@@ -3927,21 +4039,31 @@ export const DocumentRenderer = {
     commentsPanel.className = 'comments-panel'
     commentsPanel.innerHTML = `
       <div class="comments-panel-header">
-        <span>Comments</span>
-        <div class="comments-panel-header-actions">
-          <button class="comments-panel-add-btn" title="Add a general comment (Shift+G)">+ Add</button>
-          <button class="comments-panel-close" title="Close comments panel" aria-label="Close comments panel">&#x2715;</button>
+        <div class="comments-panel-header-row1">
+          <div class="comments-panel-header-left">
+            <span class="comments-panel-title">Comments</span>
+            <span class="comments-panel-count-badge" id="commentsPanelCountBadge">0</span>
+          </div>
+          <div class="comments-panel-header-actions">
+            <button class="comments-panel-add-btn" title="Add a general comment (Shift+G)">+ Add</button>
+            <button class="comments-panel-close" title="Close comments panel" aria-label="Close comments panel">&#x2715;</button>
+          </div>
         </div>
-      </div>
-      <div class="comments-panel-filter" style="display:none">
-        <label class="comments-panel-switch">
-          <input type="checkbox" id="showResolvedToggle">
-          <span class="comments-panel-switch-track"><span class="comments-panel-switch-thumb"></span></span>
-          <span class="comments-panel-switch-text">Show resolved</span>
-        </label>
+        <div class="comments-panel-header-row2">
+          <div class="comments-filter-pill" id="commentsFilterPill" role="group" aria-label="Filter comments">
+            <div class="comments-filter-pill-indicator" id="commentsFilterIndicator"></div>
+            <button class="comments-filter-pill-btn active" data-filter="all">All <span class="filter-count">0</span></button>
+            <button class="comments-filter-pill-btn" data-filter="open">Open <span class="filter-count">0</span></button>
+            <button class="comments-filter-pill-btn" data-filter="resolved">Resolved <span class="filter-count">0</span></button>
+          </div>
+          <button class="comments-panel-expand-all" id="commentsPanelExpandAll">Expand all</button>
+        </div>
       </div>
       <div class="comments-panel-body"></div>
     `
+    // Track active filter: 'all', 'open', 'resolved'
+    commentsPanel._activeFilter = 'all'
+
     commentsPanel.querySelector('.comments-panel-add-btn').addEventListener('click', () => {
       openReviewCommentForm(ctx)
     })
@@ -3950,8 +4072,23 @@ export const DocumentRenderer = {
       syncCommentsPanelAria(false)
       updateTocPosition(ctx)
     })
-    commentsPanel.querySelector('#showResolvedToggle').addEventListener('change', () => {
+
+    // Segmented pill filter
+    const filterPill = commentsPanel.querySelector('#commentsFilterPill')
+    filterPill.addEventListener('click', (e) => {
+      const btn = e.target.closest('.comments-filter-pill-btn')
+      if (!btn) return
+      const filter = btn.dataset.filter
+      commentsPanel._activeFilter = filter
+      filterPill.querySelectorAll('.comments-filter-pill-btn').forEach(b => b.classList.remove('active'))
+      btn.classList.add('active')
+      updateCommentsFilterIndicator(commentsPanel)
       renderCommentsPanel(ctx)
+    })
+
+    // Expand all / Collapse all
+    commentsPanel.querySelector('#commentsPanelExpandAll').addEventListener('click', () => {
+      toggleExpandAllComments(ctx)
     })
     const mainLayout = document.getElementById('crit-main-layout')
     mainLayout.appendChild(commentsPanel)

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -409,7 +409,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -471,7 +470,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -872,7 +870,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -409,6 +409,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -470,6 +471,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -870,6 +872,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }

--- a/e2e/comments-panel-detail.spec.ts
+++ b/e2e/comments-panel-detail.spec.ts
@@ -142,12 +142,10 @@ test.describe("Comments Panel — Detail", () => {
     const panel = page.locator(".comments-panel");
     await expect(panel).toHaveClass(/comments-panel-open/, { timeout: 5_000 });
 
-    // The "Show resolved" toggle label should become visible now
-    const filterLabel = panel.locator(".comments-panel-switch");
-    await expect(filterLabel).toBeVisible({ timeout: 5_000 });
-
-    // Click the label to toggle the checkbox (checkbox itself is visually hidden)
-    await filterLabel.click();
+    // Click the "Resolved" filter button to show only resolved comments
+    const resolvedBtn = panel.locator('.crit-toggle-btn[data-filter="resolved"]');
+    await expect(resolvedBtn).toBeVisible({ timeout: 5_000 });
+    await resolvedBtn.click();
 
     // Panel should now contain the resolved comment
     await expect(panel).toContainText("Will be resolved for panel", { timeout: 5_000 });

--- a/e2e/comments-panel-redesign.spec.ts
+++ b/e2e/comments-panel-redesign.spec.ts
@@ -1,0 +1,275 @@
+import { test, expect } from "@playwright/test";
+import {
+  createReview,
+  deleteReview,
+  loadReview,
+  seedComment,
+  waitForCommentCard,
+  addCommentViaUI,
+} from "./helpers";
+
+/**
+ * Tests for the redesigned comments panel:
+ * - Two-row header with count badge
+ * - Segmented filter pill (All / Open / Resolved)
+ * - Collapsible file groups
+ * - Expand all / Collapse all toggle
+ */
+test.describe("Comments Panel — Redesigned Header & Filters", () => {
+  let token: string;
+  let deleteToken: string;
+
+  test.beforeEach(async ({ request }) => {
+    const review = await createReview(request, {
+      files: [
+        {
+          path: "main.ts",
+          content:
+            "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10\n",
+        },
+      ],
+    });
+    token = review.token;
+    deleteToken = review.deleteToken;
+  });
+
+  test.afterEach(async ({ request }) => {
+    await deleteReview(request, deleteToken);
+  });
+
+  /**
+   * Helper: open the comments panel and return the panel locator.
+   */
+  async function openPanel(page: import("@playwright/test").Page) {
+    await page.locator("#comment-count").click();
+    const panel = page.locator(".comments-panel");
+    await expect(panel).toHaveClass(/comments-panel-open/, { timeout: 5_000 });
+    return panel;
+  }
+
+  test("panel header shows correct count badge", async ({
+    page,
+    request,
+  }) => {
+    await seedComment(request, token, { body: "Comment A", startLine: 1 });
+    await seedComment(request, token, { body: "Comment B", startLine: 3 });
+    await seedComment(request, token, { body: "Comment C", startLine: 5 });
+
+    await loadReview(page, token);
+    await waitForCommentCard(page, "Comment A");
+
+    const panel = await openPanel(page);
+
+    // Count badge should show total of 3
+    const badge = panel.locator("#commentsPanelCountBadge");
+    await expect(badge).toHaveText("3");
+  });
+
+  test("segmented filter defaults to All with all comments shown", async ({
+    page,
+    request,
+  }) => {
+    await seedComment(request, token, { body: "Open comment", startLine: 1 });
+    await seedComment(request, token, { body: "Another open", startLine: 3 });
+
+    await loadReview(page, token);
+    await waitForCommentCard(page, "Open comment");
+
+    const panel = await openPanel(page);
+
+    // "All" button should be active by default
+    const allBtn = panel.locator('.crit-toggle-btn[data-filter="all"]');
+    await expect(allBtn).toHaveClass(/crit-toggle-btn--active/);
+
+    // Both comments should be visible in the panel
+    await expect(panel).toContainText("Open comment");
+    await expect(panel).toContainText("Another open");
+  });
+
+  test("segmented filter Open shows only unresolved comments", async ({
+    page,
+  }) => {
+    await loadReview(page, token);
+
+    // Add two comments via UI so we can resolve one
+    await addCommentViaUI(page, "Will stay open", { lineIndex: 0 });
+    await addCommentViaUI(page, "Will be resolved", { lineIndex: 4 });
+
+    // Resolve the second comment
+    const resolvedCard = page
+      .locator(".comment-card")
+      .filter({ hasText: "Will be resolved" });
+    await resolvedCard.locator(".resolve-btn").click();
+    await expect(resolvedCard).toHaveClass(/resolved-card/, { timeout: 5_000 });
+
+    const panel = await openPanel(page);
+
+    // Click "Open" filter
+    const openBtn = panel.locator('.crit-toggle-btn[data-filter="open"]');
+    await openBtn.click();
+    await expect(openBtn).toHaveClass(/crit-toggle-btn--active/);
+
+    // Only the open comment should be visible
+    await expect(panel).toContainText("Will stay open");
+    await expect(
+      panel.locator(".panel-comment-block").filter({ hasText: "Will be resolved" })
+    ).not.toBeVisible();
+  });
+
+  test("segmented filter Resolved shows only resolved comments", async ({
+    page,
+  }) => {
+    await loadReview(page, token);
+
+    await addCommentViaUI(page, "Stays open", { lineIndex: 0 });
+    await addCommentViaUI(page, "Gets resolved", { lineIndex: 4 });
+
+    // Resolve the second comment
+    const card = page
+      .locator(".comment-card")
+      .filter({ hasText: "Gets resolved" });
+    await card.locator(".resolve-btn").click();
+    await expect(card).toHaveClass(/resolved-card/, { timeout: 5_000 });
+
+    const panel = await openPanel(page);
+
+    // Click "Resolved" filter
+    const resolvedBtn = panel.locator('.crit-toggle-btn[data-filter="resolved"]');
+    await resolvedBtn.click();
+    await expect(resolvedBtn).toHaveClass(/crit-toggle-btn--active/);
+
+    // Only the resolved comment should be visible
+    await expect(panel).toContainText("Gets resolved");
+    await expect(
+      panel.locator(".panel-comment-block").filter({ hasText: "Stays open" })
+    ).not.toBeVisible();
+  });
+
+  test("filter pill counts match actual comment counts", async ({
+    page,
+  }) => {
+    await loadReview(page, token);
+
+    // Create 3 comments, resolve 1
+    await addCommentViaUI(page, "Open one", { lineIndex: 0 });
+    await addCommentViaUI(page, "Open two", { lineIndex: 2 });
+    await addCommentViaUI(page, "To resolve", { lineIndex: 4 });
+
+    const card = page
+      .locator(".comment-card")
+      .filter({ hasText: "To resolve" });
+    await card.locator(".resolve-btn").click();
+    await expect(card).toHaveClass(/resolved-card/, { timeout: 5_000 });
+
+    const panel = await openPanel(page);
+
+    // All = 3, Open = 2, Resolved = 1
+    const allCount = panel.locator('.crit-toggle-btn[data-filter="all"] .filter-count');
+    const openCount = panel.locator('.crit-toggle-btn[data-filter="open"] .filter-count');
+    const resolvedCount = panel.locator('.crit-toggle-btn[data-filter="resolved"] .filter-count');
+
+    await expect(allCount).toHaveText("3");
+    await expect(openCount).toHaveText("2");
+    await expect(resolvedCount).toHaveText("1");
+  });
+
+  test("collapsible file groups toggle on click", async ({
+    page,
+    request,
+  }) => {
+    await seedComment(request, token, { body: "File comment", startLine: 1 });
+
+    await loadReview(page, token);
+    await waitForCommentCard(page, "File comment");
+
+    const panel = await openPanel(page);
+
+    // Find the file group
+    const fileGroup = panel.locator(".comments-panel-file-group").first();
+    const fileCards = fileGroup.locator(".comments-panel-file-cards");
+
+    // Initially expanded — cards should be visible
+    await expect(fileCards).toBeVisible();
+
+    // Click the file group header to collapse
+    const fileHeader = fileGroup.locator(".comments-panel-file-name");
+    await fileHeader.click();
+
+    // Group should now have collapsed class
+    await expect(fileGroup).toHaveClass(/collapsed/);
+
+    // Click again to expand
+    await fileHeader.click();
+    await expect(fileGroup).not.toHaveClass(/collapsed/);
+  });
+
+  test("Expand all / Collapse all toggles all comment cards", async ({
+    page,
+    request,
+  }) => {
+    await seedComment(request, token, { body: "Card one", startLine: 1 });
+    await seedComment(request, token, { body: "Card two", startLine: 3 });
+
+    await loadReview(page, token);
+    await waitForCommentCard(page, "Card one");
+
+    const panel = await openPanel(page);
+
+    const expandAllBtn = panel.locator("#commentsPanelExpandAll");
+
+    // Initially cards are expanded, so button should say "Collapse all"
+    await expect(expandAllBtn).toHaveText("Collapse all");
+
+    // Click to collapse all
+    await expandAllBtn.click();
+
+    // All panel comment cards should have the collapsed class
+    const panelCards = panel.locator(".comment-card");
+    const count = await panelCards.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+    for (let i = 0; i < count; i++) {
+      await expect(panelCards.nth(i)).toHaveClass(/collapsed/);
+    }
+
+    // Button label should now say "Expand all"
+    await expect(expandAllBtn).toHaveText("Expand all");
+
+    // Click to expand all again
+    await expandAllBtn.click();
+
+    for (let i = 0; i < count; i++) {
+      await expect(panelCards.nth(i)).not.toHaveClass(/collapsed/);
+    }
+    await expect(expandAllBtn).toHaveText("Collapse all");
+  });
+
+  test("Collapse all also collapses inline comments in the document body", async ({
+    page,
+    request,
+  }) => {
+    await seedComment(request, token, { body: "Inline collapse test", startLine: 1 });
+
+    await loadReview(page, token);
+    await waitForCommentCard(page, "Inline collapse test");
+
+    const panel = await openPanel(page);
+
+    // Verify inline comment card in document is initially not collapsed
+    const inlineCard = page
+      .locator("#document-renderer .comment-card")
+      .filter({ hasText: "Inline collapse test" });
+    await expect(inlineCard).toBeVisible();
+    await expect(inlineCard).not.toHaveClass(/collapsed/);
+
+    // Click Collapse all in the panel
+    const expandAllBtn = panel.locator("#commentsPanelExpandAll");
+    await expandAllBtn.click();
+
+    // Inline comment card should now be collapsed
+    await expect(inlineCard).toHaveClass(/collapsed/);
+
+    // Click Expand all to restore
+    await expandAllBtn.click();
+    await expect(inlineCard).not.toHaveClass(/collapsed/);
+  });
+});

--- a/e2e/comments-panel-redesign.spec.ts
+++ b/e2e/comments-panel-redesign.spec.ts
@@ -177,9 +177,18 @@ test.describe("Comments Panel — Redesigned Header & Filters", () => {
     page,
     request,
   }) => {
-    await seedComment(request, token, { body: "File comment", startLine: 1 });
+    // Create a multi-file review so file group headers are rendered
+    const multiFileReview = await createReview(request, {
+      files: [
+        { path: "alpha.ts", content: "Line 1\nLine 2\nLine 3\n" },
+        { path: "beta.ts", content: "Line 1\nLine 2\nLine 3\n" },
+      ],
+    });
+    const mfToken = multiFileReview.token;
 
-    await loadReview(page, token);
+    await seedComment(request, mfToken, { body: "File comment", startLine: 1, file: "alpha.ts" });
+
+    await loadReview(page, mfToken);
     await waitForCommentCard(page, "File comment");
 
     const panel = await openPanel(page);
@@ -201,6 +210,9 @@ test.describe("Comments Panel — Redesigned Header & Filters", () => {
     // Click again to expand
     await fileHeader.click();
     await expect(fileGroup).not.toHaveClass(/collapsed/);
+
+    // Clean up the multi-file review
+    await deleteReview(request, multiFileReview.deleteToken);
   });
 
   test("Expand all / Collapse all toggles all comment cards", async ({


### PR DESCRIPTION
## Summary

- **Two-row header layout**: Comments title with count badge, Add button, and close button on row 1; segmented filter and expand/collapse toggle on row 2
- **Segmented filter (All/Open/Resolved)**: Replaces the old "Show resolved" toggle, using the `.crit-toggle-btn` pattern consistent with the diff mode toggle
- **Collapsible file groups**: Each file section has a chevron and comment count, clickable to collapse/expand
- **Expand all / Collapse all toggle**: Works for both panel and inline comments

## Changed files

- `assets/css/app.css` — Panel header layout, segmented filter styles, collapsible group styles
- `assets/js/document-renderer.js` — Filter logic, collapsible group behavior, expand/collapse all toggle
- `assets/package-lock.json` — Minor lockfile cleanup

## Test plan

- [x] `mix test` passes (427 tests, 0 failures)
- [ ] Verify panel opens with two-row header and count badge
- [ ] Verify All/Open/Resolved filter segments work correctly
- [ ] Verify file groups collapse/expand with chevron click
- [ ] Verify Expand all / Collapse all toggle works for panel and inline comments
- [ ] Verify comment card styling is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)