### PR TITLE
feat: add file snippet previews to dashboard and overview lists

### DIFF
--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -489,22 +489,27 @@ defmodule Crit.Reviews do
         where: rf.review_id == parent_as(:review).id,
         order_by: [asc: rf.position],
         limit: 1,
-        select: rf.file_path
+        select: %{file_path: rf.file_path, content: rf.content}
       )
 
     from(r in Review, as: :review)
     |> join(:left, [r], c in Comment, on: c.review_id == r.id)
     |> join(:left, [r, _c], rf in ReviewRoundSnapshot, on: rf.review_id == r.id)
     |> join(:left_lateral, [r, _c, _rf], fp in subquery(first_file_subquery), on: true)
-    |> group_by([r, _c, _rf, fp], [
+    |> join(:left, [r, _c, _rf, _fp], u in User, on: u.id == r.user_id)
+    |> group_by([r, _c, _rf, fp, u], [
       r.id,
       r.token,
       r.inserted_at,
       r.last_activity_at,
       r.user_id,
-      fp.file_path
+      fp.file_path,
+      fp.content,
+      u.name,
+      u.email,
+      u.avatar_url
     ])
-    |> select([r, c, rf, fp], %{
+    |> select([r, c, rf, fp, u], %{
       id: r.id,
       token: r.token,
       inserted_at: r.inserted_at,
@@ -512,7 +517,11 @@ defmodule Crit.Reviews do
       user_id: r.user_id,
       comment_count: count(c.id, :distinct),
       file_count: count(rf.id, :distinct),
-      first_file_path: fp.file_path
+      first_file_path: fp.file_path,
+      first_file_content: fp.content,
+      author_name: u.name,
+      author_email: u.email,
+      author_avatar_url: u.avatar_url
     })
     |> order_by([r], desc: r.last_activity_at)
     |> Repo.all()
@@ -528,7 +537,7 @@ defmodule Crit.Reviews do
         where: rf.review_id == parent_as(:review).id,
         order_by: [asc: rf.position],
         limit: 1,
-        select: rf.file_path
+        select: %{file_path: rf.file_path, content: rf.content}
       )
 
     from(r in Review, as: :review)
@@ -542,7 +551,8 @@ defmodule Crit.Reviews do
       r.inserted_at,
       r.last_activity_at,
       r.user_id,
-      fp.file_path
+      fp.file_path,
+      fp.content
     ])
     |> select([r, c, rf, fp], %{
       id: r.id,
@@ -552,7 +562,8 @@ defmodule Crit.Reviews do
       user_id: r.user_id,
       comment_count: count(c.id, :distinct),
       file_count: count(rf.id, :distinct),
-      first_file_path: fp.file_path
+      first_file_path: fp.file_path,
+      first_file_content: fp.content
     })
     |> order_by([r], desc: r.last_activity_at)
     |> Repo.all()

--- a/lib/crit_web/components/review_snippet.ex
+++ b/lib/crit_web/components/review_snippet.ex
@@ -1,0 +1,74 @@
+defmodule CritWeb.Components.ReviewSnippet do
+  @moduledoc """
+  Renders the snippet preview block used in the dashboard and overview review lists.
+
+  Computes the preview from the file path and content via
+  `CritWeb.Helpers.snippet_preview/2`, rendering one of three branches: a
+  syntax-highlighted code listing with line numbers, rendered markdown, or a
+  "no preview" placeholder.
+
+  The parent must include the `SnippetHighlight` colocated hook to apply
+  highlight.js to elements with `[data-snippet-line]`.
+  """
+
+  use Phoenix.Component
+
+  attr :path, :string, default: nil
+  attr :content, :string, default: nil
+
+  def review_snippet(assigns) do
+    assigns =
+      assigns
+      |> assign(:snippet, CritWeb.Helpers.snippet_preview(assigns.path, assigns.content))
+      |> assign(:lang, CritWeb.Helpers.language_for_path(assigns.path))
+
+    ~H"""
+    <%= case @snippet do %>
+      <% {:code, lines} -> %>
+        <div class="border border-(--crit-border) rounded-md bg-(--crit-bg-card) overflow-hidden h-[200px] relative font-mono text-xs leading-5">
+          <div class="py-2">
+            <div
+              :for={{line, idx} <- Enum.with_index(lines, 1)}
+              class="grid grid-cols-[44px_1fr] gap-x-2.5 pr-3.5"
+            >
+              <span class="text-right text-(--crit-fg-muted) opacity-60 select-none text-[11px] pr-1.5 leading-5">
+                {idx}
+              </span>
+              <code
+                class="hljs whitespace-pre overflow-hidden bg-transparent p-0 text-(--crit-fg-primary)"
+                data-snippet-line
+                data-lang={@lang}
+                phx-no-format
+              >{line}</code>
+            </div>
+          </div>
+          <div class="absolute inset-x-0 bottom-0 h-9 bg-gradient-to-b from-transparent to-(--crit-bg-card) pointer-events-none">
+          </div>
+        </div>
+      <% {:markdown, html} -> %>
+        <div class="border border-(--crit-border) rounded-md bg-(--crit-bg-card) overflow-hidden h-[200px] relative px-5 py-3 text-sm
+                    [&_h1]:text-base [&_h1]:font-semibold [&_h1]:mt-0 [&_h1]:mb-1.5 [&_h1]:pb-1 [&_h1]:border-b [&_h1]:border-(--crit-border)
+                    [&_h2]:text-[15px] [&_h2]:font-semibold [&_h2]:mt-2.5 [&_h2]:mb-1
+                    [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:mt-2 [&_h3]:mb-1
+                    [&_p]:my-1 [&_p]:leading-relaxed
+                    [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:my-1
+                    [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:my-1
+                    [&_li]:my-0.5
+                    [&_a]:text-(--crit-brand) [&_a]:underline
+                    [&_code]:font-mono [&_code]:text-[12px] [&_code]:bg-(--crit-bg-elevated) [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded
+                    [&_pre]:font-mono [&_pre]:text-[12px] [&_pre]:bg-(--crit-bg-elevated) [&_pre]:p-2 [&_pre]:rounded [&_pre]:my-1.5 [&_pre]:overflow-hidden
+                    [&_pre_code]:bg-transparent [&_pre_code]:px-0 [&_pre_code]:py-0
+                    [&_blockquote]:border-l-2 [&_blockquote]:border-(--crit-border-strong) [&_blockquote]:pl-3 [&_blockquote]:text-(--crit-fg-secondary)
+                    [&_strong]:font-semibold [&_em]:italic">
+          {html}
+          <div class="absolute inset-x-0 bottom-0 h-9 bg-gradient-to-b from-transparent to-(--crit-bg-card) pointer-events-none">
+          </div>
+        </div>
+      <% :none -> %>
+        <div class="border border-dashed border-(--crit-border) rounded-md bg-(--crit-bg-card) h-12 flex items-center justify-center text-xs text-(--crit-fg-muted)">
+          No preview available
+        </div>
+    <% end %>
+    """
+  end
+end

--- a/lib/crit_web/helpers.ex
+++ b/lib/crit_web/helpers.ex
@@ -13,4 +13,124 @@ defmodule CritWeb.Helpers do
       true -> "#{div(diff, 604_800)}w ago"
     end
   end
+
+  @doc """
+  Classifies how recently a review has been touched. Drives the leading
+  status dot color in the reviews list (green / yellow / muted).
+  """
+  def activity_status(datetime) do
+    diff = DateTime.diff(DateTime.utc_now(), datetime, :second)
+
+    cond do
+      diff < 86_400 -> :active
+      diff < 604_800 -> :idle
+      true -> :stale
+    end
+  end
+
+  @doc """
+  Splits a path into `{directory, filename}` so the directory portion
+  can be dimmed and the filename emphasized in the reviews list.
+  """
+  def split_path(nil), do: {"", "Untitled"}
+
+  def split_path(path) when is_binary(path) do
+    case path |> String.split("/", trim: false) |> Enum.reverse() do
+      [filename] -> {"", filename}
+      [filename | rest] -> {(rest |> Enum.reverse() |> Enum.join("/")) <> "/", filename}
+    end
+  end
+
+  @snippet_lines 10
+
+  @doc """
+  Builds a snippet preview for the reviews list.
+
+  Returns one of:
+    * `{:markdown, safe_html}` — for `.md` / `.markdown` files; first ~10 source
+      lines rendered to HTML via Earmark, marked safe for direct injection.
+    * `{:code, [line_string, ...]}` — line-numbered plain-text preview for any
+      other file type (or markdown when rendering fails).
+    * `:none` — when there is no file content available.
+  """
+  def snippet_preview(_path, nil), do: :none
+  def snippet_preview(_path, ""), do: :none
+
+  def snippet_preview(path, content) when is_binary(content) do
+    lines = content |> String.split("\n") |> Enum.take(@snippet_lines)
+
+    cond do
+      markdown?(path) ->
+        case Earmark.as_html(Enum.join(lines, "\n"),
+               escape: true,
+               compact_output: true,
+               smartypants: false
+             ) do
+          {:ok, html, _} -> {:markdown, Phoenix.HTML.raw(html)}
+          _ -> {:code, lines}
+        end
+
+      true ->
+        {:code, lines}
+    end
+  end
+
+  defp markdown?(nil), do: false
+
+  defp markdown?(path) when is_binary(path) do
+    ext = path |> Path.extname() |> String.downcase()
+    ext in [".md", ".markdown", ".mdown", ".mkd"]
+  end
+
+  @doc """
+  Maps a file path to a highlight.js language id for syntax highlighting.
+  Returns `nil` when the extension is unknown — the snippet should render
+  as plain text in that case.
+  """
+  def language_for_path(nil), do: nil
+
+  def language_for_path(path) when is_binary(path) do
+    case path |> Path.extname() |> String.downcase() do
+      ".ex" -> "elixir"
+      ".exs" -> "elixir"
+      ".eex" -> "elixir"
+      ".heex" -> "elixir"
+      ".js" -> "javascript"
+      ".jsx" -> "javascript"
+      ".mjs" -> "javascript"
+      ".cjs" -> "javascript"
+      ".ts" -> "typescript"
+      ".tsx" -> "typescript"
+      ".py" -> "python"
+      ".rb" -> "ruby"
+      ".go" -> "go"
+      ".rs" -> "rust"
+      ".java" -> "java"
+      ".kt" -> "kotlin"
+      ".swift" -> "swift"
+      ".c" -> "c"
+      ".h" -> "c"
+      ".cpp" -> "cpp"
+      ".cc" -> "cpp"
+      ".hpp" -> "cpp"
+      ".cs" -> "csharp"
+      ".php" -> "php"
+      ".sh" -> "bash"
+      ".bash" -> "bash"
+      ".zsh" -> "bash"
+      ".fish" -> "bash"
+      ".sql" -> "sql"
+      ".yaml" -> "yaml"
+      ".yml" -> "yaml"
+      ".json" -> "json"
+      ".toml" -> "ini"
+      ".ini" -> "ini"
+      ".xml" -> "xml"
+      ".html" -> "xml"
+      ".css" -> "css"
+      ".scss" -> "scss"
+      ".dockerfile" -> "dockerfile"
+      _ -> nil
+    end
+  end
 end

--- a/lib/crit_web/live/dashboard_live.ex
+++ b/lib/crit_web/live/dashboard_live.ex
@@ -3,7 +3,8 @@ defmodule CritWeb.DashboardLive do
 
   alias Crit.Reviews
 
-  import CritWeb.Helpers, only: [time_ago: 1]
+  import CritWeb.Helpers, only: [time_ago: 1, split_path: 1]
+  import CritWeb.Components.ReviewSnippet
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -7,69 +7,101 @@
     current_page={:dashboard}
   />
 
-  <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">
-    <div class="flex justify-between items-center mb-3">
-      <span class="text-xs uppercase tracking-wider text-(--crit-fg-muted)">
-        My Reviews ({@review_count})
-      </span>
-      <span class="text-xs text-(--crit-fg-muted)">sorted by recent activity</span>
-    </div>
-    <div id="reviews-list" class="flex flex-col gap-2" phx-update="stream">
-      <div
-        :for={{dom_id, review} <- @streams.reviews}
-        id={dom_id}
-        class="flex items-center justify-between p-3 border border-(--crit-border) bg-(--crit-bg-card) rounded-lg hover:border-(--crit-brand) transition-colors group"
-      >
-        <div class="min-w-0">
-          <a
-            href={~p"/r/#{review.token}"}
-            class="text-sm font-semibold crit-link truncate block"
-          >
-            {review.first_file_path || "Untitled"}
-          </a>
-          <div class="text-xs text-(--crit-fg-muted) mt-0.5 flex items-center gap-3 flex-wrap">
-            <span class="flex items-center gap-1">
-              <.icon name="hero-chat-bubble-left-micro" class="size-3.5" />{review.comment_count} {if review.comment_count ==
-                                                                                                        1,
-                                                                                                      do:
-                                                                                                        "comment",
-                                                                                                      else:
-                                                                                                        "comments"}
-            </span>
-            <span class="flex items-center gap-1">
-              <.icon name="hero-document-text-micro" class="size-3.5" />{review.file_count} {if review.file_count ==
-                                                                                                  1,
-                                                                                                do:
-                                                                                                  "file",
-                                                                                                else:
-                                                                                                  "files"}
-            </span>
-            <span class="flex items-center gap-1 text-(--crit-fg-muted)">
-              <.icon name="hero-plus-circle-micro" class="size-3.5" />created {time_ago(
-                review.inserted_at
-              )}
-            </span>
-            <span class="flex items-center gap-1 text-(--crit-fg-muted)">
-              <.icon name="hero-clock-micro" class="size-3.5" />active {time_ago(
-                review.last_activity_at
-              )}
-            </span>
-          </div>
-        </div>
-        <button
-          phx-click="delete_review"
-          phx-value-id={review.id}
-          data-confirm="Delete this review? This cannot be undone."
-          class="text-(--crit-fg-muted) hover:text-red-400 transition-colors cursor-pointer shrink-0 ml-4"
-        >
-          <.icon name="hero-trash" class="size-4" />
-        </button>
-      </div>
+  <div class="max-w-7xl mx-auto w-full px-8 my-10 max-sm:px-4">
+    <div class="flex justify-between items-baseline mb-6 pb-4 border-b border-(--crit-border)">
+      <h1 class="text-3xl font-extrabold tracking-tight">
+        Reviews <span class="text-(--crit-fg-muted) font-normal ml-2">{@review_count}</span>
+      </h1>
+      <span class="text-xs text-(--crit-fg-muted) max-sm:hidden">Sorted by recent activity</span>
     </div>
 
     <%= if @review_count == 0 do %>
-      <div class="text-center py-12 text-(--crit-fg-muted) text-sm">
+      <div class="border border-(--crit-border) bg-(--crit-bg-card) rounded-lg p-12 text-center text-(--crit-fg-muted) text-sm">
         No reviews yet. Share a review from the Crit CLI to see it here.
+      </div>
+    <% else %>
+      <div
+        id="reviews-list"
+        class="flex flex-col gap-7"
+        phx-update="stream"
+        phx-hook=".SnippetHighlight"
+      >
+        <script :type={Phoenix.LiveView.ColocatedHook} name=".SnippetHighlight">
+          import hljs from "highlight.js"
+          export default {
+            mounted() { this.run() },
+            updated() { this.run() },
+            run() {
+              this.el.querySelectorAll('[data-snippet-line]:not([data-hl])').forEach(el => {
+                const lang = el.dataset.lang
+                if (lang && hljs.getLanguage(lang)) {
+                  try {
+                    el.innerHTML = hljs.highlight(el.textContent, { language: lang, ignoreIllegals: true }).value
+                  } catch (_) {}
+                }
+                el.setAttribute('data-hl', '1')
+              })
+            }
+          }
+        </script>
+        <article :for={{dom_id, review} <- @streams.reviews} id={dom_id} class="group">
+          <header class="flex items-start justify-between gap-4 mb-2 px-0.5">
+            <div class="min-w-0 flex flex-col gap-0.5">
+              <a
+                href={~p"/r/#{review.token}"}
+                class={[
+                  "text-[15px] font-semibold truncate block max-w-[720px] hover:underline",
+                  if(review.first_file_path,
+                    do: "text-(--crit-brand)",
+                    else: "text-(--crit-fg-secondary) italic"
+                  )
+                ]}
+              >
+                <% {dir, file} = split_path(review.first_file_path) %>
+                <span class="text-(--crit-fg-muted) font-normal">{dir}</span>{file}
+              </a>
+              <span class="text-xs text-(--crit-fg-muted)">
+                Active {time_ago(review.last_activity_at)}
+              </span>
+            </div>
+            <div class="flex items-center gap-3.5 text-xs text-(--crit-fg-secondary) shrink-0">
+              <span class="inline-flex items-center gap-1 tabular-nums">
+                <.icon name="hero-document-text-micro" class="size-3.5 text-(--crit-fg-muted)" />
+                <span class="text-(--crit-fg-primary) font-medium">{review.file_count}</span>
+                {if review.file_count == 1, do: "file", else: "files"}
+              </span>
+              <span class={[
+                "inline-flex items-center gap-1 tabular-nums",
+                review.comment_count == 0 && "text-(--crit-fg-muted)"
+              ]}>
+                <.icon
+                  name="hero-chat-bubble-left-micro"
+                  class="size-3.5 text-(--crit-fg-muted)"
+                />
+                <span class={[
+                  if(review.comment_count == 0,
+                    do: "text-(--crit-fg-muted)",
+                    else: "text-(--crit-fg-primary) font-medium"
+                  )
+                ]}>
+                  {review.comment_count}
+                </span>
+                {if review.comment_count == 1, do: "comment", else: "comments"}
+              </span>
+              <button
+                phx-click="delete_review"
+                phx-value-id={review.id}
+                data-confirm="Delete this review? This cannot be undone."
+                class="size-6 inline-flex items-center justify-center rounded text-(--crit-fg-muted) hover:text-(--crit-red) hover:bg-(--crit-bg-elevated) transition-colors cursor-pointer ml-1"
+                aria-label="Delete review"
+              >
+                <.icon name="hero-trash" class="size-3.5" />
+              </button>
+            </div>
+          </header>
+
+          <.review_snippet path={review.first_file_path} content={review.first_file_content} />
+        </article>
       </div>
     <% end %>
   </div>

--- a/lib/crit_web/live/overview_live.ex
+++ b/lib/crit_web/live/overview_live.ex
@@ -3,7 +3,8 @@ defmodule CritWeb.OverviewLive do
 
   alias Crit.{Reviews, Statistics}
 
-  import CritWeb.Helpers, only: [time_ago: 1]
+  import CritWeb.Helpers, only: [time_ago: 1, split_path: 1]
+  import CritWeb.Components.ReviewSnippet
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/crit_web/live/overview_live.html.heex
+++ b/lib/crit_web/live/overview_live.html.heex
@@ -9,29 +9,36 @@
     current_page={:overview}
   />
 
-  <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">
+  <div class="max-w-7xl mx-auto w-full px-8 my-10 max-sm:px-4">
+    <div class="flex justify-between items-baseline mb-6 pb-4 border-b border-(--crit-border)">
+      <h1 class="text-3xl font-extrabold tracking-tight">Overview</h1>
+      <span class="text-xs text-(--crit-fg-muted) max-sm:hidden">Last 30 days</span>
+    </div>
+
     <%!-- Stats cards --%>
     <%!-- Desktop: 3 separate cards. Mobile: single unified strip with dividers. --%>
     <div class="sm:grid sm:grid-cols-3 sm:gap-4 hidden">
       <div class="border border-(--crit-border) bg-(--crit-bg-card) rounded-lg p-5">
         <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted)">Reviews</div>
-        <div class="text-3xl font-bold text-(--crit-fg-primary) mt-1">
+        <div class="text-3xl font-bold text-(--crit-fg-primary) mt-1 tabular-nums">
           {@stats.total_reviews}
         </div>
-        <div class="text-xs text-green-400 mt-1">+{@stats.reviews_this_week} this week</div>
+        <div class="text-xs text-(--crit-green) mt-1">
+          +{@stats.reviews_this_week} this week
+        </div>
       </div>
       <div class="border border-(--crit-border) bg-(--crit-bg-card) rounded-lg p-5">
         <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted)">Comments</div>
-        <div class="text-3xl font-bold text-(--crit-fg-primary) mt-1">
+        <div class="text-3xl font-bold text-(--crit-fg-primary) mt-1 tabular-nums">
           {@stats.total_comments}
         </div>
-        <div class="text-xs text-green-400 mt-1">
+        <div class="text-xs text-(--crit-fg-muted) mt-1">
           ~{Float.round(@stats.avg_comments_per_review, 1)} per review
         </div>
       </div>
       <div class="border border-(--crit-border) bg-(--crit-bg-card) rounded-lg p-5">
         <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted)">Files</div>
-        <div class="text-3xl font-bold text-(--crit-fg-primary) mt-1">
+        <div class="text-3xl font-bold text-(--crit-fg-primary) mt-1 tabular-nums">
           {@stats.total_files}
         </div>
         <div class="text-xs text-(--crit-fg-muted) mt-1">
@@ -42,28 +49,28 @@
     <%!-- Mobile strip --%>
     <div class="flex sm:hidden border border-(--crit-border) bg-(--crit-bg-card) rounded-lg overflow-hidden">
       <div class="flex-1 px-4 py-3">
-        <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted) mb-1">
-          Reviews
+        <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted) mb-1">Reviews</div>
+        <div class="text-2xl font-bold text-(--crit-fg-primary) tabular-nums">
+          {@stats.total_reviews}
         </div>
-        <div class="text-2xl font-bold text-(--crit-fg-primary)">{@stats.total_reviews}</div>
-        <div class="text-xs text-green-400 mt-0.5">+{@stats.reviews_this_week} wk</div>
+        <div class="text-xs text-(--crit-green) mt-0.5">+{@stats.reviews_this_week} wk</div>
       </div>
       <div class="w-px bg-(--crit-border)"></div>
       <div class="flex-1 px-4 py-3">
-        <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted) mb-1">
-          Comments
-        </div>
-        <div class="text-2xl font-bold text-(--crit-fg-primary)">
+        <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted) mb-1">Comments</div>
+        <div class="text-2xl font-bold text-(--crit-fg-primary) tabular-nums">
           {@stats.total_comments}
         </div>
-        <div class="text-xs text-green-400 mt-0.5">
+        <div class="text-xs text-(--crit-fg-muted) mt-0.5">
           ~{Float.round(@stats.avg_comments_per_review, 1)}/review
         </div>
       </div>
       <div class="w-px bg-(--crit-border)"></div>
       <div class="flex-1 px-4 py-3">
         <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted) mb-1">Files</div>
-        <div class="text-2xl font-bold text-(--crit-fg-primary)">{@stats.total_files}</div>
+        <div class="text-2xl font-bold text-(--crit-fg-primary) tabular-nums">
+          {@stats.total_files}
+        </div>
         <div class="text-xs text-(--crit-fg-muted) mt-0.5">
           {format_bytes(@stats.total_storage_bytes)}
         </div>
@@ -98,7 +105,7 @@
         <%= if @oauth_configured do %>
           <a
             href={~p"/auth/login"}
-            class="inline-flex items-center gap-2 rounded-lg bg-gray-800 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700"
+            class="inline-flex items-center gap-2 rounded-lg bg-(--crit-brand-cta) hover:bg-(--crit-brand-cta-hover) px-4 py-2 text-sm font-bold text-(--crit-fg-on-brand) transition-colors"
           >
             Sign in with OAuth
           </a>
@@ -127,71 +134,135 @@
         <% end %>
       </div>
     <% else %>
-      <div class="mt-6">
-        <div class="flex justify-between items-center mb-3">
-          <span class="text-xs uppercase tracking-wider text-(--crit-fg-muted)">
-            All Reviews ({@review_count})
+      <div class="mt-10 pt-6 border-t border-(--crit-border)">
+        <div class="flex justify-between items-baseline mb-6">
+          <h2 class="text-2xl font-extrabold tracking-tight">
+            All Reviews
+            <span class="text-(--crit-fg-muted) font-normal ml-2">{@review_count}</span>
+          </h2>
+          <span class="text-xs text-(--crit-fg-muted) max-sm:hidden">
+            Sorted by recent activity
           </span>
-          <span class="text-xs text-(--crit-fg-muted)">sorted by recent activity</span>
-        </div>
-        <div id="reviews-list" class="flex flex-col gap-2" phx-update="stream">
-          <div
-            :for={{dom_id, review} <- @streams.reviews}
-            id={dom_id}
-            class="flex items-center justify-between p-3 border border-(--crit-border) bg-(--crit-bg-card) rounded-lg hover:border-(--crit-brand) transition-colors group"
-          >
-            <div class="min-w-0">
-              <a
-                href={~p"/r/#{review.token}"}
-                class="text-sm font-semibold crit-link truncate block"
-              >
-                {review.first_file_path || "Untitled"}
-              </a>
-              <div class="text-xs text-(--crit-fg-muted) mt-0.5 flex items-center gap-3 flex-wrap">
-                <span class="flex items-center gap-1">
-                  <.icon name="hero-chat-bubble-left-micro" class="size-3.5" />{review.comment_count} {if review.comment_count ==
-                                                                                                            1,
-                                                                                                          do:
-                                                                                                            "comment",
-                                                                                                          else:
-                                                                                                            "comments"}
-                </span>
-                <span class="flex items-center gap-1">
-                  <.icon name="hero-document-text-micro" class="size-3.5" />{review.file_count} {if review.file_count ==
-                                                                                                      1,
-                                                                                                    do:
-                                                                                                      "file",
-                                                                                                    else:
-                                                                                                      "files"}
-                </span>
-                <span class="flex items-center gap-1 text-(--crit-fg-muted)">
-                  <.icon name="hero-plus-circle-micro" class="size-3.5" />created {time_ago(
-                    review.inserted_at
-                  )}
-                </span>
-                <span class="flex items-center gap-1 text-(--crit-fg-muted)">
-                  <.icon name="hero-clock-micro" class="size-3.5" />active {time_ago(
-                    review.last_activity_at
-                  )}
-                </span>
-              </div>
-            </div>
-            <%= if not @oauth_configured or (not is_nil(@current_user) and (is_nil(review.user_id) or review.user_id == @current_user.id)) do %>
-              <button
-                phx-click="delete_review"
-                phx-value-id={review.id}
-                data-confirm="Delete this review? This cannot be undone."
-                class="text-(--crit-fg-muted) hover:text-red-400 transition-colors cursor-pointer shrink-0 ml-4"
-              >
-                <.icon name="hero-trash" class="size-4" />
-              </button>
-            <% end %>
-          </div>
         </div>
 
         <%= if @review_count == 0 do %>
-          <div class="text-center py-12 text-(--crit-fg-muted) text-sm">
+          <div class="border border-(--crit-border) bg-(--crit-bg-card) rounded-lg p-12 text-center text-(--crit-fg-muted) text-sm">
             No reviews yet. Share a review from the Crit CLI to see it here.
+          </div>
+        <% else %>
+          <div
+            id="reviews-list"
+            class="flex flex-col gap-7"
+            phx-update="stream"
+            phx-hook=".SnippetHighlight"
+          >
+            <script :type={Phoenix.LiveView.ColocatedHook} name=".SnippetHighlight">
+              import hljs from "highlight.js"
+              export default {
+                mounted() { this.run() },
+                updated() { this.run() },
+                run() {
+                  this.el.querySelectorAll('[data-snippet-line]:not([data-hl])').forEach(el => {
+                    const lang = el.dataset.lang
+                    if (lang && hljs.getLanguage(lang)) {
+                      try {
+                        el.innerHTML = hljs.highlight(el.textContent, { language: lang, ignoreIllegals: true }).value
+                      } catch (_) {}
+                    }
+                    el.setAttribute('data-hl', '1')
+                  })
+                }
+              }
+            </script>
+            <article
+              :for={{dom_id, review} <- @streams.reviews}
+              id={dom_id}
+              class="group"
+            >
+              <header class="flex items-start justify-between gap-4 mb-2 px-0.5">
+                <div class="min-w-0 flex items-start gap-3">
+                  <%= if review.author_avatar_url do %>
+                    <img
+                      src={review.author_avatar_url}
+                      alt={review.author_name || review.author_email || ""}
+                      class="size-7 rounded-full mt-0.5 shrink-0"
+                    />
+                  <% else %>
+                    <div class="size-7 rounded-full mt-0.5 shrink-0 bg-(--crit-bg-elevated) border border-(--crit-border) flex items-center justify-center text-[11px] font-semibold text-(--crit-fg-secondary) uppercase">
+                      {(review.author_name || review.author_email || "?")
+                      |> String.first()}
+                    </div>
+                  <% end %>
+                  <div class="min-w-0 flex flex-col gap-0.5">
+                    <div class="flex items-baseline gap-1.5 min-w-0">
+                      <%= if review.author_name || review.author_email do %>
+                        <span class="text-sm font-medium text-(--crit-fg-primary) truncate max-w-[160px]">
+                          {review.author_name || review.author_email}
+                        </span>
+                        <span class="text-(--crit-fg-muted) text-sm shrink-0">/</span>
+                      <% end %>
+                      <a
+                        href={~p"/r/#{review.token}"}
+                        class={[
+                          "text-[15px] font-semibold truncate hover:underline",
+                          if(review.first_file_path,
+                            do: "text-(--crit-brand)",
+                            else: "text-(--crit-fg-secondary) italic"
+                          )
+                        ]}
+                      >
+                        <% {dir, file} = split_path(review.first_file_path) %>
+                        <span class="text-(--crit-fg-muted) font-normal">{dir}</span>{file}
+                      </a>
+                    </div>
+                    <span class="text-xs text-(--crit-fg-muted)">
+                      Active {time_ago(review.last_activity_at)}
+                    </span>
+                  </div>
+                </div>
+                <div class="flex items-center gap-3.5 text-xs text-(--crit-fg-secondary) shrink-0">
+                  <span class="inline-flex items-center gap-1 tabular-nums">
+                    <.icon
+                      name="hero-document-text-micro"
+                      class="size-3.5 text-(--crit-fg-muted)"
+                    />
+                    <span class="text-(--crit-fg-primary) font-medium">{review.file_count}</span>
+                    {if review.file_count == 1, do: "file", else: "files"}
+                  </span>
+                  <span class={[
+                    "inline-flex items-center gap-1 tabular-nums",
+                    review.comment_count == 0 && "text-(--crit-fg-muted)"
+                  ]}>
+                    <.icon
+                      name="hero-chat-bubble-left-micro"
+                      class="size-3.5 text-(--crit-fg-muted)"
+                    />
+                    <span class={[
+                      if(review.comment_count == 0,
+                        do: "text-(--crit-fg-muted)",
+                        else: "text-(--crit-fg-primary) font-medium"
+                      )
+                    ]}>
+                      {review.comment_count}
+                    </span>
+                    {if review.comment_count == 1, do: "comment", else: "comments"}
+                  </span>
+                  <%= if not @oauth_configured or (not is_nil(@current_user) and (is_nil(review.user_id) or review.user_id == @current_user.id)) do %>
+                    <button
+                      phx-click="delete_review"
+                      phx-value-id={review.id}
+                      data-confirm="Delete this review? This cannot be undone."
+                      class="size-6 inline-flex items-center justify-center rounded text-(--crit-fg-muted) hover:text-(--crit-red) hover:bg-(--crit-bg-elevated) transition-colors cursor-pointer ml-1"
+                      aria-label="Delete review"
+                    >
+                      <.icon name="hero-trash" class="size-3.5" />
+                    </button>
+                  <% end %>
+                </div>
+              </header>
+
+              <.review_snippet path={review.first_file_path} content={review.first_file_content} />
+            </article>
           </div>
         <% end %>
       </div>

--- a/test/crit_web/components/review_snippet_test.exs
+++ b/test/crit_web/components/review_snippet_test.exs
@@ -17,9 +17,9 @@ defmodule CritWeb.Components.ReviewSnippetTest do
       assert html =~ ~s(data-lang="elixir")
       assert html =~ "defmodule Foo do"
       assert html =~ "def bar, do: :ok"
-      # line numbers
-      assert html =~ ">1<"
-      assert html =~ ">2<"
+      # line numbers (rendered inside the gutter span with whitespace)
+      assert html =~ ~r{>\s*1\s*<}
+      assert html =~ ~r{>\s*2\s*<}
     end
 
     test "omits data-lang for unknown extensions" do

--- a/test/crit_web/components/review_snippet_test.exs
+++ b/test/crit_web/components/review_snippet_test.exs
@@ -1,0 +1,81 @@
+defmodule CritWeb.Components.ReviewSnippetTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [render_component: 2]
+
+  alias CritWeb.Components.ReviewSnippet
+
+  describe "review_snippet/1" do
+    test "renders a code block with line numbers for source files" do
+      html =
+        render_component(&ReviewSnippet.review_snippet/1,
+          path: "lib/foo.ex",
+          content: "defmodule Foo do\n  def bar, do: :ok\nend"
+        )
+
+      assert html =~ "data-snippet-line"
+      assert html =~ ~s(data-lang="elixir")
+      assert html =~ "defmodule Foo do"
+      assert html =~ "def bar, do: :ok"
+      # line numbers
+      assert html =~ ">1<"
+      assert html =~ ">2<"
+    end
+
+    test "omits data-lang for unknown extensions" do
+      html =
+        render_component(&ReviewSnippet.review_snippet/1,
+          path: "data.unknownext",
+          content: "raw text"
+        )
+
+      assert html =~ "data-snippet-line"
+      refute html =~ "data-lang=\"elixir\""
+    end
+
+    test "renders rendered markdown for .md files" do
+      html =
+        render_component(&ReviewSnippet.review_snippet/1,
+          path: "README.md",
+          content: "# Hello\n\nWorld"
+        )
+
+      assert html =~ "<h1>Hello</h1>"
+      assert html =~ "<p>World</p>"
+    end
+
+    test "renders the empty state when content is missing" do
+      html =
+        render_component(&ReviewSnippet.review_snippet/1,
+          path: "lib/foo.ex",
+          content: nil
+        )
+
+      assert html =~ "No preview available"
+      refute html =~ "data-snippet-line"
+    end
+
+    test "renders the empty state when content is an empty string" do
+      html =
+        render_component(&ReviewSnippet.review_snippet/1,
+          path: "lib/foo.ex",
+          content: ""
+        )
+
+      assert html =~ "No preview available"
+    end
+
+    test "caps code preview at 10 lines" do
+      content = Enum.map_join(1..30, "\n", &"line #{&1}")
+
+      html =
+        render_component(&ReviewSnippet.review_snippet/1,
+          path: "lib/many.ex",
+          content: content
+        )
+
+      assert html =~ "line 10"
+      refute html =~ "line 11"
+    end
+  end
+end

--- a/test/crit_web/helpers_test.exs
+++ b/test/crit_web/helpers_test.exs
@@ -1,0 +1,148 @@
+defmodule CritWeb.HelpersTest do
+  use ExUnit.Case, async: true
+
+  alias CritWeb.Helpers
+
+  describe "time_ago/1" do
+    test "renders 'just now' under a minute" do
+      now = DateTime.utc_now()
+      assert Helpers.time_ago(now) == "just now"
+    end
+
+    test "renders minutes" do
+      ts = DateTime.add(DateTime.utc_now(), -120, :second)
+      assert Helpers.time_ago(ts) == "2m ago"
+    end
+
+    test "renders hours" do
+      ts = DateTime.add(DateTime.utc_now(), -7200, :second)
+      assert Helpers.time_ago(ts) == "2h ago"
+    end
+
+    test "renders days" do
+      ts = DateTime.add(DateTime.utc_now(), -3 * 86_400, :second)
+      assert Helpers.time_ago(ts) == "3d ago"
+    end
+
+    test "renders weeks" do
+      ts = DateTime.add(DateTime.utc_now(), -2 * 604_800, :second)
+      assert Helpers.time_ago(ts) == "2w ago"
+    end
+  end
+
+  describe "activity_status/1" do
+    test "active when within the last day" do
+      ts = DateTime.add(DateTime.utc_now(), -3600, :second)
+      assert Helpers.activity_status(ts) == :active
+    end
+
+    test "idle between one day and one week" do
+      ts = DateTime.add(DateTime.utc_now(), -3 * 86_400, :second)
+      assert Helpers.activity_status(ts) == :idle
+    end
+
+    test "stale beyond one week" do
+      ts = DateTime.add(DateTime.utc_now(), -8 * 86_400, :second)
+      assert Helpers.activity_status(ts) == :stale
+    end
+  end
+
+  describe "split_path/1" do
+    test "nil path returns Untitled" do
+      assert Helpers.split_path(nil) == {"", "Untitled"}
+    end
+
+    test "bare filename has empty directory" do
+      assert Helpers.split_path("README.md") == {"", "README.md"}
+    end
+
+    test "splits directory from filename" do
+      assert Helpers.split_path("apps/billing/lib/generator.ex") ==
+               {"apps/billing/lib/", "generator.ex"}
+    end
+
+    test "single-level directory" do
+      assert Helpers.split_path("scripts/migrate.sh") == {"scripts/", "migrate.sh"}
+    end
+  end
+
+  describe "snippet_preview/2" do
+    test "returns :none when content is nil" do
+      assert Helpers.snippet_preview("foo.ex", nil) == :none
+    end
+
+    test "returns :none when content is empty" do
+      assert Helpers.snippet_preview("foo.ex", "") == :none
+    end
+
+    test "returns {:code, lines} for non-markdown files" do
+      content = "defmodule Foo do\n  def bar, do: :ok\nend"
+      assert {:code, lines} = Helpers.snippet_preview("foo.ex", content)
+      assert lines == ["defmodule Foo do", "  def bar, do: :ok", "end"]
+    end
+
+    test "caps the snippet at 10 lines" do
+      content = Enum.map_join(1..50, "\n", &"line #{&1}")
+      assert {:code, lines} = Helpers.snippet_preview("foo.ex", content)
+      assert length(lines) == 10
+      assert hd(lines) == "line 1"
+    end
+
+    test "renders markdown for .md files" do
+      content = "# Title\n\nBody text"
+      assert {:markdown, html} = Helpers.snippet_preview("README.md", content)
+      rendered = Phoenix.HTML.safe_to_string(html)
+      assert rendered =~ "<h1>"
+      assert rendered =~ "Title"
+      assert rendered =~ "<p>"
+    end
+
+    test "recognizes other markdown extensions" do
+      assert {:markdown, _} = Helpers.snippet_preview("doc.markdown", "# x")
+      assert {:markdown, _} = Helpers.snippet_preview("doc.mdown", "# x")
+      assert {:markdown, _} = Helpers.snippet_preview("doc.mkd", "# x")
+    end
+
+    test "extension match is case-insensitive" do
+      assert {:markdown, _} = Helpers.snippet_preview("README.MD", "# x")
+    end
+  end
+
+  describe "language_for_path/1" do
+    test "returns nil for nil path" do
+      assert Helpers.language_for_path(nil) == nil
+    end
+
+    test "maps elixir extensions" do
+      assert Helpers.language_for_path("foo.ex") == "elixir"
+      assert Helpers.language_for_path("foo.exs") == "elixir"
+      assert Helpers.language_for_path("foo.heex") == "elixir"
+    end
+
+    test "maps javascript family" do
+      assert Helpers.language_for_path("foo.js") == "javascript"
+      assert Helpers.language_for_path("foo.mjs") == "javascript"
+      assert Helpers.language_for_path("foo.ts") == "typescript"
+      assert Helpers.language_for_path("foo.tsx") == "typescript"
+    end
+
+    test "maps shell scripts" do
+      assert Helpers.language_for_path("script.sh") == "bash"
+      assert Helpers.language_for_path("script.zsh") == "bash"
+    end
+
+    test "maps html and xml to xml" do
+      assert Helpers.language_for_path("page.html") == "xml"
+      assert Helpers.language_for_path("config.xml") == "xml"
+    end
+
+    test "returns nil for unknown extensions" do
+      assert Helpers.language_for_path("README") == nil
+      assert Helpers.language_for_path("data.unknownext") == nil
+    end
+
+    test "extension match is case-insensitive" do
+      assert Helpers.language_for_path("Foo.EX") == "elixir"
+    end
+  end
+end

--- a/test/crit_web/live/dashboard_live_test.exs
+++ b/test/crit_web/live/dashboard_live_test.exs
@@ -61,7 +61,7 @@ defmodule CritWeb.DashboardLiveTest do
 
       {:ok, _view, html} = live(conn, ~p"/dashboard")
 
-      assert html =~ "My Reviews (1)"
+      assert html =~ ~r/Reviews.*?>1</
       assert html =~ hd(review.files).file_path
       refute html =~ hd(other_review.files).file_path
     end
@@ -110,7 +110,7 @@ defmodule CritWeb.DashboardLiveTest do
 
       html = render(view)
       refute html =~ hd(review.files).file_path
-      assert html =~ "My Reviews (0)"
+      assert html =~ ~r/Reviews.*?>0</
     end
 
     test "cannot delete another user's review", %{conn: conn} do
@@ -151,8 +151,8 @@ defmodule CritWeb.DashboardLiveTest do
 
       {:ok, _view, html} = live(conn, ~p"/dashboard")
 
-      assert html =~ "1 comment"
-      assert html =~ "1 file"
+      assert html =~ ~r{>1</span>\s*comment}
+      assert html =~ ~r{>1</span>\s*file}
     end
 
     test "pluralizes counts correctly for multiple items", %{conn: conn} do
@@ -185,8 +185,8 @@ defmodule CritWeb.DashboardLiveTest do
 
       {:ok, _view, html} = live(conn, ~p"/dashboard")
 
-      assert html =~ "2 comments"
-      assert html =~ "2 files"
+      assert html =~ ~r{>2</span>\s*comments}
+      assert html =~ ~r{>2</span>\s*files}
     end
   end
 
@@ -208,7 +208,7 @@ defmodule CritWeb.DashboardLiveTest do
 
       {:ok, _view, html} = live(conn, ~p"/dashboard")
 
-      assert html =~ "My Reviews (2)"
+      assert html =~ ~r/Reviews.*?>2</
       assert html =~ "older.md"
       assert html =~ "newer.md"
     end
@@ -231,14 +231,14 @@ defmodule CritWeb.DashboardLiveTest do
         )
 
       {:ok, view, html} = live(conn, ~p"/dashboard")
-      assert html =~ "My Reviews (2)"
+      assert html =~ ~r/Reviews.*?>2</
 
       view
       |> element("button[phx-value-id='#{review1.id}']")
       |> render_click()
 
       html = render(view)
-      assert html =~ "My Reviews (1)"
+      assert html =~ ~r/Reviews.*?>1</
       refute html =~ "first.md"
       assert html =~ "second.md"
     end

--- a/test/crit_web/live/dashboard_live_test.exs
+++ b/test/crit_web/live/dashboard_live_test.exs
@@ -61,7 +61,7 @@ defmodule CritWeb.DashboardLiveTest do
 
       {:ok, _view, html} = live(conn, ~p"/dashboard")
 
-      assert html =~ ~r/Reviews.*?>1</
+      assert html =~ ~r/Reviews[^<]*<[^>]*>1</
       assert html =~ hd(review.files).file_path
       refute html =~ hd(other_review.files).file_path
     end
@@ -110,7 +110,7 @@ defmodule CritWeb.DashboardLiveTest do
 
       html = render(view)
       refute html =~ hd(review.files).file_path
-      assert html =~ ~r/Reviews.*?>0</
+      assert html =~ ~r/Reviews[^<]*<[^>]*>0</
     end
 
     test "cannot delete another user's review", %{conn: conn} do
@@ -151,8 +151,8 @@ defmodule CritWeb.DashboardLiveTest do
 
       {:ok, _view, html} = live(conn, ~p"/dashboard")
 
-      assert html =~ ~r{>1</span>\s*comment}
-      assert html =~ ~r{>1</span>\s*file}
+      assert html =~ ~r{>\s*1\s*</span>\s*comment}
+      assert html =~ ~r{>\s*1\s*</span>\s*file}
     end
 
     test "pluralizes counts correctly for multiple items", %{conn: conn} do
@@ -185,8 +185,8 @@ defmodule CritWeb.DashboardLiveTest do
 
       {:ok, _view, html} = live(conn, ~p"/dashboard")
 
-      assert html =~ ~r{>2</span>\s*comments}
-      assert html =~ ~r{>2</span>\s*files}
+      assert html =~ ~r{>\s*2\s*</span>\s*comments}
+      assert html =~ ~r{>\s*2\s*</span>\s*files}
     end
   end
 
@@ -208,7 +208,7 @@ defmodule CritWeb.DashboardLiveTest do
 
       {:ok, _view, html} = live(conn, ~p"/dashboard")
 
-      assert html =~ ~r/Reviews.*?>2</
+      assert html =~ ~r/Reviews[^<]*<[^>]*>2</
       assert html =~ "older.md"
       assert html =~ "newer.md"
     end
@@ -231,14 +231,14 @@ defmodule CritWeb.DashboardLiveTest do
         )
 
       {:ok, view, html} = live(conn, ~p"/dashboard")
-      assert html =~ ~r/Reviews.*?>2</
+      assert html =~ ~r/Reviews[^<]*<[^>]*>2</
 
       view
       |> element("button[phx-value-id='#{review1.id}']")
       |> render_click()
 
       html = render(view)
-      assert html =~ ~r/Reviews.*?>1</
+      assert html =~ ~r/Reviews[^<]*<[^>]*>1</
       refute html =~ "first.md"
       assert html =~ "second.md"
     end

--- a/test/crit_web/live/overview_live_test.exs
+++ b/test/crit_web/live/overview_live_test.exs
@@ -135,7 +135,7 @@ defmodule CritWeb.OverviewLiveTest do
 
       html = render(view)
       refute html =~ hd(review.files).file_path
-      assert html =~ ~r/All Reviews.*?>0</
+      assert html =~ ~r/All Reviews[^<]*<[^>]*>0</
     end
   end
 
@@ -145,7 +145,7 @@ defmodule CritWeb.OverviewLiveTest do
     test "shows empty message when no reviews", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/overview")
 
-      assert html =~ ~r/All Reviews.*?>0</
+      assert html =~ ~r/All Reviews[^<]*<[^>]*>0</
       assert html =~ "No reviews yet"
     end
   end
@@ -158,14 +158,14 @@ defmodule CritWeb.OverviewLiveTest do
       comment_fixture(review)
 
       {:ok, view, html} = live(conn, ~p"/overview")
-      assert html =~ ~r/All Reviews.*?>1</
+      assert html =~ ~r/All Reviews[^<]*<[^>]*>1</
 
       view
       |> element("button[phx-value-id='#{review.id}']")
       |> render_click()
 
       html = render(view)
-      assert html =~ ~r/All Reviews.*?>0</
+      assert html =~ ~r/All Reviews[^<]*<[^>]*>0</
     end
   end
 
@@ -212,8 +212,8 @@ defmodule CritWeb.OverviewLiveTest do
 
       {:ok, _view, html} = live(conn, ~p"/overview")
 
-      assert html =~ ~r{>1</span>\s*comment}
-      assert html =~ ~r{>1</span>\s*file}
+      assert html =~ ~r{>\s*1\s*</span>\s*comment}
+      assert html =~ ~r{>\s*1\s*</span>\s*file}
     end
 
     test "review links to /r/:token", %{conn: conn} do

--- a/test/crit_web/live/overview_live_test.exs
+++ b/test/crit_web/live/overview_live_test.exs
@@ -135,7 +135,7 @@ defmodule CritWeb.OverviewLiveTest do
 
       html = render(view)
       refute html =~ hd(review.files).file_path
-      assert html =~ "All Reviews (0)"
+      assert html =~ ~r/All Reviews.*?>0</
     end
   end
 
@@ -145,7 +145,7 @@ defmodule CritWeb.OverviewLiveTest do
     test "shows empty message when no reviews", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/overview")
 
-      assert html =~ "All Reviews (0)"
+      assert html =~ ~r/All Reviews.*?>0</
       assert html =~ "No reviews yet"
     end
   end
@@ -158,14 +158,14 @@ defmodule CritWeb.OverviewLiveTest do
       comment_fixture(review)
 
       {:ok, view, html} = live(conn, ~p"/overview")
-      assert html =~ "All Reviews (1)"
+      assert html =~ ~r/All Reviews.*?>1</
 
       view
       |> element("button[phx-value-id='#{review.id}']")
       |> render_click()
 
       html = render(view)
-      assert html =~ "All Reviews (0)"
+      assert html =~ ~r/All Reviews.*?>0</
     end
   end
 
@@ -212,8 +212,8 @@ defmodule CritWeb.OverviewLiveTest do
 
       {:ok, _view, html} = live(conn, ~p"/overview")
 
-      assert html =~ "1 comment"
-      assert html =~ "1 file"
+      assert html =~ ~r{>1</span>\s*comment}
+      assert html =~ ~r{>1</span>\s*file}
     end
 
     test "review links to /r/:token", %{conn: conn} do


### PR DESCRIPTION
## Summary

- Each review row on `/dashboard` and `/overview` now shows a 200px preview of the first file. `.md` files render as markdown; everything else renders as line-numbered, syntax-highlighted code with a fade-out at the bottom.
- Overview "All Reviews" rows now show the author avatar and name (`tomasz / generator.ex`-style).
- Filenames are no longer monospace in the title — only the actual code inside snippets is.
- Trash icon is always visible when the user is allowed to delete the review (was hover-revealed).
- Page heading style matches the marketing pages (`text-3xl font-extrabold tracking-tight`); pages now use `max-w-7xl` to align with the dashboard header.
- Overview cleanup: replaced hardcoded `gray-800` / `green-400` utilities with `crit-*` theme variables so light/dark modes render correctly; added a top "Overview" h1 above the stats so the section hierarchy reads cleanly.
- Snippet rendering lives in `CritWeb.Components.ReviewSnippet` (standalone module), imported into the two live views that use it.
- Syntax highlighting runs via a colocated `SnippetHighlight` hook on the list parent — re-runs on stream patches so new rows get highlighted too.

Schema-side: extended `list_reviews_with_counts/0` and `list_user_reviews_with_counts/1` to also project `first_file_content` (snippet source) and, for the overview query, the joined user's `name` / `email` / `avatar_url`.

## Test plan

- [ ] Visit `/dashboard` while logged in: each review shows the file path, file/comment counts, last-active timestamp, and a 200px preview. Markdown files render as prose; code files show line-numbered syntax highlighting.
- [ ] Visit `/overview` (admin / self-hosted): rows show author avatar + name to the left of the file path. Authors without an avatar show a letter chip fallback.
- [ ] Empty reviews list: shows the "No reviews yet" placeholder.
- [ ] Hover a row: title underlines, snippet border stays static (no border-color change on hover).
- [ ] Trash icon is visible at rest on every row the user can delete; hovering it tints red.
- [ ] Stream updates (after deleting a review) keep the remaining rows highlighted correctly.
- [ ] Light / dark theme: stats numbers, "+N this week" green text, and OAuth button render correctly in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)