### PR TITLE
feat: improve mobile review listings and link styling

### DIFF
--- a/lib/crit_web/components/review_snippet.ex
+++ b/lib/crit_web/components/review_snippet.ex
@@ -25,7 +25,7 @@ defmodule CritWeb.Components.ReviewSnippet do
     ~H"""
     <%= case @snippet do %>
       <% {:code, lines} -> %>
-        <div class="border border-(--crit-border) rounded-md bg-(--crit-bg-card) overflow-hidden h-[200px] relative font-mono text-xs leading-5">
+        <div class="border border-(--crit-border) rounded-md overflow-hidden h-[200px] relative font-mono text-xs leading-5">
           <div class="py-2">
             <div
               :for={{line, idx} <- Enum.with_index(lines, 1)}
@@ -35,18 +35,18 @@ defmodule CritWeb.Components.ReviewSnippet do
                 {idx}
               </span>
               <code
-                class="hljs whitespace-pre overflow-hidden bg-transparent p-0 text-(--crit-fg-primary)"
+                class="hljs whitespace-pre overflow-hidden !bg-transparent p-0 text-(--crit-fg-primary)"
                 data-snippet-line
                 data-lang={@lang}
                 phx-no-format
               >{line}</code>
             </div>
           </div>
-          <div class="absolute inset-x-0 bottom-0 h-9 bg-gradient-to-b from-transparent to-(--crit-bg-card) pointer-events-none">
+          <div class="absolute inset-x-0 bottom-0 h-9 bg-gradient-to-b from-transparent to-(--crit-bg-page) pointer-events-none">
           </div>
         </div>
       <% {:markdown, html} -> %>
-        <div class="border border-(--crit-border) rounded-md bg-(--crit-bg-card) overflow-hidden h-[200px] relative px-5 py-3 text-sm
+        <div class="border border-(--crit-border) rounded-md overflow-hidden h-[200px] relative px-5 py-3 text-sm
                     [&_h1]:text-base [&_h1]:font-semibold [&_h1]:mt-0 [&_h1]:mb-1.5 [&_h1]:pb-1 [&_h1]:border-b [&_h1]:border-(--crit-border)
                     [&_h2]:text-[15px] [&_h2]:font-semibold [&_h2]:mt-2.5 [&_h2]:mb-1
                     [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:mt-2 [&_h3]:mb-1
@@ -61,11 +61,11 @@ defmodule CritWeb.Components.ReviewSnippet do
                     [&_blockquote]:border-l-2 [&_blockquote]:border-(--crit-border-strong) [&_blockquote]:pl-3 [&_blockquote]:text-(--crit-fg-secondary)
                     [&_strong]:font-semibold [&_em]:italic">
           {html}
-          <div class="absolute inset-x-0 bottom-0 h-9 bg-gradient-to-b from-transparent to-(--crit-bg-card) pointer-events-none">
+          <div class="absolute inset-x-0 bottom-0 h-9 bg-gradient-to-b from-transparent to-(--crit-bg-page) pointer-events-none">
           </div>
         </div>
       <% :none -> %>
-        <div class="border border-dashed border-(--crit-border) rounded-md bg-(--crit-bg-card) h-12 flex items-center justify-center text-xs text-(--crit-fg-muted)">
+        <div class="border border-dashed border-(--crit-border) rounded-md h-12 flex items-center justify-center text-xs text-(--crit-fg-muted)">
           No preview available
         </div>
     <% end %>

--- a/lib/crit_web/controllers/page_html/changelog.html.heex
+++ b/lib/crit_web/controllers/page_html/changelog.html.heex
@@ -42,7 +42,7 @@
           <div class="max-sm:flex max-sm:items-baseline max-sm:gap-3">
             <a
               href={release.url}
-              class="font-mono text-lg font-semibold crit-link block"
+              class="font-mono text-lg font-semibold crit-link"
               target="_blank"
               rel="noopener"
             >
@@ -118,7 +118,7 @@
           <div class="max-sm:flex max-sm:items-baseline max-sm:gap-3">
             <a
               href={release.url}
-              class="font-mono text-lg font-semibold crit-link block"
+              class="font-mono text-lg font-semibold crit-link"
               target="_blank"
               rel="noopener"
             >

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -10,7 +10,7 @@
   <div class="max-w-7xl mx-auto w-full px-8 my-10 max-sm:px-4">
     <div class="flex justify-between items-baseline mb-6 pb-4 border-b border-(--crit-border)">
       <h1 class="text-3xl font-extrabold tracking-tight">
-        Reviews <span class="text-(--crit-fg-muted) font-normal ml-2">{@review_count}</span>
+        Your Reviews <span class="text-(--crit-fg-muted) font-normal ml-2">{@review_count}</span>
       </h1>
       <span class="text-xs text-(--crit-fg-muted) max-sm:hidden">Sorted by recent activity</span>
     </div>
@@ -222,14 +222,14 @@
           }
         </script>
         <article :for={{dom_id, review} <- @streams.reviews} id={dom_id} class="group">
-          <header class="flex items-start justify-between gap-4 mb-2 px-0.5">
-            <div class="min-w-0 flex flex-col gap-0.5">
+          <header class="flex items-start justify-between gap-4 mb-2 px-0.5 max-sm:flex-col max-sm:gap-1">
+            <div class="min-w-0 flex flex-col gap-0.5 max-sm:w-full">
               <a
                 href={~p"/r/#{review.token}"}
                 class={[
-                  "text-sm font-semibold truncate block max-w-[720px] hover:underline",
+                  "font-semibold truncate block w-fit max-w-[720px] max-sm:max-w-full leading-tight",
                   if(review.first_file_path,
-                    do: "text-(--crit-brand)",
+                    do: "crit-link",
                     else: "text-(--crit-fg-secondary) italic"
                   )
                 ]}
@@ -237,11 +237,14 @@
                 <% {dir, file} = split_path(review.first_file_path) %>
                 <span class="text-(--crit-fg-muted) font-normal">{dir}</span>{file}
               </a>
-              <span class="text-xs text-(--crit-fg-muted)">
+              <span class="text-xs text-(--crit-fg-muted) max-sm:hidden">
                 Active {time_ago(review.last_activity_at)}
               </span>
             </div>
-            <div class="flex items-center gap-3.5 text-xs text-(--crit-fg-secondary) shrink-0">
+            <div class="flex items-center gap-3.5 text-xs text-(--crit-fg-secondary) shrink-0 max-sm:w-full max-sm:gap-3">
+              <span class="hidden max-sm:inline-flex items-center text-(--crit-fg-muted)">
+                Active {time_ago(review.last_activity_at)}
+              </span>
               <span class="inline-flex items-center gap-1 tabular-nums">
                 <.icon name="hero-document-text-micro" class="size-3.5 text-(--crit-fg-muted)" />
                 <span class="text-(--crit-fg-primary) font-medium">{review.file_count}</span>
@@ -269,7 +272,7 @@
                 phx-click="delete_review"
                 phx-value-id={review.id}
                 data-confirm="Delete this review? This cannot be undone."
-                class="size-6 inline-flex items-center justify-center rounded text-(--crit-fg-muted) hover:text-(--crit-red) hover:bg-(--crit-bg-elevated) transition-colors cursor-pointer ml-1"
+                class="size-6 inline-flex items-center justify-center rounded text-(--crit-fg-muted) hover:text-(--crit-red) hover:bg-(--crit-bg-elevated) transition-colors cursor-pointer ml-1 max-sm:ml-auto"
                 aria-label="Delete review"
               >
                 <.icon name="hero-trash" class="size-3.5" />

--- a/lib/crit_web/live/overview_live.html.heex
+++ b/lib/crit_web/live/overview_live.html.heex
@@ -179,34 +179,34 @@
               id={dom_id}
               class="group"
             >
-              <header class="flex items-start justify-between gap-4 mb-2 px-0.5">
-                <div class="min-w-0 flex items-start gap-3">
+              <header class="flex items-start justify-between gap-4 mb-2 px-0.5 max-sm:flex-col max-sm:gap-1.5">
+                <div class="min-w-0 flex items-start gap-3 max-sm:w-full max-sm:items-center">
                   <%= if review.author_avatar_url do %>
                     <img
                       src={review.author_avatar_url}
                       alt={review.author_name || review.author_email || ""}
-                      class="size-7 rounded-full mt-0.5 shrink-0"
+                      class="size-7 rounded-full mt-0.5 shrink-0 max-sm:mt-0"
                     />
                   <% else %>
-                    <div class="size-7 rounded-full mt-0.5 shrink-0 bg-(--crit-bg-elevated) border border-(--crit-border) flex items-center justify-center text-[11px] font-semibold text-(--crit-fg-secondary) uppercase">
+                    <div class="size-7 rounded-full mt-0.5 shrink-0 max-sm:mt-0 bg-(--crit-bg-elevated) border border-(--crit-border) flex items-center justify-center text-xs font-semibold text-(--crit-fg-secondary) uppercase">
                       {(review.author_name || review.author_email || "?")
                       |> String.first()}
                     </div>
                   <% end %>
-                  <div class="min-w-0 flex flex-col gap-0.5">
+                  <div class="min-w-0 flex flex-col gap-0.5 max-sm:w-full">
                     <div class="flex items-baseline gap-1.5 min-w-0">
                       <%= if review.author_name || review.author_email do %>
-                        <span class="text-sm font-medium text-(--crit-fg-primary) truncate max-w-[160px]">
+                        <span class="font-medium text-(--crit-fg-primary) truncate max-w-[160px] max-sm:max-w-[180px]">
                           {review.author_name || review.author_email}
                         </span>
-                        <span class="text-(--crit-fg-muted) text-sm shrink-0">/</span>
+                        <span class="text-(--crit-fg-muted) shrink-0">/</span>
                       <% end %>
                       <a
                         href={~p"/r/#{review.token}"}
                         class={[
-                          "text-[15px] font-semibold truncate hover:underline",
+                          "font-semibold truncate leading-tight",
                           if(review.first_file_path,
-                            do: "text-(--crit-brand)",
+                            do: "crit-link",
                             else: "text-(--crit-fg-secondary) italic"
                           )
                         ]}
@@ -215,12 +215,15 @@
                         <span class="text-(--crit-fg-muted) font-normal">{dir}</span>{file}
                       </a>
                     </div>
-                    <span class="text-xs text-(--crit-fg-muted)">
+                    <span class="text-xs text-(--crit-fg-muted) max-sm:hidden">
                       Active {time_ago(review.last_activity_at)}
                     </span>
                   </div>
                 </div>
-                <div class="flex items-center gap-3.5 text-xs text-(--crit-fg-secondary) shrink-0">
+                <div class="flex items-center gap-3.5 text-xs text-(--crit-fg-secondary) shrink-0 max-sm:w-full max-sm:gap-3">
+                  <span class="hidden max-sm:inline-flex items-center text-(--crit-fg-muted)">
+                    Active {time_ago(review.last_activity_at)}
+                  </span>
                   <span class="inline-flex items-center gap-1 tabular-nums">
                     <.icon
                       name="hero-document-text-micro"
@@ -252,7 +255,7 @@
                       phx-click="delete_review"
                       phx-value-id={review.id}
                       data-confirm="Delete this review? This cannot be undone."
-                      class="size-6 inline-flex items-center justify-center rounded text-(--crit-fg-muted) hover:text-(--crit-red) hover:bg-(--crit-bg-elevated) transition-colors cursor-pointer ml-1"
+                      class="size-6 inline-flex items-center justify-center rounded text-(--crit-fg-muted) hover:text-(--crit-red) hover:bg-(--crit-bg-elevated) transition-colors cursor-pointer ml-1 max-sm:ml-auto"
                       aria-label="Delete review"
                     >
                       <.icon name="hero-trash" class="size-3.5" />


### PR DESCRIPTION
## Summary

- **Mobile layout**: stack the review header vertically on `max-sm:` so the title gets full width (matches gist.github.com pattern). Author/title row stays compact, meta + delete drop to a row underneath. Desktop layout untouched.
- **Snippet card**: drop the solid `--crit-bg-card` fill — was jarring against the page in light mode. Border-only now; bottom gradient fade blends to `--crit-bg-page`. Also forced `!bg-transparent` on the per-line `<code class="hljs">` so the highlight.js theme doesn't paint a dark fill in dark mode.
- **Link styling**: file links in dashboard/overview now use `.crit-link` (animated border-bottom on hover) instead of brand-color + `hover:underline`. Added `leading-tight` so the underline sits closer to the text since the link is `block`.
- **Font size audit**: replaced arbitrary `text-[11px]` and `text-[15px]` in overview with scale tokens; dropped redundant `text-base` on items that inherit it; matched dashboard's title size to overview.
- **Heading**: dashboard heading is now "Your Reviews".
- **Drive-by**: removed stray `block` class from the changelog version link.

## Test plan

- [x] `mix precommit` — 466 tests passing, format clean, sobelow clean, no vuln
- [x] Manual: dashboard + overview at desktop and `max-sm` widths, light + dark themes
- [x] Snippet preview no longer shows white fill (light) or dark hljs fill (dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)