### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
           otp-version: "28"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload test artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: |


### PR DESCRIPTION
## Summary
- Bump remaining GitHub Actions to latest major versions to resolve Node.js 20 deprecation warnings

### Action updates
| Action | Was | Now |
|--------|-----|-----|
| `actions/setup-node` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |

## Test plan
- CI will validate the updated actions work correctly on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)