### PR TITLE
fix: show Dashboard link on mobile marketing nav

### DIFF
--- a/lib/crit_web/components/layouts.ex
+++ b/lib/crit_web/components/layouts.ex
@@ -192,7 +192,7 @@ defmodule CritWeb.Layouts do
           </span>
 
           <%= if @current_user do %>
-            <div class="max-sm:hidden">
+            <div>
               <.nav_link href={~p"/dashboard"}>Dashboard</.nav_link>
             </div>
 

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -2,7 +2,7 @@
   <div class="crit-header">
     <div class="crit-header-bar">
       <div class="crit-header-left">
-        <a href="/" class="crit-header-title">
+        <a href="/dashboard" class="crit-header-title">
           <svg class="crit-header-logo" viewBox="50 -1600 3430 1650" aria-label="crit">
             <g transform="scale(1,-1)">
               <path


### PR DESCRIPTION
## Summary
- Show Dashboard link directly in the mobile header bar (not just inside hamburger menu) when logged in
- Review page logo now navigates to /dashboard instead of /

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (no review rendering changes)

## Test plan
- Verified 466 tests pass
- Manual: mobile marketing nav shows Dashboard link when logged in
- Manual: review page logo navigates to /dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)