### PR TITLE
fix: auto-close empty comment forms when opening another

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -335,6 +335,18 @@ function getLineRangeFromSelection(selection) {
   return { filePath, startLine, endLine, afterBlockIndex }
 }
 
+function closeEmptyForms(ctx, exceptKey) {
+  const toClose = []
+  ctx.activeForms.forEach(function(f) {
+    if (f.formKey === exceptKey) return
+    if (f.editingId) return
+    const ta = ctx.el.querySelector('.comment-form[data-form-key="' + f.formKey + '"] textarea')
+    const text = ta ? ta.value : (f.draftBody || '')
+    if (!text.trim()) toClose.push(f)
+  })
+  toClose.forEach(function(f) { removeForm(ctx, f.formKey) })
+}
+
 function openForm(ctx, newForm) {
   const fk = formKey(newForm)
   const existing = ctx.activeForms.find(f => f.formKey === fk)
@@ -345,6 +357,7 @@ function openForm(ctx, newForm) {
     focusCommentTextarea(ctx, existing.formKey)
     return
   }
+  closeEmptyForms(ctx, fk)
   addForm(ctx, newForm)
   ctx.selectionStart = newForm.startLine
   ctx.selectionEnd = newForm.endLine

--- a/e2e/comments.spec.ts
+++ b/e2e/comments.spec.ts
@@ -111,6 +111,36 @@ test.describe("Comments — Add via UI", () => {
     await waitForCommentCard(page, "Ctrl+Enter comment");
   });
 
+  test("opening a new comment form closes existing empty form", async ({ page }) => {
+    await loadReview(page, token);
+
+    // Open form on first line (leave empty)
+    await page.locator(".line-gutter").first().click();
+    await expect(page.locator(".comment-form")).toBeVisible({ timeout: 5_000 });
+
+    // Open form on a different line without filling first
+    await page.locator(".line-gutter").nth(2).click();
+
+    // Only one form should remain (the new one); the empty first form was closed
+    await expect(page.locator(".comment-form")).toHaveCount(1);
+  });
+
+  test("opening a new comment form keeps existing form with text", async ({ page }) => {
+    await loadReview(page, token);
+
+    await page.locator(".line-gutter").first().click();
+    const firstTextarea = page.locator(".comment-form textarea");
+    await expect(firstTextarea).toBeVisible({ timeout: 5_000 });
+    await firstTextarea.fill("draft text");
+
+    // Open form on a different line
+    await page.locator(".line-gutter").nth(2).click();
+
+    // Both forms should remain; first retains text
+    await expect(page.locator(".comment-form")).toHaveCount(2);
+    await expect(page.locator('.comment-form textarea').first()).toHaveValue("draft text");
+  });
+
   test("cancels a comment form with Escape", async ({ page }) => {
     await loadReview(page, token);
 

--- a/e2e/threading.spec.ts
+++ b/e2e/threading.spec.ts
@@ -77,6 +77,36 @@ test.describe("Comment Threading", () => {
     await expect(card.locator(".reply-body")).toContainText("Done, fixed it");
   });
 
+  test("reply form collapses and clears after successful submit", async ({
+    page,
+    request,
+  }) => {
+    await seedComment(request, token, {
+      body: "Review this",
+      startLine: 1,
+    });
+
+    await loadReview(page, token);
+    await waitForCommentCard(page, "Review this");
+
+    const card = page
+      .locator(".comment-card")
+      .filter({ hasText: "Review this" });
+
+    await card.locator(".reply-input").click();
+    await card.locator(".reply-textarea").fill("Addressed this");
+    await card.locator(".reply-form-buttons .btn-primary").click();
+
+    // Reply should render
+    await expect(card.locator(".comment-reply")).toHaveCount(1);
+
+    // Form should collapse — textarea gone, compact input visible & empty
+    await expect(card.locator(".reply-textarea")).toHaveCount(0);
+    await expect(card.locator(".reply-form.expanded")).toHaveCount(0);
+    await expect(card.locator(".reply-input")).toBeVisible();
+    await expect(card.locator(".reply-input")).toHaveValue("");
+  });
+
   test("reply form Cancel collapses without submitting", async ({
     page,
     request,


### PR DESCRIPTION
## Summary
- Opening a new comment form now closes other open forms that are empty (forms with text or in-edit are kept).
- Adds a regression test that the reply form collapses and clears after a successful submit (already correct in this repo).

## Review
- [x] Code review: passed (no blockers)
- [x] Parity audit: in sync with crit/

## Test plan
- [x] `e2e/comments.spec.ts` — empty form closes on new form open; non-empty stays
- [x] `e2e/threading.spec.ts` — reply collapses after submit
- [x] All existing comment + threading e2e specs pass

See also: tomasz-tomczyk/crit#366

🤖 Generated with [Claude Code](https://claude.com/claude-code)