### PR TITLE
fix: clarify Hide resolved comments label, hide Reviews link in selfhosted

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3780,9 +3780,9 @@ function renderSettingsPane() {
 
   // Hide resolved row
   html += '<div class="settings-display-row">'
-  html += '<span class="settings-display-label">Hide resolved</span>'
+  html += '<span class="settings-display-label">Hide resolved comments</span>'
   html += '<label class="comments-panel-switch">'
-  html += '<input type="checkbox" id="hideResolvedToggle" aria-label="Hide resolved"' + (hideResolved ? ' checked' : '') + '>'
+  html += '<input type="checkbox" id="hideResolvedToggle" aria-label="Hide resolved comments"' + (hideResolved ? ' checked' : '') + '>'
   html += '<span class="comments-panel-switch-track"><span class="comments-panel-switch-thumb"></span></span>'
   html += '</label>'
   html += '</div>'

--- a/lib/crit_web/live/settings_live.html.heex
+++ b/lib/crit_web/live/settings_live.html.heex
@@ -23,7 +23,7 @@
               Account
             </a>
           </li>
-          <li>
+          <li :if={!@selfhosted}>
             <a
               href="#reviews"
               class="block px-3 py-2 text-sm rounded-md text-(--crit-fg-muted) hover:text-(--crit-fg-primary) hover:bg-(--crit-bg-card) transition-colors max-md:rounded-none"


### PR DESCRIPTION
## Summary
- Settings label "Hide resolved" → "Hide resolved comments" (clearer; aria-label too)
- Hide the "Reviews" sidebar link in selfhosted mode (the section was already gated)

Companion: tomasz-tomczyk/crit#364

## Test plan
- [x] mix precommit passes (466 tests, 0 failures)
- [ ] Verify in selfhosted mode that Reviews nav link is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)