### PR TITLE
fix: hide TOC button and panel when document has no headings

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3006,6 +3006,7 @@ function buildToc(tocEl, toggleBtn, items) {
 
   if (items.length === 0) {
     toggleBtn.style.display = "none"
+    tocEl.classList.add("crit-toc-hidden")
     return
   }
   toggleBtn.style.display = ""
@@ -4037,9 +4038,11 @@ export const DocumentRenderer = {
     const tocItems = extractTocItems(md, rawContent)
     if (tocEl && tocToggleBtn) {
       buildToc(tocEl, tocToggleBtn, tocItems)
-      const saved = localStorage.getItem("crit-toc")
-      if (saved === "open" || (saved === null && window.innerWidth > 1200)) {
-        tocEl.classList.remove("crit-toc-hidden")
+      if (tocItems.length > 0) {
+        const saved = localStorage.getItem("crit-toc")
+        if (saved === "open" || (saved === null && window.innerWidth > 1200)) {
+          tocEl.classList.remove("crit-toc-hidden")
+        }
       }
       tocToggleBtn.addEventListener("click", () => {
         const isHidden = tocEl.classList.contains("crit-toc-hidden")

--- a/e2e/toc.spec.ts
+++ b/e2e/toc.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import { createReview, deleteReview, loadReview } from "./helpers";
+
+test.describe("Table of Contents", () => {
+  let token: string;
+  let deleteToken: string;
+
+  test.afterEach(async ({ request }) => {
+    if (deleteToken) await deleteReview(request, deleteToken);
+  });
+
+  test("toggle button is visible and panel opens when document has headings", async ({
+    page,
+    request,
+  }) => {
+    const review = await createReview(request, {
+      files: [
+        {
+          path: "with-headings.md",
+          content:
+            "# Top Heading\n\nSome content.\n\n## Subsection\n\nMore content.\n",
+        },
+      ],
+    });
+    token = review.token;
+    deleteToken = review.deleteToken;
+
+    await page.setViewportSize({ width: 1400, height: 900 });
+    await loadReview(page, token);
+
+    const toggle = page.locator("#crit-toc-toggle");
+    const panel = page.locator("#crit-toc");
+
+    await expect(toggle).toBeVisible();
+    await expect(panel.locator(".crit-toc-list a")).toHaveCount(2);
+  });
+
+  test("toggle button and panel are hidden when document has no headings", async ({
+    page,
+    request,
+  }) => {
+    const review = await createReview(request, {
+      files: [
+        {
+          path: "no-headings.md",
+          content:
+            "Just a paragraph of text.\n\nAnother paragraph, no headings here.\n",
+        },
+      ],
+    });
+    token = review.token;
+    deleteToken = review.deleteToken;
+
+    // Wide viewport — default behavior would open TOC if not guarded
+    await page.setViewportSize({ width: 1400, height: 900 });
+    await loadReview(page, token);
+
+    const toggle = page.locator("#crit-toc-toggle");
+    const panel = page.locator("#crit-toc");
+
+    await expect(toggle).toBeHidden();
+    await expect(panel).toHaveClass(/crit-toc-hidden/);
+  });
+
+  test("panel stays hidden for empty TOC even when localStorage says open", async ({
+    page,
+    request,
+  }) => {
+    const review = await createReview(request, {
+      files: [
+        {
+          path: "no-headings.md",
+          content: "Just text. No headings at all in this file.\n",
+        },
+      ],
+    });
+    token = review.token;
+    deleteToken = review.deleteToken;
+
+    // Pre-seed localStorage with a previous "open" state
+    await page.goto("/");
+    await page.evaluate(() => localStorage.setItem("crit-toc", "open"));
+
+    await page.setViewportSize({ width: 1400, height: 900 });
+    await loadReview(page, token);
+
+    const toggle = page.locator("#crit-toc-toggle");
+    const panel = page.locator("#crit-toc");
+
+    await expect(toggle).toBeHidden();
+    await expect(panel).toHaveClass(/crit-toc-hidden/);
+  });
+});


### PR DESCRIPTION
## Summary
- TOC toggle button and panel previously rendered (empty) for documents without headings on wide viewports because the localStorage open-state restoration ran unconditionally.
- `buildToc` now adds `crit-toc-hidden` to the panel when the heading list is empty, and the mount-time restoration only runs when there are items.

## Test plan
- New `e2e/toc.spec.ts` covers:
  - Toggle visible + 2 entries when doc has headings
  - Toggle hidden + panel hidden when doc has no headings
  - Panel stays hidden when no headings even with `localStorage["crit-toc"] = "open"` pre-seeded
- See also: tomasz-tomczyk/crit#TBD (sibling fix in crit local for parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)