### PR TITLE
feat: add review meta header with author and owner delete

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2135,6 +2135,17 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 }
 .crit-viewed-count.all-viewed { color: var(--crit-green); }
 
+/* ===== Review meta bar wrapper (constrains shared listing header to content width) ===== */
+.crit-review-meta {
+  border-bottom: 1px solid var(--crit-border);
+  background: var(--crit-bg-card);
+}
+.crit-review-meta-inner {
+  max-width: var(--crit-content-width);
+  margin: 0 auto;
+  padding: 12px 20px;
+}
+
 /* ===== Main layout (flex row: tree | content | comments) ===== */
 .crit-main-layout {
   display: flex;

--- a/e2e/review-page.spec.ts
+++ b/e2e/review-page.spec.ts
@@ -18,10 +18,8 @@ test.describe("Review Page — Loading", () => {
   test("renders the review page with document content", async ({ page }) => {
     await loadReview(page, token);
 
-    // The header should show the filename
-    await expect(page.locator(".crit-header-filename")).toContainText(
-      "example.md"
-    );
+    // The meta bar should show the filename
+    await expect(page.locator(".crit-review-meta")).toContainText("example.md");
 
     // The document should have rendered line blocks
     const lineBlocks = page.locator(".line-block");

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -13,6 +13,7 @@ defmodule Crit.Reviews do
         from r in Review,
           where: r.token == ^token,
           preload: [
+            :user,
             comments:
               ^from(c in Comment,
                 where: is_nil(c.parent_id),

--- a/lib/crit_web/components/review_listing_header.ex
+++ b/lib/crit_web/components/review_listing_header.ex
@@ -1,0 +1,137 @@
+defmodule CritWeb.Components.ReviewListingHeader do
+  @moduledoc """
+  Header row used by the dashboard review list and the review page meta bar.
+
+  Renders title (dimmed dir + emphasized filename), an "Active {time_ago}"
+  subline, and a stats group on the right (file count, comment count, optional
+  delete). The title can be a link; an optional author chip replaces the
+  "Active" subline with avatar + name when provided.
+  """
+
+  use Phoenix.Component
+
+  import CritWeb.Helpers, only: [time_ago: 1, split_path: 1]
+  import CritWeb.CoreComponents, only: [icon: 1]
+
+  attr :path, :string, default: nil
+  attr :last_activity_at, :any, required: true
+  attr :file_count, :integer, required: true
+  attr :comment_count, :integer, required: true
+  attr :link_to, :string, default: nil
+  attr :author, :map, default: nil
+
+  slot :actions
+
+  def review_listing_header(assigns) do
+    {dir, file} = split_path(assigns.path)
+    assigns = assigns |> assign(:dir, dir) |> assign(:file, file)
+
+    ~H"""
+    <header class="flex items-start justify-between gap-4 max-sm:flex-col max-sm:gap-1.5">
+      <div class={[
+        "min-w-0 flex max-sm:w-full",
+        if(@author,
+          do: "items-start gap-3 max-sm:items-center",
+          else: "flex-col gap-0.5"
+        )
+      ]}>
+        <%= if @author do %>
+          <%= if @author.avatar_url do %>
+            <img
+              src={@author.avatar_url}
+              alt={@author.name || @author.email || ""}
+              class="size-7 rounded-full mt-0.5 shrink-0 max-sm:mt-0"
+            />
+          <% else %>
+            <div class="size-7 rounded-full mt-0.5 shrink-0 max-sm:mt-0 bg-(--crit-bg-elevated) border border-(--crit-border) flex items-center justify-center text-xs font-semibold text-(--crit-fg-secondary) uppercase">
+              {String.first(@author.name || @author.email || "?")}
+            </div>
+          <% end %>
+          <div class="min-w-0 flex flex-col gap-0.5 max-sm:w-full">
+            <div class="flex items-baseline gap-1.5 min-w-0">
+              <%= if @author.name || @author.email do %>
+                <span class="font-medium text-(--crit-fg-primary) truncate max-w-[160px] max-sm:max-w-[180px]">
+                  {@author.name || @author.email}
+                </span>
+                <span class="text-(--crit-fg-muted) shrink-0">/</span>
+              <% end %>
+              <%= if @link_to do %>
+                <.link
+                  navigate={@link_to}
+                  class={[
+                    "font-semibold truncate leading-tight",
+                    if(@path, do: "crit-link", else: "text-(--crit-fg-secondary) italic")
+                  ]}
+                >
+                  <span class="text-(--crit-fg-muted) font-normal">{@dir}</span>{@file}
+                </.link>
+              <% else %>
+                <span class={[
+                  "font-semibold truncate leading-tight",
+                  if(@path,
+                    do: "text-(--crit-fg-primary)",
+                    else: "text-(--crit-fg-secondary) italic"
+                  )
+                ]}>
+                  <span class="text-(--crit-fg-muted) font-normal">{@dir}</span>{@file}
+                </span>
+              <% end %>
+            </div>
+            <span class="text-xs text-(--crit-fg-muted) max-sm:hidden">
+              Active {time_ago(@last_activity_at)}
+            </span>
+          </div>
+        <% else %>
+          <%= if @link_to do %>
+            <.link
+              navigate={@link_to}
+              class={[
+                "font-semibold truncate block w-fit max-w-[720px] max-sm:max-w-full leading-tight",
+                if(@path, do: "crit-link", else: "text-(--crit-fg-secondary) italic")
+              ]}
+            >
+              <span class="text-(--crit-fg-muted) font-normal">{@dir}</span>{@file}
+            </.link>
+          <% else %>
+            <span class={[
+              "font-semibold truncate block max-w-[720px] max-sm:max-w-full leading-tight",
+              if(@path, do: "text-(--crit-fg-primary)", else: "text-(--crit-fg-secondary) italic")
+            ]}>
+              <span class="text-(--crit-fg-muted) font-normal">{@dir}</span>{@file}
+            </span>
+          <% end %>
+          <span class="text-xs text-(--crit-fg-muted) max-sm:hidden">
+            Active {time_ago(@last_activity_at)}
+          </span>
+        <% end %>
+      </div>
+      <div class="flex items-center gap-3.5 text-xs text-(--crit-fg-secondary) shrink-0 max-sm:w-full max-sm:gap-3">
+        <span class="hidden max-sm:inline-flex items-center text-(--crit-fg-muted)">
+          Active {time_ago(@last_activity_at)}
+        </span>
+        <span class="inline-flex items-center gap-1 tabular-nums">
+          <.icon name="hero-document-text-micro" class="size-3.5 text-(--crit-fg-muted)" />
+          <span class="text-(--crit-fg-primary) font-medium">{@file_count}</span>
+          {if @file_count == 1, do: "file", else: "files"}
+        </span>
+        <span class={[
+          "inline-flex items-center gap-1 tabular-nums",
+          @comment_count == 0 && "text-(--crit-fg-muted)"
+        ]}>
+          <.icon name="hero-chat-bubble-left-micro" class="size-3.5 text-(--crit-fg-muted)" />
+          <span class={[
+            if(@comment_count == 0,
+              do: "text-(--crit-fg-muted)",
+              else: "text-(--crit-fg-primary) font-medium"
+            )
+          ]}>
+            {@comment_count}
+          </span>
+          {if @comment_count == 1, do: "comment", else: "comments"}
+        </span>
+        {render_slot(@actions)}
+      </div>
+    </header>
+    """
+  end
+end

--- a/lib/crit_web/live/dashboard_live.ex
+++ b/lib/crit_web/live/dashboard_live.ex
@@ -3,8 +3,8 @@ defmodule CritWeb.DashboardLive do
 
   alias Crit.Reviews
 
-  import CritWeb.Helpers, only: [time_ago: 1, split_path: 1]
   import CritWeb.Components.ReviewSnippet
+  import CritWeb.Components.ReviewListingHeader
 
   @impl true
   def mount(_params, _session, socket) do
@@ -21,26 +21,5 @@ defmodule CritWeb.DashboardLive do
       |> assign(:review_count, length(reviews))
 
     {:ok, socket, layout: false}
-  end
-
-  @impl true
-  def handle_event("delete_review", %{"id" => id}, socket) do
-    current_user = socket.assigns.current_user
-
-    case Reviews.delete_review(id, owner_id: current_user.id) do
-      :ok ->
-        reviews = Reviews.list_user_reviews_with_counts(current_user.id)
-
-        {:noreply,
-         socket
-         |> stream(:reviews, reviews, reset: true)
-         |> assign(:review_count, length(reviews))}
-
-      {:error, :unauthorized} ->
-        {:noreply, put_flash(socket, :error, "You can only delete your own reviews.")}
-
-      {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to delete review.")}
-    end
   end
 end

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -223,13 +223,13 @@
         </script>
         <article :for={{dom_id, review} <- @streams.reviews} id={dom_id} class="group">
           <div class="mb-2 px-0.5">
-          <.review_listing_header
-            path={review.first_file_path}
-            last_activity_at={review.last_activity_at}
-            file_count={review.file_count}
-            comment_count={review.comment_count}
-            link_to={~p"/r/#{review.token}"}
-          />
+            <.review_listing_header
+              path={review.first_file_path}
+              last_activity_at={review.last_activity_at}
+              file_count={review.file_count}
+              comment_count={review.comment_count}
+              link_to={~p"/r/#{review.token}"}
+            />
           </div>
           <.review_snippet path={review.first_file_path} content={review.first_file_content} />
         </article>

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -222,64 +222,15 @@
           }
         </script>
         <article :for={{dom_id, review} <- @streams.reviews} id={dom_id} class="group">
-          <header class="flex items-start justify-between gap-4 mb-2 px-0.5 max-sm:flex-col max-sm:gap-1">
-            <div class="min-w-0 flex flex-col gap-0.5 max-sm:w-full">
-              <a
-                href={~p"/r/#{review.token}"}
-                class={[
-                  "font-semibold truncate block w-fit max-w-[720px] max-sm:max-w-full leading-tight",
-                  if(review.first_file_path,
-                    do: "crit-link",
-                    else: "text-(--crit-fg-secondary) italic"
-                  )
-                ]}
-              >
-                <% {dir, file} = split_path(review.first_file_path) %>
-                <span class="text-(--crit-fg-muted) font-normal">{dir}</span>{file}
-              </a>
-              <span class="text-xs text-(--crit-fg-muted) max-sm:hidden">
-                Active {time_ago(review.last_activity_at)}
-              </span>
-            </div>
-            <div class="flex items-center gap-3.5 text-xs text-(--crit-fg-secondary) shrink-0 max-sm:w-full max-sm:gap-3">
-              <span class="hidden max-sm:inline-flex items-center text-(--crit-fg-muted)">
-                Active {time_ago(review.last_activity_at)}
-              </span>
-              <span class="inline-flex items-center gap-1 tabular-nums">
-                <.icon name="hero-document-text-micro" class="size-3.5 text-(--crit-fg-muted)" />
-                <span class="text-(--crit-fg-primary) font-medium">{review.file_count}</span>
-                {if review.file_count == 1, do: "file", else: "files"}
-              </span>
-              <span class={[
-                "inline-flex items-center gap-1 tabular-nums",
-                review.comment_count == 0 && "text-(--crit-fg-muted)"
-              ]}>
-                <.icon
-                  name="hero-chat-bubble-left-micro"
-                  class="size-3.5 text-(--crit-fg-muted)"
-                />
-                <span class={[
-                  if(review.comment_count == 0,
-                    do: "text-(--crit-fg-muted)",
-                    else: "text-(--crit-fg-primary) font-medium"
-                  )
-                ]}>
-                  {review.comment_count}
-                </span>
-                {if review.comment_count == 1, do: "comment", else: "comments"}
-              </span>
-              <button
-                phx-click="delete_review"
-                phx-value-id={review.id}
-                data-confirm="Delete this review? This cannot be undone."
-                class="size-6 inline-flex items-center justify-center rounded text-(--crit-fg-muted) hover:text-(--crit-red) hover:bg-(--crit-bg-elevated) transition-colors cursor-pointer ml-1 max-sm:ml-auto"
-                aria-label="Delete review"
-              >
-                <.icon name="hero-trash" class="size-3.5" />
-              </button>
-            </div>
-          </header>
-
+          <div class="mb-2 px-0.5">
+          <.review_listing_header
+            path={review.first_file_path}
+            last_activity_at={review.last_activity_at}
+            file_count={review.file_count}
+            comment_count={review.comment_count}
+            link_to={~p"/r/#{review.token}"}
+          />
+          </div>
           <.review_snippet path={review.first_file_path} content={review.first_file_content} />
         </article>
       </div>

--- a/lib/crit_web/live/overview_live.ex
+++ b/lib/crit_web/live/overview_live.ex
@@ -3,8 +3,8 @@ defmodule CritWeb.OverviewLive do
 
   alias Crit.{Reviews, Statistics}
 
-  import CritWeb.Helpers, only: [time_ago: 1, split_path: 1]
   import CritWeb.Components.ReviewSnippet
+  import CritWeb.Components.ReviewListingHeader
 
   @impl true
   def mount(_params, _session, socket) do
@@ -37,35 +37,6 @@ defmodule CritWeb.OverviewLive do
     {:ok, socket, layout: false}
   end
 
-  @impl true
-  def handle_event("delete_review", %{"id" => id}, socket) do
-    %{oauth_configured: oauth_configured, current_user: current_user} = socket.assigns
-
-    opts =
-      if oauth_configured && current_user do
-        [owner_id: current_user.id]
-      else
-        []
-      end
-
-    case Reviews.delete_review(id, opts) do
-      :ok ->
-        reviews = Reviews.list_reviews_with_counts()
-        stats = Statistics.dashboard_stats()
-
-        {:noreply,
-         socket
-         |> stream(:reviews, reviews, reset: true)
-         |> assign(:review_count, length(reviews))
-         |> assign(:stats, stats)}
-
-      {:error, :unauthorized} ->
-        {:noreply, put_flash(socket, :error, "You can only delete your own reviews.")}
-
-      {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to delete review.")}
-    end
-  end
 
   defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
   defp format_bytes(bytes) when bytes < 1_048_576, do: "#{Float.round(bytes / 1024, 1)} KB"

--- a/lib/crit_web/live/overview_live.ex
+++ b/lib/crit_web/live/overview_live.ex
@@ -37,7 +37,6 @@ defmodule CritWeb.OverviewLive do
     {:ok, socket, layout: false}
   end
 
-
   defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
   defp format_bytes(bytes) when bytes < 1_048_576, do: "#{Float.round(bytes / 1024, 1)} KB"
   defp format_bytes(bytes), do: "#{Float.round(bytes / 1_048_576, 1)} MB"

--- a/lib/crit_web/live/overview_live.html.heex
+++ b/lib/crit_web/live/overview_live.html.heex
@@ -179,91 +179,24 @@
               id={dom_id}
               class="group"
             >
-              <header class="flex items-start justify-between gap-4 mb-2 px-0.5 max-sm:flex-col max-sm:gap-1.5">
-                <div class="min-w-0 flex items-start gap-3 max-sm:w-full max-sm:items-center">
-                  <%= if review.author_avatar_url do %>
-                    <img
-                      src={review.author_avatar_url}
-                      alt={review.author_name || review.author_email || ""}
-                      class="size-7 rounded-full mt-0.5 shrink-0 max-sm:mt-0"
-                    />
-                  <% else %>
-                    <div class="size-7 rounded-full mt-0.5 shrink-0 max-sm:mt-0 bg-(--crit-bg-elevated) border border-(--crit-border) flex items-center justify-center text-xs font-semibold text-(--crit-fg-secondary) uppercase">
-                      {(review.author_name || review.author_email || "?")
-                      |> String.first()}
-                    </div>
-                  <% end %>
-                  <div class="min-w-0 flex flex-col gap-0.5 max-sm:w-full">
-                    <div class="flex items-baseline gap-1.5 min-w-0">
-                      <%= if review.author_name || review.author_email do %>
-                        <span class="font-medium text-(--crit-fg-primary) truncate max-w-[160px] max-sm:max-w-[180px]">
-                          {review.author_name || review.author_email}
-                        </span>
-                        <span class="text-(--crit-fg-muted) shrink-0">/</span>
-                      <% end %>
-                      <a
-                        href={~p"/r/#{review.token}"}
-                        class={[
-                          "font-semibold truncate leading-tight",
-                          if(review.first_file_path,
-                            do: "crit-link",
-                            else: "text-(--crit-fg-secondary) italic"
-                          )
-                        ]}
-                      >
-                        <% {dir, file} = split_path(review.first_file_path) %>
-                        <span class="text-(--crit-fg-muted) font-normal">{dir}</span>{file}
-                      </a>
-                    </div>
-                    <span class="text-xs text-(--crit-fg-muted) max-sm:hidden">
-                      Active {time_ago(review.last_activity_at)}
-                    </span>
-                  </div>
-                </div>
-                <div class="flex items-center gap-3.5 text-xs text-(--crit-fg-secondary) shrink-0 max-sm:w-full max-sm:gap-3">
-                  <span class="hidden max-sm:inline-flex items-center text-(--crit-fg-muted)">
-                    Active {time_ago(review.last_activity_at)}
-                  </span>
-                  <span class="inline-flex items-center gap-1 tabular-nums">
-                    <.icon
-                      name="hero-document-text-micro"
-                      class="size-3.5 text-(--crit-fg-muted)"
-                    />
-                    <span class="text-(--crit-fg-primary) font-medium">{review.file_count}</span>
-                    {if review.file_count == 1, do: "file", else: "files"}
-                  </span>
-                  <span class={[
-                    "inline-flex items-center gap-1 tabular-nums",
-                    review.comment_count == 0 && "text-(--crit-fg-muted)"
-                  ]}>
-                    <.icon
-                      name="hero-chat-bubble-left-micro"
-                      class="size-3.5 text-(--crit-fg-muted)"
-                    />
-                    <span class={[
-                      if(review.comment_count == 0,
-                        do: "text-(--crit-fg-muted)",
-                        else: "text-(--crit-fg-primary) font-medium"
-                      )
-                    ]}>
-                      {review.comment_count}
-                    </span>
-                    {if review.comment_count == 1, do: "comment", else: "comments"}
-                  </span>
-                  <%= if not @oauth_configured or (not is_nil(@current_user) and (is_nil(review.user_id) or review.user_id == @current_user.id)) do %>
-                    <button
-                      phx-click="delete_review"
-                      phx-value-id={review.id}
-                      data-confirm="Delete this review? This cannot be undone."
-                      class="size-6 inline-flex items-center justify-center rounded text-(--crit-fg-muted) hover:text-(--crit-red) hover:bg-(--crit-bg-elevated) transition-colors cursor-pointer ml-1 max-sm:ml-auto"
-                      aria-label="Delete review"
-                    >
-                      <.icon name="hero-trash" class="size-3.5" />
-                    </button>
-                  <% end %>
-                </div>
-              </header>
-
+              <div class="mb-2 px-0.5">
+              <.review_listing_header
+                path={review.first_file_path}
+                last_activity_at={review.last_activity_at}
+                file_count={review.file_count}
+                comment_count={review.comment_count}
+                link_to={~p"/r/#{review.token}"}
+                author={
+                  if review.author_name || review.author_email || review.author_avatar_url do
+                    %{
+                      name: review.author_name,
+                      email: review.author_email,
+                      avatar_url: review.author_avatar_url
+                    }
+                  end
+                }
+              />
+              </div>
               <.review_snippet path={review.first_file_path} content={review.first_file_content} />
             </article>
           </div>

--- a/lib/crit_web/live/overview_live.html.heex
+++ b/lib/crit_web/live/overview_live.html.heex
@@ -180,22 +180,22 @@
               class="group"
             >
               <div class="mb-2 px-0.5">
-              <.review_listing_header
-                path={review.first_file_path}
-                last_activity_at={review.last_activity_at}
-                file_count={review.file_count}
-                comment_count={review.comment_count}
-                link_to={~p"/r/#{review.token}"}
-                author={
-                  if review.author_name || review.author_email || review.author_avatar_url do
-                    %{
-                      name: review.author_name,
-                      email: review.author_email,
-                      avatar_url: review.author_avatar_url
-                    }
-                  end
-                }
-              />
+                <.review_listing_header
+                  path={review.first_file_path}
+                  last_activity_at={review.last_activity_at}
+                  file_count={review.file_count}
+                  comment_count={review.comment_count}
+                  link_to={~p"/r/#{review.token}"}
+                  author={
+                    if review.author_name || review.author_email || review.author_avatar_url do
+                      %{
+                        name: review.author_name,
+                        email: review.author_email,
+                        avatar_url: review.author_avatar_url
+                      }
+                    end
+                  }
+                />
               </div>
               <.review_snippet path={review.first_file_path} content={review.first_file_content} />
             </article>

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -3,6 +3,7 @@ defmodule CritWeb.ReviewLive do
 
   alias Crit.Reviews
 
+
   on_mount {CritWeb.Live.Hooks, :load_current_user}
 
   @pubsub Crit.PubSub
@@ -125,6 +126,28 @@ defmodule CritWeb.ReviewLive do
          |> assign(:og_type, "article")
          |> assign(:canonical_url, CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"),
          layout: {CritWeb.Layouts, :review}}
+    end
+  end
+
+  def handle_event("delete_review", _params, socket) do
+    %{review: review, current_user: current_user} = socket.assigns
+
+    if current_user && (is_nil(review.user_id) || review.user_id == current_user.id) do
+      case Reviews.delete_review(review.id, owner_id: current_user.id) do
+        :ok ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Review deleted.")
+           |> redirect(to: ~p"/dashboard")}
+
+        {:error, :unauthorized} ->
+          {:noreply, put_flash(socket, :error, "You can only delete your own reviews.")}
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, "Failed to delete review.")}
+      end
+    else
+      {:noreply, put_flash(socket, :error, "You can only delete your own reviews.")}
     end
   end
 

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -3,7 +3,6 @@ defmodule CritWeb.ReviewLive do
 
   alias Crit.Reviews
 
-
   on_mount {CritWeb.Live.Hooks, :load_current_user}
 
   @pubsub Crit.PubSub

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -364,10 +364,11 @@
       Enum.reduce(@review.comments, 0, fn c, acc ->
         acc + 1 + length(c.replies)
       end) %>
-    <% first_path = case List.first(@review.files) do
-      nil -> nil
-      f -> f.file_path
-    end %>
+    <% first_path =
+      case List.first(@review.files) do
+        nil -> nil
+        f -> f.file_path
+      end %>
     <div class="crit-review-meta">
       <div class="crit-review-meta-inner">
         <CritWeb.Components.ReviewListingHeader.review_listing_header

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -29,22 +29,6 @@
           </svg>
         </a>
         <%= if not (@auth_required and is_nil(@current_user)) do %>
-          <%= if first = List.first(@review.files) do %>
-            <span class="crit-header-filename">
-              <svg
-                class="crit-filename-icon"
-                viewBox="0 0 16 16"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M3.75 1.5a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V6H9.75A1.75 1.75 0 0 1 8 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25V1.75z"
-                />
-              </svg>
-              {first.file_path}
-            </span>
-          <% end %>
           <%= if @review.review_round > 1 do %>
             <span class="crit-header-round">Round #{@review.review_round}</span>
           <% end %>
@@ -374,6 +358,39 @@
       </div>
     </div>
   <% else %>
+    <% owner? = @current_user && (is_nil(@review.user_id) || @review.user_id == @current_user.id) %>
+    <% author = @review.user %>
+    <% comment_count =
+      Enum.reduce(@review.comments, 0, fn c, acc ->
+        acc + 1 + length(c.replies)
+      end) %>
+    <% first_path = case List.first(@review.files) do
+      nil -> nil
+      f -> f.file_path
+    end %>
+    <div class="crit-review-meta">
+      <div class="crit-review-meta-inner">
+        <CritWeb.Components.ReviewListingHeader.review_listing_header
+          path={first_path}
+          last_activity_at={@review.last_activity_at}
+          file_count={length(@review.files)}
+          comment_count={comment_count}
+          author={author}
+        >
+          <:actions :if={owner?}>
+            <button
+              phx-click="delete_review"
+              data-confirm="Delete this review? This cannot be undone."
+              class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-(--crit-border) bg-(--crit-bg-card) text-(--crit-fg-secondary) hover:text-(--crit-red) hover:border-(--crit-red) hover:bg-(--crit-bg-elevated) transition-colors cursor-pointer ml-1 font-medium"
+              aria-label="Delete review"
+            >
+              <.icon name="hero-trash" class="size-3.5" />
+              <span>Delete review</span>
+            </button>
+          </:actions>
+        </CritWeb.Components.ReviewListingHeader.review_listing_header>
+      </div>
+    </div>
     <div id="crit-main-layout" class="crit-main-layout">
       <div id="fileTreePanel" class="tree-panel" style="display:none">
         <div class="tree-header">

--- a/test/crit_web/live/dashboard_live_test.exs
+++ b/test/crit_web/live/dashboard_live_test.exs
@@ -97,44 +97,6 @@ defmodule CritWeb.DashboardLiveTest do
     end
   end
 
-  describe "delete_review" do
-    test "owner can delete their own review", %{conn: conn} do
-      {conn, user} = login_user_with_record(conn)
-      review = review_fixture(user_id: user.id)
-
-      {:ok, view, html} = live(conn, ~p"/dashboard")
-      assert html =~ hd(review.files).file_path
-
-      view
-      |> element("button[phx-value-id='#{review.id}']")
-      |> render_click()
-
-      html = render(view)
-      refute html =~ hd(review.files).file_path
-      assert html =~ ~r/Reviews[^<]*<[^>]*>0</
-    end
-
-    test "cannot delete another user's review", %{conn: conn} do
-      {conn, _user} = login_user_with_record(conn)
-
-      {:ok, other_user} =
-        Crit.Accounts.find_or_create_from_oauth("github", %{
-          "sub" => "other_uid_#{System.unique_integer()}",
-          "email" => "other@example.com",
-          "name" => "Other User"
-        })
-
-      review = review_fixture(user_id: other_user.id)
-
-      {:ok, view, _html} = live(conn, ~p"/dashboard")
-
-      # The review shouldn't even show, but test the event handler too
-      view |> render_hook("delete_review", %{"id" => review.id})
-
-      assert render(view) =~ "You can only delete your own reviews."
-    end
-  end
-
   describe "review counts and metadata" do
     test "shows comment and file counts", %{conn: conn} do
       {conn, user} = login_user_with_record(conn)
@@ -212,36 +174,6 @@ defmodule CritWeb.DashboardLiveTest do
       assert html =~ ~r/Reviews[^<]*<[^>]*>2</
       assert html =~ "older.md"
       assert html =~ "newer.md"
-    end
-  end
-
-  describe "delete_review updates count" do
-    test "review count decrements after deletion", %{conn: conn} do
-      {conn, user} = login_user_with_record(conn)
-
-      review1 =
-        review_fixture(
-          user_id: user.id,
-          files: [%{"path" => "first.md", "content" => "content"}]
-        )
-
-      _review2 =
-        review_fixture(
-          user_id: user.id,
-          files: [%{"path" => "second.md", "content" => "content"}]
-        )
-
-      {:ok, view, html} = live(conn, ~p"/dashboard")
-      assert html =~ ~r/Reviews[^<]*<[^>]*>2</
-
-      view
-      |> element("button[phx-value-id='#{review1.id}']")
-      |> render_click()
-
-      html = render(view)
-      assert html =~ ~r/Reviews[^<]*<[^>]*>1</
-      refute html =~ "first.md"
-      assert html =~ "second.md"
     end
   end
 

--- a/test/crit_web/live/overview_live_test.exs
+++ b/test/crit_web/live/overview_live_test.exs
@@ -120,25 +120,6 @@ defmodule CritWeb.OverviewLiveTest do
     end
   end
 
-  describe "delete_review" do
-    setup :without_oauth
-
-    test "removes review from list", %{conn: conn} do
-      review = review_fixture()
-
-      {:ok, view, html} = live(conn, ~p"/overview")
-      assert html =~ hd(review.files).file_path
-
-      view
-      |> element("button[phx-value-id='#{review.id}']")
-      |> render_click()
-
-      html = render(view)
-      refute html =~ hd(review.files).file_path
-      assert html =~ ~r/All Reviews[^<]*<[^>]*>0</
-    end
-  end
-
   describe "overview empty state" do
     setup :without_oauth
 
@@ -147,25 +128,6 @@ defmodule CritWeb.OverviewLiveTest do
 
       assert html =~ ~r/All Reviews[^<]*<[^>]*>0</
       assert html =~ "No reviews yet"
-    end
-  end
-
-  describe "stats update after delete" do
-    setup :without_oauth
-
-    test "stats refresh after deleting a review", %{conn: conn} do
-      review = review_fixture()
-      comment_fixture(review)
-
-      {:ok, view, html} = live(conn, ~p"/overview")
-      assert html =~ ~r/All Reviews[^<]*<[^>]*>1</
-
-      view
-      |> element("button[phx-value-id='#{review.id}']")
-      |> render_click()
-
-      html = render(view)
-      assert html =~ ~r/All Reviews[^<]*<[^>]*>0</
     end
   end
 
@@ -225,55 +187,4 @@ defmodule CritWeb.OverviewLiveTest do
     end
   end
 
-  describe "delete_review with OAuth" do
-    test "owner can delete their own review", %{conn: conn} do
-      {conn, user} = login_user_with_record(conn)
-      review = review_fixture(user_id: user.id)
-
-      {:ok, view, html} = live(conn, ~p"/overview")
-      assert html =~ hd(review.files).file_path
-
-      view
-      |> element("button[phx-value-id='#{review.id}']")
-      |> render_click()
-
-      refute render(view) =~ hd(review.files).file_path
-    end
-
-    test "user cannot delete another user's review", %{conn: conn} do
-      {:ok, other_user} =
-        Crit.Accounts.find_or_create_from_oauth("github", %{
-          "sub" => "other_uid_#{System.unique_integer()}",
-          "email" => "other@example.com",
-          "name" => "Other User"
-        })
-
-      review = review_fixture(user_id: other_user.id)
-      conn = login_user(conn)
-
-      {:ok, view, _html} = live(conn, ~p"/overview")
-
-      refute has_element?(view, "button[phx-value-id='#{review.id}']")
-
-      # Also verify the server-side guard rejects a crafted event
-      view
-      |> render_hook("delete_review", %{"id" => review.id})
-
-      assert render(view) =~ hd(review.files).file_path
-    end
-
-    test "any authenticated user can delete an ownerless review", %{conn: conn} do
-      review = review_fixture()
-      conn = login_user(conn)
-
-      {:ok, view, html} = live(conn, ~p"/overview")
-      assert html =~ hd(review.files).file_path
-
-      view
-      |> element("button[phx-value-id='#{review.id}']")
-      |> render_click()
-
-      refute render(view) =~ hd(review.files).file_path
-    end
-  end
 end

--- a/test/crit_web/live/overview_live_test.exs
+++ b/test/crit_web/live/overview_live_test.exs
@@ -186,5 +186,4 @@ defmodule CritWeb.OverviewLiveTest do
       assert html =~ ~p"/r/#{review.token}"
     end
   end
-
 end


### PR DESCRIPTION
## Summary
- Extract shared `ReviewListingHeader` component used by dashboard, overview, and a new review-page meta bar (constrained to `--crit-content-width`)
- Review page meta bar shows author avatar/name, last activity, file/comment counts; owner gets a "Delete review" button that deletes and redirects to `/dashboard`
- Drop the icon-delete from dashboard/overview listings (and their `delete_review` handlers/tests) — deletion lives on the review page only
- `Reviews.get_by_token` now preloads `:user` so the meta bar can render author info

## Test plan
- [x] `DB_PORT=5433 mix precommit` — 458 tests, 0 failures
- [ ] Visually confirm meta bar layout matches overview listing on `/r/:token`
- [ ] Owner sees Delete button; non-owner does not
- [ ] Delete redirects to `/dashboard` and removes the review from listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)