### PR TITLE
feat: add keep_reviews setting to prevent auto-deletion

### DIFF
--- a/lib/crit/accounts.ex
+++ b/lib/crit/accounts.ex
@@ -133,6 +133,16 @@ defmodule Crit.Accounts do
   end
 
   @doc """
+  Updates the keep_reviews setting for a user.
+  Returns `{:ok, user}` or `{:error, changeset}`.
+  """
+  def update_keep_reviews(%User{} = user, keep_reviews) when is_boolean(keep_reviews) do
+    user
+    |> Ecto.Changeset.change(keep_reviews: keep_reviews)
+    |> Repo.update()
+  end
+
+  @doc """
   Deletes a user account. PostgreSQL cascade handles:
   - API tokens (deleted)
   - Device codes (deleted)

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -2,7 +2,7 @@ defmodule Crit.Reviews do
   @moduledoc "Context for reviews and comments."
 
   import Ecto.Query
-  alias Crit.{Repo, Review, Comment, ReviewRoundSnapshot, Statistics}
+  alias Crit.{Repo, Review, Comment, ReviewRoundSnapshot, Statistics, User}
 
   @max_total_size 10_485_760
 
@@ -446,7 +446,14 @@ defmodule Crit.Reviews do
   """
   def delete_inactive(days) when is_integer(days) and days > 0 do
     cutoff = DateTime.add(DateTime.utc_now(), -days, :day)
-    base = from r in Review, where: r.last_activity_at < ^cutoff
+
+    kept_user_ids =
+      from(u in User, where: u.keep_reviews == true, select: u.id)
+
+    base =
+      from r in Review,
+        where: r.last_activity_at < ^cutoff,
+        where: r.user_id not in subquery(kept_user_ids) or is_nil(r.user_id)
 
     query =
       case Application.get_env(:crit, :demo_review_token) do

--- a/lib/crit/user.ex
+++ b/lib/crit/user.ex
@@ -7,6 +7,7 @@ defmodule Crit.User do
     field :email, :string
     field :name, :string
     field :avatar_url, :string
+    field :keep_reviews, :boolean, default: false
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/crit_web/live/settings_live.ex
+++ b/lib/crit_web/live/settings_live.ex
@@ -17,9 +17,27 @@ defmodule CritWeb.SettingsLive do
       |> assign(:new_token_plaintext, nil)
       |> assign(:new_token_name, "")
       |> assign(:delete_confirmation, "")
+      |> assign(:keep_reviews, user.keep_reviews)
       |> assign(:selfhosted, Application.get_env(:crit, :selfhosted) == true)
 
     {:ok, socket, layout: false}
+  end
+
+  @impl true
+  def handle_event("toggle_keep_reviews", _params, socket) do
+    user = socket.assigns.current_user
+    new_value = !socket.assigns.keep_reviews
+
+    case Accounts.update_keep_reviews(user, new_value) do
+      {:ok, updated_user} ->
+        {:noreply,
+         socket
+         |> assign(:keep_reviews, new_value)
+         |> assign(:current_user, updated_user)}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Failed to update setting.")}
+    end
   end
 
   @impl true

--- a/lib/crit_web/live/settings_live.html.heex
+++ b/lib/crit_web/live/settings_live.html.heex
@@ -25,6 +25,14 @@
           </li>
           <li>
             <a
+              href="#reviews"
+              class="block px-3 py-2 text-sm rounded-md text-(--crit-fg-muted) hover:text-(--crit-fg-primary) hover:bg-(--crit-bg-card) transition-colors max-md:rounded-none"
+            >
+              Reviews
+            </a>
+          </li>
+          <li>
+            <a
               href="#tokens"
               class="block px-3 py-2 text-sm rounded-md text-(--crit-fg-muted) hover:text-(--crit-fg-primary) hover:bg-(--crit-bg-card) transition-colors max-md:rounded-none"
             >
@@ -70,6 +78,41 @@
                 </div>
               </div>
             </div>
+          </div>
+        </section>
+
+        <%!-- Reviews section --%>
+        <section :if={!@selfhosted} id="reviews" class="mb-12">
+          <h2 class="text-lg font-semibold text-(--crit-fg-primary) pb-3 border-b border-(--crit-border) mb-6">
+            Reviews
+          </h2>
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <div class="text-sm font-medium text-(--crit-fg-primary)">
+                Keep reviews
+              </div>
+              <div class="text-xs text-(--crit-fg-muted) mt-1">
+                Prevent your reviews from being automatically deleted after 30 days of inactivity.
+              </div>
+            </div>
+            <button
+              id="keep-reviews-toggle"
+              phx-click="toggle_keep_reviews"
+              role="switch"
+              aria-checked={to_string(@keep_reviews)}
+              class={[
+                "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none",
+                if(@keep_reviews,
+                  do: "bg-(--crit-brand)",
+                  else: "bg-(--crit-border)"
+                )
+              ]}
+            >
+              <span class={[
+                "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform transition duration-200 ease-in-out",
+                if(@keep_reviews, do: "translate-x-5", else: "translate-x-0")
+              ]} />
+            </button>
           </div>
         </section>
 

--- a/priv/repo/migrations/20260425090501_add_keep_reviews_to_users.exs
+++ b/priv/repo/migrations/20260425090501_add_keep_reviews_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Crit.Repo.Migrations.AddKeepReviewsToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :keep_reviews, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/crit/reviews_inactive_test.exs
+++ b/test/crit/reviews_inactive_test.exs
@@ -4,7 +4,7 @@ defmodule Crit.ReviewsInactiveTest do
   import Ecto.Query
   import Crit.ReviewsFixtures
 
-  alias Crit.{Reviews, Review, Comment, Repo}
+  alias Crit.{Accounts, Reviews, Review, Comment, Repo}
 
   defp set_last_activity(review, days_ago) do
     old_time = DateTime.add(DateTime.utc_now(), -days_ago, :day)
@@ -88,6 +88,52 @@ defmodule Crit.ReviewsInactiveTest do
       assert {:ok, 1} = Reviews.delete_inactive(30)
       assert Repo.get(Review, demo.id)
       assert is_nil(Repo.get(Review, other.id))
+    end
+
+    test "does not delete reviews owned by users with keep_reviews enabled" do
+      {:ok, user} =
+        Accounts.find_or_create_from_oauth("github", %{
+          "sub" => "keep_#{System.unique_integer()}",
+          "name" => "Keeper"
+        })
+
+      {:ok, user} = Accounts.update_keep_reviews(user, true)
+
+      review = review_fixture(%{user_id: user.id})
+      set_last_activity(review, 31)
+
+      assert {:ok, 0} = Reviews.delete_inactive(30)
+      assert Repo.get(Review, review.id)
+    end
+
+    test "deletes stale reviews from users without keep_reviews" do
+      {:ok, user} =
+        Accounts.find_or_create_from_oauth("github", %{
+          "sub" => "nokeep_#{System.unique_integer()}",
+          "name" => "No Keep"
+        })
+
+      review = review_fixture(%{user_id: user.id})
+      set_last_activity(review, 31)
+
+      assert {:ok, 1} = Reviews.delete_inactive(30)
+      assert is_nil(Repo.get(Review, review.id))
+    end
+
+    test "deletes anonymous stale reviews even when keep_reviews users exist" do
+      {:ok, user} =
+        Accounts.find_or_create_from_oauth("github", %{
+          "sub" => "keeper2_#{System.unique_integer()}",
+          "name" => "Keeper"
+        })
+
+      {:ok, _user} = Accounts.update_keep_reviews(user, true)
+
+      anon_review = review_fixture()
+      set_last_activity(anon_review, 31)
+
+      assert {:ok, 1} = Reviews.delete_inactive(30)
+      assert is_nil(Repo.get(Review, anon_review.id))
     end
   end
 end

--- a/test/crit_web/live/settings_live_test.exs
+++ b/test/crit_web/live/settings_live_test.exs
@@ -216,6 +216,61 @@ defmodule CritWeb.SettingsLiveTest do
     end
   end
 
+  describe "keep reviews toggle" do
+    test "shows toggle in off state by default", %{conn: conn} do
+      {conn, _user} = login_user(conn)
+
+      {:ok, view, _html} = live(conn, ~p"/settings")
+
+      assert has_element?(view, "#keep-reviews-toggle[aria-checked='false']")
+    end
+
+    test "toggling updates the setting", %{conn: conn} do
+      {conn, user} = login_user(conn)
+
+      {:ok, view, _html} = live(conn, ~p"/settings")
+
+      view
+      |> element("#keep-reviews-toggle")
+      |> render_click()
+
+      assert has_element?(view, "#keep-reviews-toggle[aria-checked='true']")
+
+      {:ok, updated} = Crit.Accounts.get_user(user.id)
+      assert updated.keep_reviews == true
+    end
+
+    test "toggling off after on", %{conn: conn} do
+      {conn, user} = login_user(conn)
+      {:ok, _} = Crit.Accounts.update_keep_reviews(user, true)
+
+      {:ok, view, _html} = live(conn, ~p"/settings")
+
+      assert has_element?(view, "#keep-reviews-toggle[aria-checked='true']")
+
+      view
+      |> element("#keep-reviews-toggle")
+      |> render_click()
+
+      assert has_element?(view, "#keep-reviews-toggle[aria-checked='false']")
+
+      {:ok, updated} = Crit.Accounts.get_user(user.id)
+      assert updated.keep_reviews == false
+    end
+
+    test "is hidden in selfhosted mode", %{conn: conn} do
+      Application.put_env(:crit, :selfhosted, true)
+      on_exit(fn -> Application.delete_env(:crit, :selfhosted) end)
+
+      {conn, _user} = login_user(conn)
+
+      {:ok, view, html} = live(conn, ~p"/settings")
+
+      refute has_element?(view, "#keep-reviews-toggle")
+      refute html =~ "Keep reviews"
+    end
+  end
+
   describe "settings page title" do
     test "page title is Settings - Crit", %{conn: conn} do
       {conn, _user} = login_user(conn)


### PR DESCRIPTION
## Summary

- Adds a `keep_reviews` boolean column to the users table (default: `false`)
- Users can toggle this in Settings to prevent their reviews from being auto-deleted after 30 days of inactivity
- The cleanup query in `delete_inactive/1` now excludes reviews owned by users with `keep_reviews` enabled
- Anonymous reviews (no user) are still cleaned up normally
- Setting is hidden on self-hosted instances (where `ReviewCleaner` already short-circuits and reviews are never auto-deleted)

## Test plan

- [x] Toggle on/off in settings UI updates DB correctly
- [x] Stale reviews from kept users survive `delete_inactive`
- [x] Stale reviews from non-kept users are still deleted
- [x] Anonymous stale reviews are still deleted
- [x] Toggle is hidden in selfhosted mode
- [x] Full test suite passes
- [x] `mix precommit` passes (format, compile, sobelow, audit, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)