### PR TITLE
fix: align comment + button position with crit CLI

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -840,24 +840,52 @@
   align-items: flex-start;
   justify-content: flex-end;
 }
-.line-gutter:hover .line-num { display: none; }
 .line-gutter:hover .line-add { display: flex; }
 body.dragging { user-select: none; cursor: grabbing; }
-body.dragging .line-block.selected .line-gutter .line-num { display: none; }
-body.dragging .line-block.selected .line-gutter .line-add { display: flex; }
+body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; }
+/* Document-path comment gutter: overlay column between line numbers and content */
+.line-gutter > .line-comment-gutter {
+  position: absolute;
+  right: -10px;
+  top: 0;
+  bottom: 0;
+  width: 20px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 1px;
+  z-index: 5;
+}
+/* Blue connecting line between drag endpoints */
+.line-block.drag-range .line-comment-gutter::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  margin-left: -1px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--crit-brand);
+  pointer-events: none;
+  z-index: 0;
+}
+.line-block.drag-range-start .line-comment-gutter::after { top: 10px; }
+.line-block.drag-range-end .line-comment-gutter::after { bottom: calc(100% - 10px); }
+.line-block.drag-range-start.drag-range-end .line-comment-gutter::after { display: none; }
 .line-num { padding-top: 1px; line-height: inherit; }
 .line-add {
   display: none;
   align-items: center;
   justify-content: center;
   width: 20px; height: 20px;
-  margin-top: 1px;
   border-radius: 4px;
   background: var(--crit-brand);
   color: #fff;
   font-size: 14px;
   font-weight: 700;
   line-height: 1;
+  position: relative;
+  z-index: 2;
 }
 
 /* ===== Line Content ===== */

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1481,6 +1481,15 @@ function renderRoundDiffBlock(ctx, block, diffClass, file, commentable, blockInd
       block.startLine >= ctx.selectionStart && block.endLine <= ctx.selectionEnd
     if (inCurrentSelection) lineBlockEl.classList.add('selected')
     if (hasFormForBlock && !inCurrentSelection) lineBlockEl.classList.add('form-selected')
+    if (inCurrentSelection && ctx.dragState) {
+      const ds = ctx.dragState
+      const isAnchor = block.startLine <= ds.anchorEndLine && block.endLine >= ds.anchorStartLine
+      const isCurrent = block.startLine <= ds.currentEndLine && block.endLine >= ds.currentStartLine
+      if (isAnchor || isCurrent) lineBlockEl.classList.add('drag-endpoint')
+      lineBlockEl.classList.add('drag-range')
+      if (block.startLine === ctx.selectionStart) lineBlockEl.classList.add('drag-range-start')
+      if (block.endLine === ctx.selectionEnd) lineBlockEl.classList.add('drag-range-end')
+    }
 
     // Comment gutter
     const commentGutter = document.createElement('div')
@@ -2004,6 +2013,15 @@ function renderBlock(ctx, block, index, commentsMap, commentedLineSet, filePath)
   if (hasFormForBlock && !inCurrentSelection) {
     lineBlockEl.classList.add("form-selected")
   }
+  if (inCurrentSelection && ctx.dragState) {
+    const ds = ctx.dragState
+    const isAnchor = block.startLine <= ds.anchorEndLine && block.endLine >= ds.anchorStartLine
+    const isCurrent = block.startLine <= ds.currentEndLine && block.endLine >= ds.currentStartLine
+    if (isAnchor || isCurrent) lineBlockEl.classList.add("drag-endpoint")
+    lineBlockEl.classList.add("drag-range")
+    if (block.startLine === ctx.selectionStart) lineBlockEl.classList.add("drag-range-start")
+    if (block.endLine === ctx.selectionEnd) lineBlockEl.classList.add("drag-range-end")
+  }
 
   // Gutter
   const gutter = document.createElement("div")
@@ -2015,12 +2033,15 @@ function renderBlock(ctx, block, index, commentsMap, commentedLineSet, filePath)
   lineNum.className = "line-num"
   lineNum.textContent = block.startLine === block.endLine ? block.startLine : String(block.startLine)
 
+  const commentGutter = document.createElement("div")
+  commentGutter.className = "line-comment-gutter"
   const lineAdd = document.createElement("span")
   lineAdd.className = "line-add"
   lineAdd.textContent = "+"
+  commentGutter.appendChild(lineAdd)
 
   gutter.appendChild(lineNum)
-  gutter.appendChild(lineAdd)
+  gutter.appendChild(commentGutter)
   gutter.addEventListener("mousedown", (e) => handleGutterMouseDown(e, ctx))
 
   // Content


### PR DESCRIPTION
## Summary
- Render the `+` comment button in a 20px overlay column between line numbers and content (document path), matching crit/ layout.
- During multi-line drag-select, only show `+` at anchor + current endpoints with a connecting blue line, instead of stacking `+` on every selected line.

## Review
- [x] mix precommit: passed (466 tests, 0 failures)

## Test plan
- Drag-select a range of lines on a `/r/:token` review and verify only endpoint `+` buttons render, with a vertical blue connector between.
- Hover a single line; `+` appears in the gap, line numbers stay visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)