### PR TITLE
fix: auto-close empty forms when opening file/review comment forms

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3078,6 +3078,7 @@ function updateTocActive(tocItems) {
 function openFileCommentForm(ctx, filePath) {
   const fk = 'file:' + filePath
   if (ctx.activeForms.find(f => f.formKey === fk)) return
+  closeEmptyForms(ctx, fk)
   const form = { formKey: fk, scope: 'file', filePath: filePath, startLine: null, endLine: null, editingId: null }
   ctx.activeForms.push(form)
   render(ctx)
@@ -3090,6 +3091,7 @@ function openFileCommentForm(ctx, filePath) {
 function openReviewCommentForm(ctx) {
   const fk = 'review:general'
   if (ctx.activeForms.find(f => f.formKey === fk)) return
+  closeEmptyForms(ctx, fk)
   const form = { formKey: fk, scope: 'review', filePath: null, startLine: null, endLine: null, editingId: null }
   ctx.activeForms.push(form)
   // Open panel if not open


### PR DESCRIPTION
## Summary
- Parity port from crit/ PR #366
- `closeEmptyForms` was already wired into `openForm` (line-scope) via PR #124, but the file-scope and review-scope paths (`openFileCommentForm` / `openReviewCommentForm`) were missed
- 2-line addition matching the existing line-scope pattern

## Review
- [x] Code review: passed (frontend-expert agent — verdict: ship)
- [x] Parity audit: passed (port from crit/ #366)

## Test plan
- [ ] Open empty file-scope comment form, then click "Add review comment" — file form should auto-close
- [ ] Open empty review-scope form, select lines, open line-scope form — review form should auto-close

Note: pre-existing test failures in `test/crit/statistics_test.exs` on main (DB pollution) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)