### PR TITLE
refactor: redesign dashboard header with identity popover and self-hosted indicator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,9 @@ Elixir 1.19 / OTP 28 / PostgreSQL 17.
 - `phx-hook="MyHook"` requires a unique `id` and `phx-update="ignore"` if the hook manages its own DOM
 - Never write raw `<script>` tags — use colocated hooks (`:type={Phoenix.LiveView.ColocatedHook}`, name starts with `.`) or external hooks in `assets/js/`
 - Use `push_event/3` server→client, `this.pushEvent` client→server
+- For UI toggles (popovers, dropdowns, mobile drawers, tabs), prefer `Phoenix.LiveView.JS` commands declaratively in the template — `JS.toggle_attribute({"hidden", "hidden"}, to: "#el")`, `JS.toggle_attribute({"aria-expanded", "true", "false"})`, `JS.toggle/1`. Pipe them together for multi-step toggles
+- For behaviors `JS` can't express (click-outside, Escape close, focus traps), use a colocated hook scoped to the element. Hooks have lifecycle (`mounted`/`destroyed`) so listeners clean up on unmount
+- **Never** attach listeners via `document.getElementById("x").addEventListener(...)` in `app.js` for elements rendered inside LiveView templates — they break across client-side patches (`<.link navigate={...}>`) because the new DOM node isn't the one you bound to. Either use `JS` commands, a hook, or document-level event delegation if you really need vanilla JS
 
 ### LiveView tests
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -130,6 +130,17 @@
   --crit-badge-removed-color: var(--crit-editor-fg-muted);
   --crit-badge-removed-border: color-mix(in srgb, var(--crit-editor-fg-muted) 20%, transparent);
 
+  /* ---- Dashboard header / popover ---- */
+  --crit-popover-bg: #1c1e29;
+  --crit-popover-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.4),
+    0 12px 32px -8px rgba(0, 0, 0, 0.6),
+    0 4px 12px -4px rgba(0, 0, 0, 0.5);
+  --crit-row-hover: rgba(255, 255, 255, 0.04);
+  --crit-workspace-tag-bg: rgba(122, 162, 247, 0.12);
+  --crit-workspace-tag-fg: #b6c8f5;
+  --crit-focus-ring: rgba(122, 162, 247, 0.45);
+
   /* ---- Editor palette (Tokyo Night) ---- */
   --crit-editor-bg:              #1a1b26;
   --crit-editor-bg-card:         #16171f;
@@ -244,6 +255,17 @@
   --crit-badge-removed-color: var(--crit-editor-fg-muted);
   --crit-badge-removed-border: color-mix(in srgb, var(--crit-editor-fg-muted) 20%, transparent);
 
+  /* ---- Dashboard header / popover ---- */
+  --crit-popover-bg: #1c1e29;
+  --crit-popover-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.4),
+    0 12px 32px -8px rgba(0, 0, 0, 0.6),
+    0 4px 12px -4px rgba(0, 0, 0, 0.5);
+  --crit-row-hover: rgba(255, 255, 255, 0.04);
+  --crit-workspace-tag-bg: rgba(122, 162, 247, 0.12);
+  --crit-workspace-tag-fg: #b6c8f5;
+  --crit-focus-ring: rgba(122, 162, 247, 0.45);
+
   /* ---- Editor palette (Tokyo Night) ---- */
   --crit-editor-bg:              #1a1b26;
   --crit-editor-bg-card:         #16171f;
@@ -352,6 +374,17 @@
   --crit-badge-removed-bg: rgba(100, 100, 100, 0.08);
   --crit-badge-removed-color: var(--crit-editor-fg-muted);
   --crit-badge-removed-border: color-mix(in srgb, var(--crit-editor-fg-muted) 15%, transparent);
+
+  /* ---- Dashboard header / popover ---- */
+  --crit-popover-bg: #ffffff;
+  --crit-popover-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.04),
+    0 12px 32px -8px rgba(15, 23, 42, 0.18),
+    0 4px 12px -4px rgba(15, 23, 42, 0.08);
+  --crit-row-hover: rgba(15, 23, 42, 0.05);
+  --crit-workspace-tag-bg: rgba(58, 114, 212, 0.1);
+  --crit-workspace-tag-fg: #2960bc;
+  --crit-focus-ring: rgba(58, 114, 212, 0.35);
 
   /* ---- Editor palette (light) ---- */
   --crit-editor-bg:              #fafafa;
@@ -463,6 +496,17 @@
     --crit-badge-removed-bg: rgba(100, 100, 100, 0.08);
     --crit-badge-removed-color: var(--crit-editor-fg-muted);
     --crit-badge-removed-border: color-mix(in srgb, var(--crit-editor-fg-muted) 15%, transparent);
+
+    /* ---- Dashboard header / popover ---- */
+    --crit-popover-bg: #ffffff;
+    --crit-popover-shadow:
+      0 0 0 1px rgba(15, 23, 42, 0.04),
+      0 12px 32px -8px rgba(15, 23, 42, 0.18),
+      0 4px 12px -4px rgba(15, 23, 42, 0.08);
+    --crit-row-hover: rgba(15, 23, 42, 0.05);
+    --crit-workspace-tag-bg: rgba(58, 114, 212, 0.1);
+    --crit-workspace-tag-fg: #2960bc;
+    --crit-focus-ring: rgba(58, 114, 212, 0.35);
 
     /* ---- Editor palette (light) ---- */
     --crit-editor-bg:              #fafafa;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -137,8 +137,6 @@
     0 12px 32px -8px rgba(0, 0, 0, 0.6),
     0 4px 12px -4px rgba(0, 0, 0, 0.5);
   --crit-row-hover: rgba(255, 255, 255, 0.04);
-  --crit-workspace-tag-bg: rgba(122, 162, 247, 0.12);
-  --crit-workspace-tag-fg: #b6c8f5;
   --crit-focus-ring: rgba(122, 162, 247, 0.45);
 
   /* ---- Editor palette (Tokyo Night) ---- */
@@ -262,8 +260,6 @@
     0 12px 32px -8px rgba(0, 0, 0, 0.6),
     0 4px 12px -4px rgba(0, 0, 0, 0.5);
   --crit-row-hover: rgba(255, 255, 255, 0.04);
-  --crit-workspace-tag-bg: rgba(122, 162, 247, 0.12);
-  --crit-workspace-tag-fg: #b6c8f5;
   --crit-focus-ring: rgba(122, 162, 247, 0.45);
 
   /* ---- Editor palette (Tokyo Night) ---- */
@@ -382,8 +378,6 @@
     0 12px 32px -8px rgba(15, 23, 42, 0.18),
     0 4px 12px -4px rgba(15, 23, 42, 0.08);
   --crit-row-hover: rgba(15, 23, 42, 0.05);
-  --crit-workspace-tag-bg: rgba(58, 114, 212, 0.1);
-  --crit-workspace-tag-fg: #2960bc;
   --crit-focus-ring: rgba(58, 114, 212, 0.35);
 
   /* ---- Editor palette (light) ---- */
@@ -504,8 +498,6 @@
       0 12px 32px -8px rgba(15, 23, 42, 0.18),
       0 4px 12px -4px rgba(15, 23, 42, 0.08);
     --crit-row-hover: rgba(15, 23, 42, 0.05);
-    --crit-workspace-tag-bg: rgba(58, 114, 212, 0.1);
-    --crit-workspace-tag-fg: #2960bc;
     --crit-focus-ring: rgba(58, 114, 212, 0.35);
 
     /* ---- Editor palette (light) ---- */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -62,13 +62,9 @@ function setTheme(theme) {
 window.addEventListener("phx:set-theme", e => setTheme(e.target.dataset.phxTheme));
 window.addEventListener("storage", e => e.key === "phx:theme" && setTheme(e.newValue || "system"));
 
-// Mobile hamburger menu
+// Mobile hamburger menu (public site header)
 document.getElementById("mobile-nav-toggle")?.addEventListener("click", () => {
   document.getElementById("mobile-nav")?.classList.toggle("hidden");
-});
-
-document.getElementById("dashboard-nav-toggle")?.addEventListener("click", () => {
-  document.getElementById("dashboard-nav")?.classList.toggle("hidden");
 });
 
 // connect if there are any LiveViews on the page

--- a/lib/crit_web/components/layouts.ex
+++ b/lib/crit_web/components/layouts.ex
@@ -440,7 +440,7 @@ defmodule CritWeb.Layouts do
               <div
                 id="dashboard-identity-popover"
                 role="menu"
-                aria-labelledby="dashboard-identity-toggle"
+                aria-label="Account menu"
                 hidden
                 phx-hook=".IdentityPopover"
                 class="absolute right-0 top-[calc(100%+8px)] min-w-[280px] bg-(--crit-popover-bg) border border-(--crit-border-strong) rounded-[10px] p-1.5 z-40 shadow-[var(--crit-popover-shadow)]"

--- a/lib/crit_web/components/layouts.ex
+++ b/lib/crit_web/components/layouts.ex
@@ -310,24 +310,38 @@ defmodule CritWeb.Layouts do
   end
 
   @doc """
-  Header for dashboard and admin pages. No marketing nav links.
+  Header for dashboard, overview, and settings pages. No marketing nav links.
   Used in both public and selfhosted modes.
+
+  Layout: a chrome row (logo + identity popover) and a tab strip below
+  (Dashboard, optional Overview, Settings). Pass `current_page` to mark
+  the active tab. Sign out lives inside the identity popover on desktop
+  and at the bottom of the mobile drawer.
   """
   attr :authenticated, :boolean, default: true
   attr :password_required, :boolean, default: false
   attr :current_user, :any, default: nil
   attr :show_overview_link, :boolean, default: false
+  attr :current_page, :atom, default: nil
 
   def dashboard_header(assigns) do
+    host = if assigns.show_overview_link, do: CritWeb.Endpoint.host(), else: nil
+
+    assigns =
+      assigns
+      |> assign(:host, host)
+      |> assign(:user_initial, user_initial(assigns.current_user))
+
     ~H"""
-    <header class="border-b border-(--crit-border) bg-(--crit-bg-card)">
-      <div class="max-w-7xl mx-auto flex items-center justify-between px-10 py-5 max-sm:px-5 max-sm:py-4">
-        <div class="flex items-center gap-3">
+    <header class="bg-(--crit-bg-card) border-b border-(--crit-border)">
+      <%!-- Chrome row: logo + scope chip (left), identity popover + theme + hamburger (right) --%>
+      <div class="max-w-7xl mx-auto flex items-center justify-between gap-4 px-8 py-3.5 max-sm:px-4 max-sm:py-3">
+        <div class="flex items-center gap-2.5 min-w-0">
           <a
             href={~p"/dashboard"}
-            class="text-(--crit-fg-primary) no-underline transition-colors"
+            class="text-(--crit-fg-primary) no-underline inline-flex items-center -ml-1.5 px-1.5 py-1 rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-(--crit-focus-ring)"
           >
-            <svg class="h-5 w-auto" viewBox="50 -1600 3430 1650" aria-label="crit">
+            <svg class="h-[18px] w-auto" viewBox="50 -1600 3430 1650" aria-label="crit">
               <g transform="scale(1,-1)">
                 <path
                   d="M628 -22Q459 -22 336.5 50.5Q214 123 147.5 252.5Q81 382 81 554Q81 727 147.5 857.0Q214 987 336.5 1059.5Q459 1132 628 1132Q827 1132 960.0 1032.5Q1093 933 1125 760L846 708Q827 795 772.5 845.5Q718 896 631 896Q511 896 449.0 801.5Q387 707 387 555Q387 405 449.0 309.5Q511 214 631 214Q718 214 774.0 266.5Q830 319 848 409L1127 358Q1095 181 962.0 79.5Q829 -22 628 -22Z"
@@ -352,47 +366,161 @@ defmodule CritWeb.Layouts do
               </g>
             </svg>
           </a>
-        </div>
-        <nav class="flex items-center gap-4">
-          <%= if @current_user do %>
-            <div class="flex items-center gap-3 max-sm:hidden">
-              <%= if @current_user.avatar_url do %>
-                <img
-                  src={@current_user.avatar_url}
-                  alt={@current_user.name}
-                  class="h-8 w-8 rounded-full"
-                />
-              <% end %>
-              <span class="text-sm text-(--crit-fg-primary)">
-                {@current_user.name || @current_user.email}
+
+          <%= if @show_overview_link do %>
+            <div
+              role="group"
+              aria-label={"Self-hosted instance: " <> @host}
+              class="relative inline-flex items-stretch h-[30px] ml-1 min-w-0 max-sm:hidden text-(--crit-fg-muted) before:content-[''] before:absolute before:left-0 before:top-[7px] before:bottom-[7px] before:w-px before:bg-(--crit-border-strong)"
+            >
+              <span class="inline-flex items-center px-2.5">
+                <span class="text-[9.5px] font-semibold uppercase tracking-[0.1em] text-(--crit-fg-muted) leading-none">
+                  Self-hosted
+                </span>
               </span>
-              <.link
-                href={~p"/dashboard"}
-                class="text-sm text-(--crit-fg-secondary) hover:text-(--crit-fg-primary)"
-              >
+              <span class="relative inline-flex items-center px-2.5 before:content-[''] before:absolute before:left-0 before:top-2 before:bottom-2 before:w-px before:bg-(--crit-border-strong)">
+                <span class="font-mono text-[12.5px] font-medium text-(--crit-fg-primary) tracking-tight truncate max-w-[240px] leading-none">
+                  {@host}
+                </span>
+              </span>
+            </div>
+          <% end %>
+        </div>
+
+        <div class="flex items-center gap-1.5">
+          <%= if @current_user do %>
+            <nav aria-label="Primary" class="flex items-center gap-0.5 max-sm:hidden">
+              <.dashboard_link href={~p"/dashboard"} active={@current_page == :dashboard}>
                 Dashboard
-              </.link>
+              </.dashboard_link>
               <%= if @show_overview_link do %>
-                <.link
-                  href={~p"/overview"}
-                  class="text-sm text-(--crit-fg-secondary) hover:text-(--crit-fg-primary)"
-                >
+                <.dashboard_link href={~p"/overview"} active={@current_page == :overview}>
                   Overview
-                </.link>
+                </.dashboard_link>
               <% end %>
-              <.link
-                navigate={~p"/settings"}
-                class="text-sm text-(--crit-fg-secondary) hover:text-(--crit-fg-primary)"
+            </nav>
+
+            <span
+              aria-hidden="true"
+              class="w-px h-4 bg-(--crit-border-strong) mx-1.5 max-sm:hidden"
+            >
+            </span>
+
+            <div class="relative max-sm:hidden">
+              <button
+                id="dashboard-identity-toggle"
+                type="button"
+                aria-haspopup="menu"
+                aria-expanded="false"
+                aria-controls="dashboard-identity-popover"
+                phx-click={
+                  JS.toggle_attribute({"hidden", "hidden"}, to: "#dashboard-identity-popover")
+                  |> JS.toggle_attribute({"aria-expanded", "true", "false"})
+                }
+                class="group inline-flex items-center gap-1.5 h-[30px] pl-0.5 pr-1.5 rounded-md text-(--crit-fg-secondary) hover:bg-(--crit-row-hover) hover:text-(--crit-fg-primary) aria-expanded:bg-(--crit-bg-card) aria-expanded:text-(--crit-fg-primary) cursor-pointer transition-colors focus:outline-none focus-visible:shadow-[0_0_0_2px_var(--crit-bg-page),0_0_0_4px_var(--crit-focus-ring)]"
+                aria-label="Account menu"
               >
-                Settings
-              </.link>
-              <.link
-                href={~p"/auth/logout"}
-                method="delete"
-                class="text-sm text-(--crit-fg-secondary) hover:text-(--crit-fg-primary)"
+                <%= if @current_user.avatar_url do %>
+                  <img
+                    src={@current_user.avatar_url}
+                    alt=""
+                    class="h-6 w-6 rounded-full flex-shrink-0"
+                  />
+                <% else %>
+                  <span class="h-6 w-6 rounded-full bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-[10.5px] font-semibold flex-shrink-0">
+                    {@user_initial}
+                  </span>
+                <% end %>
+                <.icon
+                  name="hero-chevron-down-micro"
+                  class="size-3 text-(--crit-fg-muted) transition-transform group-aria-expanded:rotate-180 group-aria-expanded:text-(--crit-fg-secondary) flex-shrink-0"
+                />
+              </button>
+
+              <div
+                id="dashboard-identity-popover"
+                role="menu"
+                aria-labelledby="dashboard-identity-toggle"
+                hidden
+                phx-hook=".IdentityPopover"
+                class="absolute right-0 top-[calc(100%+8px)] min-w-[280px] bg-(--crit-popover-bg) border border-(--crit-border-strong) rounded-[10px] p-1.5 z-40 shadow-[var(--crit-popover-shadow)]"
               >
-                Sign out
-              </.link>
+                <script :type={Phoenix.LiveView.ColocatedHook} name=".IdentityPopover">
+                  export default {
+                    mounted() {
+                      this.onDocClick = (e) => {
+                        if (this.el.hidden) return
+                        const trigger = document.getElementById("dashboard-identity-toggle")
+                        if (this.el.contains(e.target) || trigger?.contains(e.target)) return
+                        this.el.hidden = true
+                        trigger?.setAttribute("aria-expanded", "false")
+                      }
+                      this.onKey = (e) => {
+                        if (e.key === "Escape" && !this.el.hidden) {
+                          this.el.hidden = true
+                          document.getElementById("dashboard-identity-toggle")
+                            ?.setAttribute("aria-expanded", "false")
+                        }
+                      }
+                      document.addEventListener("click", this.onDocClick)
+                      document.addEventListener("keydown", this.onKey)
+                    },
+                    destroyed() {
+                      document.removeEventListener("click", this.onDocClick)
+                      document.removeEventListener("keydown", this.onKey)
+                    }
+                  }
+                </script>
+                <div class="flex gap-3 items-start px-3 pt-3 pb-3.5">
+                  <%= if @current_user.avatar_url do %>
+                    <img
+                      src={@current_user.avatar_url}
+                      alt=""
+                      class="h-9 w-9 rounded-md flex-shrink-0"
+                    />
+                  <% else %>
+                    <span class="h-9 w-9 rounded-md bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-[13px] font-semibold flex-shrink-0">
+                      {@user_initial}
+                    </span>
+                  <% end %>
+                  <div class="flex flex-col gap-0.5 min-w-0">
+                    <span class="text-[13px] font-semibold text-(--crit-fg-primary) leading-tight">
+                      {@current_user.name || @current_user.email}
+                    </span>
+                    <%= if @current_user.name && @current_user.email do %>
+                      <span class="text-xs text-(--crit-fg-muted) leading-tight truncate max-w-[200px]">
+                        {@current_user.email}
+                      </span>
+                    <% end %>
+                  </div>
+                </div>
+
+                <div class="h-px bg-(--crit-border) my-0.5"></div>
+
+                <div class="text-[10.5px] uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-3 pt-2 pb-1">
+                  Account
+                </div>
+                <.link
+                  navigate={~p"/settings"}
+                  role="menuitem"
+                  class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[13px] text-(--crit-fg-primary) hover:bg-(--crit-row-hover) no-underline"
+                >
+                  <.icon name="hero-cog-6-tooth-mini" class="size-3.5 text-(--crit-fg-muted)" />
+                  <span>Settings</span>
+                </.link>
+
+                <div class="h-px bg-(--crit-border) my-0.5"></div>
+
+                <.link
+                  href={~p"/auth/logout"}
+                  method="delete"
+                  role="menuitem"
+                  class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[13px] text-(--crit-red) hover:bg-(--crit-btn-danger-hover-bg) no-underline"
+                >
+                  <.icon name="hero-arrow-right-on-rectangle-mini" class="size-3.5" />
+                  <span>Sign out</span>
+                </.link>
+              </div>
             </div>
           <% else %>
             <%= if @password_required and not @authenticated do %>
@@ -404,53 +532,82 @@ defmodule CritWeb.Layouts do
               </a>
             <% end %>
           <% end %>
+
           <.theme_toggle />
+
           <button
             id="dashboard-nav-toggle"
-            class="sm:hidden p-1 text-(--crit-fg-secondary) hover:text-(--crit-fg-primary) cursor-pointer"
+            type="button"
+            phx-click={JS.toggle_attribute({"hidden", "hidden"}, to: "#dashboard-nav")}
+            class="sm:hidden p-1.5 rounded-md text-(--crit-fg-secondary) hover:text-(--crit-fg-primary) hover:bg-(--crit-row-hover) cursor-pointer"
             aria-label="Toggle menu"
           >
             <.icon name="hero-bars-3" class="size-5" />
           </button>
-        </nav>
+        </div>
       </div>
-      <%!-- Mobile nav dropdown --%>
-      <div id="dashboard-nav" class="hidden sm:hidden border-t border-(--crit-border)">
-        <div class="flex flex-col px-5 py-2">
-          <.link
-            href={~p"/dashboard"}
-            class="text-sm text-(--crit-fg-secondary) no-underline hover:text-(--crit-fg-primary) py-2"
-          >
-            Dashboard
-          </.link>
-          <%= if @show_overview_link do %>
-            <.link
-              href={~p"/overview"}
-              class="text-sm text-(--crit-fg-secondary) no-underline hover:text-(--crit-fg-primary) py-2"
-            >
-              Overview
-            </.link>
-          <% end %>
-          <.link
-            navigate={~p"/settings"}
-            class="text-sm text-(--crit-fg-secondary) no-underline hover:text-(--crit-fg-primary) py-2"
-          >
-            Settings
-          </.link>
+
+      <%!-- Mobile drawer --%>
+      <div
+        id="dashboard-nav"
+        hidden
+        class="sm:hidden bg-(--crit-bg-card) border-t border-(--crit-border)"
+      >
+        <div class="flex flex-col gap-px px-3 pt-2 pb-3.5">
           <%= if @current_user do %>
+            <div class="flex items-center gap-3 px-3 py-3 border-b border-(--crit-border) mb-1.5">
+              <%= if @current_user.avatar_url do %>
+                <img src={@current_user.avatar_url} alt="" class="h-9 w-9 rounded-md flex-shrink-0" />
+              <% else %>
+                <span class="h-9 w-9 rounded-md bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-[13px] font-semibold flex-shrink-0">
+                  {@user_initial}
+                </span>
+              <% end %>
+              <div class="flex flex-col gap-0.5 min-w-0">
+                <span class="text-sm font-semibold text-(--crit-fg-primary) truncate">
+                  {@current_user.name || @current_user.email}
+                </span>
+                <%= if @current_user.name && @current_user.email do %>
+                  <span class="text-xs text-(--crit-fg-muted) truncate">
+                    {@current_user.email}
+                  </span>
+                <% end %>
+              </div>
+            </div>
+
+            <div class="text-[10.5px] uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-2 pt-2 pb-1">
+              Navigate
+            </div>
+            <.dashboard_mobile_link href={~p"/dashboard"} active={@current_page == :dashboard}>
+              Dashboard
+            </.dashboard_mobile_link>
+            <%= if @show_overview_link do %>
+              <.dashboard_mobile_link href={~p"/overview"} active={@current_page == :overview}>
+                Overview
+              </.dashboard_mobile_link>
+            <% end %>
+
+            <div class="text-[10.5px] uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-2 pt-2 pb-1">
+              Account
+            </div>
+            <.dashboard_mobile_link navigate={~p"/settings"} active={@current_page == :settings}>
+              Settings
+            </.dashboard_mobile_link>
+
             <.link
               href={~p"/auth/logout"}
               method="delete"
-              class="text-sm text-red-400 hover:text-red-300 no-underline py-2"
+              class="flex items-center gap-3 px-2 py-2.5 rounded-md text-sm text-(--crit-red) no-underline hover:bg-(--crit-btn-danger-hover-bg)"
             >
-              Sign out
+              <.icon name="hero-arrow-right-on-rectangle-mini" class="size-4" />
+              <span>Sign out</span>
             </.link>
           <% else %>
             <%= if @password_required and @authenticated do %>
               <.form for={%{}} action={~p"/auth/logout"} method="post" id="logout-form-mobile">
                 <button
                   type="submit"
-                  class="text-sm text-red-400 hover:text-red-300 transition-colors cursor-pointer py-2"
+                  class="text-sm text-(--crit-red) hover:opacity-80 transition-opacity cursor-pointer py-2 px-2"
                 >
                   Sign out
                 </button>
@@ -462,6 +619,63 @@ defmodule CritWeb.Layouts do
     </header>
     """
   end
+
+  attr :href, :string, default: nil
+  attr :navigate, :string, default: nil
+  attr :active, :boolean, default: false
+  slot :inner_block, required: true
+
+  defp dashboard_link(assigns) do
+    ~H"""
+    <.link
+      href={@href}
+      navigate={@navigate}
+      aria-current={@active && "page"}
+      class={[
+        "inline-flex items-center h-[30px] px-2.5 rounded-md text-[13px] font-medium tracking-tight no-underline transition-colors",
+        if(@active,
+          do: "text-(--crit-fg-primary) bg-(--crit-bg-card) hover:bg-(--crit-bg-elevated)",
+          else:
+            "text-(--crit-fg-secondary) hover:text-(--crit-fg-primary) hover:bg-(--crit-row-hover)"
+        )
+      ]}
+    >
+      {render_slot(@inner_block)}
+    </.link>
+    """
+  end
+
+  attr :href, :string, default: nil
+  attr :navigate, :string, default: nil
+  attr :active, :boolean, default: false
+  slot :inner_block, required: true
+
+  defp dashboard_mobile_link(assigns) do
+    ~H"""
+    <.link
+      href={@href}
+      navigate={@navigate}
+      aria-current={@active && "page"}
+      class={[
+        "flex items-center gap-3 px-2 py-2.5 rounded-md text-sm font-medium no-underline",
+        if(@active,
+          do: "bg-(--crit-brand-bg) text-(--crit-brand)",
+          else: "text-(--crit-fg-primary) hover:bg-(--crit-row-hover)"
+        )
+      ]}
+    >
+      {render_slot(@inner_block)}
+    </.link>
+    """
+  end
+
+  defp user_initial(%{name: name}) when is_binary(name) and name != "",
+    do: name |> String.first() |> String.upcase()
+
+  defp user_initial(%{email: email}) when is_binary(email) and email != "",
+    do: email |> String.first() |> String.upcase()
+
+  defp user_initial(_), do: "?"
 
   @doc """
   Shows the flash group with standard titles and content.

--- a/lib/crit_web/components/layouts.ex
+++ b/lib/crit_web/components/layouts.ex
@@ -316,9 +316,7 @@ defmodule CritWeb.Layouts do
   attr :authenticated, :boolean, default: true
   attr :password_required, :boolean, default: false
   attr :current_user, :any, default: nil
-  attr :show_admin_link, :boolean, default: false
-  attr :show_my_reviews_link, :boolean, default: false
-  attr :show_settings_link, :boolean, default: false
+  attr :show_overview_link, :boolean, default: false
 
   def dashboard_header(assigns) do
     ~H"""
@@ -368,30 +366,26 @@ defmodule CritWeb.Layouts do
               <span class="text-sm text-(--crit-fg-primary)">
                 {@current_user.name || @current_user.email}
               </span>
-              <%= if @show_my_reviews_link do %>
+              <.link
+                href={~p"/dashboard"}
+                class="text-sm text-(--crit-fg-secondary) hover:text-(--crit-fg-primary)"
+              >
+                Dashboard
+              </.link>
+              <%= if @show_overview_link do %>
                 <.link
-                  href={~p"/dashboard"}
+                  href={~p"/overview"}
                   class="text-sm text-(--crit-fg-secondary) hover:text-(--crit-fg-primary)"
                 >
-                  My Reviews
+                  Overview
                 </.link>
               <% end %>
-              <%= if @show_admin_link do %>
-                <.link
-                  href={~p"/admin"}
-                  class="text-sm text-(--crit-fg-secondary) hover:text-(--crit-fg-primary)"
-                >
-                  Admin
-                </.link>
-              <% end %>
-              <%= if @show_settings_link do %>
-                <.link
-                  navigate={~p"/settings"}
-                  class="text-sm text-(--crit-fg-secondary) hover:text-(--crit-fg-primary)"
-                >
-                  Settings
-                </.link>
-              <% end %>
+              <.link
+                navigate={~p"/settings"}
+                class="text-sm text-(--crit-fg-secondary) hover:text-(--crit-fg-primary)"
+              >
+                Settings
+              </.link>
               <.link
                 href={~p"/auth/logout"}
                 method="delete"
@@ -423,30 +417,26 @@ defmodule CritWeb.Layouts do
       <%!-- Mobile nav dropdown --%>
       <div id="dashboard-nav" class="hidden sm:hidden border-t border-(--crit-border)">
         <div class="flex flex-col px-5 py-2">
-          <%= if @show_my_reviews_link do %>
+          <.link
+            href={~p"/dashboard"}
+            class="text-sm text-(--crit-fg-secondary) no-underline hover:text-(--crit-fg-primary) py-2"
+          >
+            Dashboard
+          </.link>
+          <%= if @show_overview_link do %>
             <.link
-              href={~p"/dashboard"}
+              href={~p"/overview"}
               class="text-sm text-(--crit-fg-secondary) no-underline hover:text-(--crit-fg-primary) py-2"
             >
-              My Reviews
+              Overview
             </.link>
           <% end %>
-          <%= if @show_admin_link do %>
-            <.link
-              href={~p"/admin"}
-              class="text-sm text-(--crit-fg-secondary) no-underline hover:text-(--crit-fg-primary) py-2"
-            >
-              Admin
-            </.link>
-          <% end %>
-          <%= if @show_settings_link do %>
-            <.link
-              navigate={~p"/settings"}
-              class="text-sm text-(--crit-fg-secondary) no-underline hover:text-(--crit-fg-primary) py-2"
-            >
-              Settings
-            </.link>
-          <% end %>
+          <.link
+            navigate={~p"/settings"}
+            class="text-sm text-(--crit-fg-secondary) no-underline hover:text-(--crit-fg-primary) py-2"
+          >
+            Settings
+          </.link>
           <%= if @current_user do %>
             <.link
               href={~p"/auth/logout"}

--- a/lib/crit_web/controllers/page_controller.ex
+++ b/lib/crit_web/controllers/page_controller.ex
@@ -185,7 +185,7 @@ defmodule CritWeb.PageController do
 
   def home(conn, _params) do
     if Application.get_env(:crit, :selfhosted) do
-      redirect(conn, to: "/dashboard")
+      redirect(conn, to: "/overview")
     else
       render(conn, :home,
         demo_token: Application.get_env(:crit, :demo_review_token),

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -1,11 +1,7 @@
 <Layouts.flash_group flash={@flash} />
 
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
-  <Layouts.dashboard_header
-    current_user={@current_user}
-    show_admin_link={@selfhosted}
-    show_settings_link={true}
-  />
+  <Layouts.dashboard_header current_user={@current_user} show_overview_link={@selfhosted} />
 
   <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">
     <div class="flex justify-between items-center mb-3">

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -1,7 +1,11 @@
 <Layouts.flash_group flash={@flash} />
 
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
-  <Layouts.dashboard_header current_user={@current_user} show_overview_link={@selfhosted} />
+  <Layouts.dashboard_header
+    current_user={@current_user}
+    show_overview_link={@selfhosted}
+    current_page={:dashboard}
+  />
 
   <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">
     <div class="flex justify-between items-center mb-3">

--- a/lib/crit_web/live/overview_live.ex
+++ b/lib/crit_web/live/overview_live.ex
@@ -1,4 +1,4 @@
-defmodule CritWeb.AdminLive do
+defmodule CritWeb.OverviewLive do
   use CritWeb, :live_view
 
   alias Crit.{Reviews, Statistics}
@@ -18,7 +18,7 @@ defmodule CritWeb.AdminLive do
       |> assign(:stats, stats)
       |> assign(:chart_data, chart_data)
       |> assign(:max_count, max_count)
-      |> assign(:page_title, "Admin - Crit")
+      |> assign(:page_title, "Overview - Crit")
       |> assign(:noindex, true)
 
     socket =

--- a/lib/crit_web/live/overview_live.html.heex
+++ b/lib/crit_web/live/overview_live.html.heex
@@ -6,6 +6,7 @@
     password_required={@password_required}
     current_user={@current_user}
     show_overview_link={true}
+    current_page={:overview}
   />
 
   <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">

--- a/lib/crit_web/live/overview_live.html.heex
+++ b/lib/crit_web/live/overview_live.html.heex
@@ -5,8 +5,7 @@
     authenticated={@authenticated}
     password_required={@password_required}
     current_user={@current_user}
-    show_admin_link={false}
-    show_my_reviews_link={true}
+    show_overview_link={true}
   />
 
   <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">

--- a/lib/crit_web/live/settings_live.html.heex
+++ b/lib/crit_web/live/settings_live.html.heex
@@ -1,7 +1,11 @@
 <Layouts.flash_group flash={@flash} />
 
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
-  <Layouts.dashboard_header current_user={@current_user} show_overview_link={@selfhosted} />
+  <Layouts.dashboard_header
+    current_user={@current_user}
+    show_overview_link={@selfhosted}
+    current_page={:settings}
+  />
 
   <%!-- Main content --%>
   <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">

--- a/lib/crit_web/live/settings_live.html.heex
+++ b/lib/crit_web/live/settings_live.html.heex
@@ -1,12 +1,7 @@
 <Layouts.flash_group flash={@flash} />
 
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
-  <Layouts.dashboard_header
-    current_user={@current_user}
-    show_my_reviews_link={true}
-    show_admin_link={@selfhosted}
-    show_settings_link={false}
-  />
+  <Layouts.dashboard_header current_user={@current_user} show_overview_link={@selfhosted} />
 
   <%!-- Main content --%>
   <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">

--- a/lib/crit_web/live/settings_live.html.heex
+++ b/lib/crit_web/live/settings_live.html.heex
@@ -1,54 +1,12 @@
 <Layouts.flash_group flash={@flash} />
 
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
-  <%!-- Header --%>
-  <header class="border-b border-(--crit-border) bg-(--crit-bg-card)">
-    <div class="max-w-7xl mx-auto flex items-center justify-between px-10 py-5 max-sm:px-5 max-sm:py-4">
-      <div class="flex items-center gap-3">
-        <a
-          href={if @selfhosted, do: ~p"/dashboard", else: ~p"/"}
-          class="text-xl font-bold text-(--crit-fg-primary) tracking-tighter no-underline transition-colors"
-        >
-          crit<span class="text-(--crit-brand)">.</span>
-        </a>
-        <%= if @selfhosted do %>
-          <span class="text-xs text-(--crit-fg-muted) border border-(--crit-border) px-2 py-0.5 rounded">
-            self-hosted
-          </span>
-        <% end %>
-      </div>
-      <nav class="flex items-center gap-4">
-        <div class="flex items-center gap-3">
-          <%= if @current_user.avatar_url do %>
-            <img
-              src={@current_user.avatar_url}
-              alt={@current_user.name}
-              class="h-8 w-8 rounded-full"
-            />
-          <% end %>
-          <span class="text-sm text-(--crit-fg-primary) max-sm:hidden">
-            {@current_user.name || @current_user.email}
-          </span>
-          <%= if @selfhosted do %>
-            <.link
-              href={~p"/dashboard"}
-              class="text-sm text-(--crit-fg-muted) hover:text-(--crit-fg-primary) max-sm:hidden"
-            >
-              Dashboard
-            </.link>
-          <% end %>
-          <.link
-            href={~p"/auth/logout"}
-            method="delete"
-            class="text-sm text-(--crit-fg-muted) hover:text-(--crit-fg-primary) max-sm:hidden"
-          >
-            Sign out
-          </.link>
-        </div>
-        <Layouts.theme_toggle />
-      </nav>
-    </div>
-  </header>
+  <Layouts.dashboard_header
+    current_user={@current_user}
+    show_my_reviews_link={true}
+    show_admin_link={@selfhosted}
+    show_settings_link={false}
+  />
 
   <%!-- Main content --%>
   <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -92,7 +92,7 @@ defmodule CritWeb.Router do
     live_session :admin,
       on_mount: [{CritWeb.Live.Hooks, :require_selfhosted_auth}],
       session: {CritWeb.Live.SessionHelper, :admin_session_opts, []} do
-      live "/admin", AdminLive, :index
+      live "/overview", OverviewLive, :index
     end
   end
 

--- a/test/crit_web/live/dashboard_live_test.exs
+++ b/test/crit_web/live/dashboard_live_test.exs
@@ -263,9 +263,9 @@ defmodule CritWeb.DashboardLiveTest do
       end)
     end
 
-    test "/ redirects to /dashboard when selfhosted", %{conn: conn} do
+    test "/ redirects to /overview when selfhosted", %{conn: conn} do
       conn = get(conn, ~p"/")
-      assert redirected_to(conn) == "/dashboard"
+      assert redirected_to(conn) == "/overview"
     end
   end
 end

--- a/test/crit_web/live/overview_live_test.exs
+++ b/test/crit_web/live/overview_live_test.exs
@@ -139,7 +139,7 @@ defmodule CritWeb.OverviewLiveTest do
     end
   end
 
-  describe "admin empty state" do
+  describe "overview empty state" do
     setup :without_oauth
 
     test "shows empty message when no reviews", %{conn: conn} do
@@ -195,7 +195,7 @@ defmodule CritWeb.OverviewLiveTest do
     end
   end
 
-  describe "admin page title" do
+  describe "overview page title" do
     test "page title is Admin - Crit", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/overview")
 
@@ -203,7 +203,7 @@ defmodule CritWeb.OverviewLiveTest do
     end
   end
 
-  describe "admin with review metadata" do
+  describe "overview with review metadata" do
     setup :without_oauth
 
     test "shows comment and file counts for reviews", %{conn: conn} do

--- a/test/crit_web/live/overview_live_test.exs
+++ b/test/crit_web/live/overview_live_test.exs
@@ -1,4 +1,4 @@
-defmodule CritWeb.AdminLiveTest do
+defmodule CritWeb.OverviewLiveTest do
   use CritWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
@@ -46,14 +46,14 @@ defmodule CritWeb.AdminLiveTest do
     test "redirects to / when not in selfhosted mode", %{conn: conn} do
       Application.delete_env(:crit, :selfhosted)
 
-      assert {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/admin")
+      assert {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/overview")
     end
 
     test "renders stats when selfhosted", %{conn: conn} do
       review = review_fixture()
       comment_fixture(review)
 
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ "Reviews"
       assert html =~ "Comments"
@@ -65,7 +65,7 @@ defmodule CritWeb.AdminLiveTest do
       without_oauth(%{})
 
       review = review_fixture()
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ "All Reviews"
       assert html =~ hd(review.files).file_path
@@ -78,7 +78,7 @@ defmodule CritWeb.AdminLiveTest do
     end
 
     test "shows login prompt when not authenticated", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ "Sign in to view and manage reviews"
       refute html =~ "All Reviews"
@@ -87,14 +87,14 @@ defmodule CritWeb.AdminLiveTest do
     test "shows password form when no OAuth configured", %{conn: conn} do
       without_oauth(%{})
 
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ "password"
       refute html =~ "Sign in with OAuth"
     end
 
     test "shows OAuth button when OAuth configured", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ "Sign in with OAuth"
       refute html =~ "login-form"
@@ -104,7 +104,7 @@ defmodule CritWeb.AdminLiveTest do
       review = review_fixture()
       conn = login_user(conn)
 
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ "All Reviews"
       assert html =~ hd(review.files).file_path
@@ -113,7 +113,7 @@ defmodule CritWeb.AdminLiveTest do
     test "shows stats even when not authenticated", %{conn: conn} do
       _review = review_fixture()
 
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ "Reviews"
       assert html =~ "Comments"
@@ -126,7 +126,7 @@ defmodule CritWeb.AdminLiveTest do
     test "removes review from list", %{conn: conn} do
       review = review_fixture()
 
-      {:ok, view, html} = live(conn, ~p"/admin")
+      {:ok, view, html} = live(conn, ~p"/overview")
       assert html =~ hd(review.files).file_path
 
       view
@@ -143,7 +143,7 @@ defmodule CritWeb.AdminLiveTest do
     setup :without_oauth
 
     test "shows empty message when no reviews", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ "All Reviews (0)"
       assert html =~ "No reviews yet"
@@ -157,7 +157,7 @@ defmodule CritWeb.AdminLiveTest do
       review = review_fixture()
       comment_fixture(review)
 
-      {:ok, view, html} = live(conn, ~p"/admin")
+      {:ok, view, html} = live(conn, ~p"/overview")
       assert html =~ "All Reviews (1)"
 
       view
@@ -179,7 +179,7 @@ defmodule CritWeb.AdminLiveTest do
       review = review_fixture()
 
       conn = init_test_session(conn, %{admin_authenticated: true})
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ "All Reviews"
       assert html =~ hd(review.files).file_path
@@ -188,7 +188,7 @@ defmodule CritWeb.AdminLiveTest do
     test "unauthenticated password session shows login form", %{conn: conn} do
       without_oauth(%{})
 
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ "password"
       refute html =~ "All Reviews"
@@ -197,9 +197,9 @@ defmodule CritWeb.AdminLiveTest do
 
   describe "admin page title" do
     test "page title is Admin - Crit", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/admin")
+      {:ok, view, _html} = live(conn, ~p"/overview")
 
-      assert page_title(view) =~ "Admin - Crit"
+      assert page_title(view) =~ "Overview - Crit"
     end
   end
 
@@ -210,7 +210,7 @@ defmodule CritWeb.AdminLiveTest do
       review = review_fixture()
       comment_fixture(review)
 
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ "1 comment"
       assert html =~ "1 file"
@@ -219,7 +219,7 @@ defmodule CritWeb.AdminLiveTest do
     test "review links to /r/:token", %{conn: conn} do
       review = review_fixture()
 
-      {:ok, _view, html} = live(conn, ~p"/admin")
+      {:ok, _view, html} = live(conn, ~p"/overview")
 
       assert html =~ ~p"/r/#{review.token}"
     end
@@ -230,7 +230,7 @@ defmodule CritWeb.AdminLiveTest do
       {conn, user} = login_user_with_record(conn)
       review = review_fixture(user_id: user.id)
 
-      {:ok, view, html} = live(conn, ~p"/admin")
+      {:ok, view, html} = live(conn, ~p"/overview")
       assert html =~ hd(review.files).file_path
 
       view
@@ -251,7 +251,7 @@ defmodule CritWeb.AdminLiveTest do
       review = review_fixture(user_id: other_user.id)
       conn = login_user(conn)
 
-      {:ok, view, _html} = live(conn, ~p"/admin")
+      {:ok, view, _html} = live(conn, ~p"/overview")
 
       refute has_element?(view, "button[phx-value-id='#{review.id}']")
 
@@ -266,7 +266,7 @@ defmodule CritWeb.AdminLiveTest do
       review = review_fixture()
       conn = login_user(conn)
 
-      {:ok, view, html} = live(conn, ~p"/admin")
+      {:ok, view, html} = live(conn, ~p"/overview")
       assert html =~ hd(review.files).file_path
 
       view


### PR DESCRIPTION
## Summary

- Restructured the logged-in header (`dashboard_header/1`) into a single chrome row: logo, optional self-hosted instance indicator, primary nav links (Dashboard + Overview), 1px vertical divider, account avatar that opens an identity popover.
- **Settings is no longer a top-level nav link** — lives only in the identity popover (and the mobile drawer's Account section). Sign out is also popover-only on desktop.
- New **self-hosted instance indicator**: small-caps `SELF-HOSTED` label + monospace hostname (from `CritWeb.Endpoint.host()`, which reads `PHX_HOST` via runtime config). Only renders when selfhosted; no icon, no chevron, no hover affordance — purely contextual chrome.
- Renamed `/admin` → `/overview` (`AdminLive` → `OverviewLive`) — better describes the page (stats + all reviews on the instance, not just admin actions).
- Migrated header toggles to Phoenix idioms: `JS.toggle_attribute` for the hamburger and identity popover; click-outside / Escape close handled by a colocated `phx-hook` with proper `destroyed`-time cleanup. Removed direct \`getElementById(...).addEventListener(...)\` listeners from \`app.js\` (which broke across LiveView client-side patches).
- New \`current_page\` attr on \`dashboard_header\` (\`:dashboard | :overview | :settings\`) — active link gets a subtle pill background.
- Avatar with initial fallback when \`avatar_url\` is missing.
- New CSS variables for popover surfaces in all four theme blocks.
- AGENTS.md: new rule under "JS hooks" documenting when to prefer \`JS\` commands and colocated hooks over vanilla \`addEventListener\`.

## Review

- [x] Code review: passed (fresh frontend + elixir expert pass)
- [x] Parity audit: N/A (no review-page files touched)
- [x] \`mix precommit\`: passed
- [x] \`mix test\` — 427 tests, 0 failures

## Test plan

- [x] \`/dashboard\` — Dashboard tab styled active, identity popover opens/closes
- [x] \`/settings\` — popover works after \`<.link navigate>\` patch (the bug that drove the JS migration)
- [x] \`/overview\` (selfhosted) — Overview link visible, indicator renders with \`PHX_HOST\`
- [x] Mobile drawer — Navigate (Dashboard/Overview) + Account (Settings) + Sign out
- [x] Light/dark theme on all three pages
- [x] Eyeball in browser before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)