### PR TITLE
style: refine review header — delete button color, no truncation

### DIFF
--- a/lib/crit_web/components/review_listing_header.ex
+++ b/lib/crit_web/components/review_listing_header.ex
@@ -48,9 +48,9 @@ defmodule CritWeb.Components.ReviewListingHeader do
             </div>
           <% end %>
           <div class="min-w-0 flex flex-col gap-0.5 max-sm:w-full">
-            <div class="flex items-baseline gap-1.5 min-w-0">
+            <div class="flex flex-wrap items-baseline gap-x-1.5 min-w-0">
               <%= if @author.name || @author.email do %>
-                <span class="font-medium text-(--crit-fg-primary) truncate max-w-[160px] max-sm:max-w-[180px]">
+                <span class="font-medium text-(--crit-fg-primary)">
                   {@author.name || @author.email}
                 </span>
                 <span class="text-(--crit-fg-muted) shrink-0">/</span>
@@ -59,7 +59,7 @@ defmodule CritWeb.Components.ReviewListingHeader do
                 <.link
                   navigate={@link_to}
                   class={[
-                    "font-semibold truncate leading-tight",
+                    "font-semibold leading-tight",
                     if(@path, do: "crit-link", else: "text-(--crit-fg-secondary) italic")
                   ]}
                 >
@@ -67,7 +67,7 @@ defmodule CritWeb.Components.ReviewListingHeader do
                 </.link>
               <% else %>
                 <span class={[
-                  "font-semibold truncate leading-tight",
+                  "font-semibold leading-tight",
                   if(@path,
                     do: "text-(--crit-fg-primary)",
                     else: "text-(--crit-fg-secondary) italic"
@@ -86,7 +86,7 @@ defmodule CritWeb.Components.ReviewListingHeader do
             <.link
               navigate={@link_to}
               class={[
-                "font-semibold truncate block w-fit max-w-[720px] max-sm:max-w-full leading-tight",
+                "font-semibold block w-fit leading-tight",
                 if(@path, do: "crit-link", else: "text-(--crit-fg-secondary) italic")
               ]}
             >
@@ -94,7 +94,7 @@ defmodule CritWeb.Components.ReviewListingHeader do
             </.link>
           <% else %>
             <span class={[
-              "font-semibold truncate block max-w-[720px] max-sm:max-w-full leading-tight",
+              "font-semibold block leading-tight",
               if(@path, do: "text-(--crit-fg-primary)", else: "text-(--crit-fg-secondary) italic")
             ]}>
               <span class="text-(--crit-fg-muted) font-normal">{@dir}</span>{@file}

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -382,11 +382,11 @@
             <button
               phx-click="delete_review"
               data-confirm="Delete this review? This cannot be undone."
-              class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-(--crit-border) bg-(--crit-bg-card) text-(--crit-fg-secondary) hover:text-(--crit-red) hover:border-(--crit-red) hover:bg-(--crit-bg-elevated) transition-colors cursor-pointer ml-1 font-medium"
+              class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-(--crit-red) bg-(--crit-bg-card) text-(--crit-red) hover:bg-(--crit-red) hover:text-white transition-colors cursor-pointer ml-1 font-medium"
               aria-label="Delete review"
             >
               <.icon name="hero-trash" class="size-3.5" />
-              <span>Delete review</span>
+              <span>Delete</span>
             </button>
           </:actions>
         </CritWeb.Components.ReviewListingHeader.review_listing_header>


### PR DESCRIPTION
## Summary
- Delete button uses `--crit-red` border + text by default; fills red on hover (was muted with red-on-hover)
- Visible label changed from "Delete review" to "Delete" (aria-label kept for screen readers)
- Author and file path no longer truncate; `flex-wrap` so they drop to a second line as content grows instead of clipping

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (`ReviewListingHeader` is crit-web only)

## Test plan
- Visual check on `/r/:token` review page meta bar
- Visual check on dashboard review listing with long author names and deep paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)