### PR TITLE
feat: author attribution for shared reviews

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -83,6 +83,14 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :crit, :demo_review_token, "seedreview12345678901"
 
+# IDs of comments + replies seeded onto the demo review. The export filter
+# uses this set to hide visitor-authored comments from the API export. Keep
+# in sync with the demo block in priv/repo/seeds.exs.
+config :crit, :demo_comment_ids, [
+  "a0000000-0000-0000-0000-000000000001",
+  "a0000000-0000-0000-0000-000000000002"
+]
+
 config :phoenix_live_view,
   # Include debug annotations and locations in rendered markup.
   # Changing this configuration will require mix clean and a full recompile.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -20,6 +20,16 @@ if demo_token = System.get_env("DEMO_REVIEW_TOKEN") do
   config :crit, :demo_review_token, demo_token
 end
 
+# Comma-separated list of comment IDs that constitute the seeded demo review's
+# canonical comments + replies. The export filter uses this to hide
+# visitor-authored comments from the public API export. If a deployment
+# configures :demo_review_token without this, the export silently returns
+# zero comments — set DEMO_COMMENT_IDS to match the seed.
+if demo_ids = System.get_env("DEMO_COMMENT_IDS") do
+  ids = demo_ids |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+  config :crit, :demo_comment_ids, ids
+end
+
 if System.get_env("SELFHOSTED") in ~w(true 1) do
   config :crit, :selfhosted, true
 end

--- a/lib/crit/comment.ex
+++ b/lib/crit/comment.ex
@@ -16,6 +16,7 @@ defmodule Crit.Comment do
     field :external_id, :string
     belongs_to :review, Crit.Review
     belongs_to :parent, Crit.Comment
+    belongs_to :user, Crit.User
     has_many :replies, Crit.Comment, foreign_key: :parent_id, preload_order: [asc: :inserted_at]
 
     timestamps(type: :utc_datetime)

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -18,7 +18,7 @@ defmodule Crit.Reviews do
               ^from(c in Comment,
                 where: is_nil(c.parent_id),
                 order_by: [asc: c.start_line, asc: c.end_line],
-                preload: [:replies]
+                preload: [:user, replies: [:user]]
               )
           ]
       )
@@ -59,23 +59,37 @@ defmodule Crit.Reviews do
       from c in Comment,
         where: c.review_id == ^review_id and is_nil(c.parent_id),
         order_by: [asc: c.start_line, asc: c.end_line],
-        preload: [:replies]
+        preload: [:user, replies: [:user]]
     )
   end
 
-  @doc "Create a comment for a review with a given identity."
+  @doc """
+  Create a comment for a review.
+
+  `identity` is the session-owner token used for anonymous web visitors so
+  they can edit/delete their comment within the session. Pass `nil` for an
+  authenticated user along with `user_id:` in opts — when `user_id` is set,
+  it takes precedence and `author_identity` is left NULL.
+
+  Opts:
+    * `:user_id` — authenticated user's id; when set, `author_identity` is NULL
+  """
   def create_comment(
         %Review{id: review_id},
         attrs,
         identity,
         display_name \\ nil,
-        file_path \\ nil
+        file_path \\ nil,
+        opts \\ []
       ) do
+    user_id = Keyword.get(opts, :user_id)
+
     %Comment{}
     |> Comment.create_changeset(attrs)
     |> Ecto.Changeset.put_change(:review_id, review_id)
-    |> Ecto.Changeset.put_change(:author_identity, identity)
+    |> Ecto.Changeset.put_change(:author_identity, if(user_id, do: nil, else: identity))
     |> Ecto.Changeset.put_change(:author_display_name, display_name)
+    |> Ecto.Changeset.put_change(:user_id, user_id)
     |> then(fn cs ->
       if file_path, do: Ecto.Changeset.put_change(cs, :file_path, file_path), else: cs
     end)
@@ -86,39 +100,55 @@ defmodule Crit.Reviews do
     end)
   end
 
-  @doc "Update a comment's body if the identity matches the author."
-  def update_comment(comment_id, body, identity) do
+  @doc """
+  Update a comment's body if the caller owns it.
+
+  Authorization rules:
+    * `user_id IS NOT NULL` on the comment → must match `opts[:user_id]`
+    * `user_id IS NULL` → must match `identity` (session token)
+  """
+  def update_comment(comment_id, body, identity, opts \\ []) do
     case Repo.get(Comment, comment_id) do
       nil ->
         {:error, :not_found}
 
-      %Comment{author_identity: author} = comment when author == identity ->
-        comment
-        |> Comment.create_changeset(%{
-          "start_line" => comment.start_line,
-          "end_line" => comment.end_line,
-          "body" => body,
-          "scope" => comment.scope || "line"
-        })
-        |> Repo.update()
-
-      _ ->
-        {:error, :unauthorized}
+      %Comment{} = comment ->
+        if comment_owned_by?(comment, identity, Keyword.get(opts, :user_id)) do
+          comment
+          |> Comment.create_changeset(%{
+            "start_line" => comment.start_line,
+            "end_line" => comment.end_line,
+            "body" => body,
+            "scope" => comment.scope || "line"
+          })
+          |> Repo.update()
+        else
+          {:error, :unauthorized}
+        end
     end
   end
 
-  @doc "Delete a comment if the identity matches the author."
-  def delete_comment(comment_id, identity) do
+  @doc "Delete a comment if the caller owns it. See `update_comment/4` for ownership rules."
+  def delete_comment(comment_id, identity, opts \\ []) do
     case Repo.get(Comment, comment_id) do
       nil ->
         {:error, :not_found}
 
-      %Comment{author_identity: author} = comment when author == identity ->
-        Repo.delete(comment)
-
-      _ ->
-        {:error, :unauthorized}
+      %Comment{} = comment ->
+        if comment_owned_by?(comment, identity, Keyword.get(opts, :user_id)) do
+          Repo.delete(comment)
+        else
+          {:error, :unauthorized}
+        end
     end
+  end
+
+  defp comment_owned_by?(%Comment{user_id: nil, author_identity: ai}, identity, _user_id) do
+    not is_nil(ai) and ai == identity
+  end
+
+  defp comment_owned_by?(%Comment{user_id: uid}, _identity, current_user_id) do
+    not is_nil(current_user_id) and uid == current_user_id
   end
 
   @doc "Create a review from the share API payload. Files is a list of %{\"path\" => _, \"content\" => _} maps."
@@ -155,13 +185,13 @@ defmodule Crit.Reviews do
         end
       end)
       |> Ecto.Multi.run(:comments, fn _repo, %{review: review} ->
-        case insert_imported_comments(review, comments_attrs) do
+        case insert_imported_comments(review, comments_attrs, user_id) do
           :ok -> {:ok, :ok}
           error -> error
         end
       end)
       |> Ecto.Multi.run(:review_comments, fn _repo, %{review: review} ->
-        case insert_imported_comments(review, review_comments_attrs) do
+        case insert_imported_comments(review, review_comments_attrs, user_id) do
           :ok -> {:ok, :ok}
           error -> error
         end
@@ -197,7 +227,9 @@ defmodule Crit.Reviews do
   Appends a new round of snapshots if anything changed — no data is deleted.
   Returns {:ok, :updated, review}, {:ok, :no_changes, review}, or {:error, reason}.
   """
-  def upsert_review(token, delete_token, payload) do
+  def upsert_review(token, delete_token, payload, opts \\ []) do
+    user_id = Keyword.get(opts, :user_id)
+
     with {:ok, review} <- fetch_review_for_update(token, delete_token) do
       files = payload["files"] || []
       comments = payload["comments"] || []
@@ -218,7 +250,7 @@ defmodule Crit.Reviews do
           end
         end)
         |> Ecto.Multi.run(:comments, fn _repo, _changes ->
-          case replace_comments(review, comments) do
+          case replace_comments(review, comments, user_id) do
             :ok -> {:ok, :ok}
             {:error, _} = error -> error
           end
@@ -245,7 +277,7 @@ defmodule Crit.Reviews do
 
         multi =
           Ecto.Multi.run(multi, :comments, fn _repo, _changes ->
-            case replace_comments(review, comments) do
+            case replace_comments(review, comments, user_id) do
               :ok -> {:ok, :ok}
               {:error, _} = error -> error
             end
@@ -289,12 +321,39 @@ defmodule Crit.Reviews do
     current != incoming
   end
 
-  defp replace_comments(review, new_comments) do
+  # Re-share path. We capture existing comments by external_id BEFORE deleting,
+  # so we can preserve their server-verified `user_id` on roundtrip. Without
+  # this carry-forward, every re-share would strip attribution from comments
+  # authored by other users.
+  defp replace_comments(review, new_comments, current_user_id) do
+    existing_by_external_id =
+      from(c in Comment,
+        where: c.review_id == ^review.id and not is_nil(c.external_id) and is_nil(c.parent_id)
+      )
+      |> Repo.all()
+      |> Map.new(fn c -> {c.external_id, c} end)
+
+    # Same carry-forward for replies. Reply external_ids are the local CLI
+    # reply IDs; assumed unique within a review (CLI stamps `rp_<random>` per
+    # reply).
+    existing_replies_by_external_id =
+      from(c in Comment,
+        where: c.review_id == ^review.id and not is_nil(c.external_id) and not is_nil(c.parent_id)
+      )
+      |> Repo.all()
+      |> Map.new(fn c -> {c.external_id, c} end)
+
     Repo.delete_all(from c in Comment, where: c.review_id == ^review.id)
 
     Enum.reduce_while(new_comments, :ok, fn attrs, :ok ->
       scope = attrs["scope"] || infer_scope(attrs)
       replies_attrs = attrs["replies"] || []
+      external_id = attrs["external_id"]
+
+      existing = external_id && Map.get(existing_by_external_id, external_id)
+
+      {resolved_user_id, resolved_identity, resolved_display_name} =
+        resolve_attribution(existing, attrs, current_user_id)
 
       %Comment{}
       |> Comment.create_changeset(%{
@@ -303,18 +362,24 @@ defmodule Crit.Reviews do
         "body" => attrs["body"],
         "file_path" => attrs["file"],
         "quote" => attrs["quote"],
-        "author_display_name" => attrs["author_display_name"] || attrs["author"],
+        "author_display_name" => resolved_display_name,
         "review_round" => attrs["review_round"] || 1,
         "resolved" => attrs["resolved"] || false,
         "scope" => scope,
-        "external_id" => attrs["external_id"]
+        "external_id" => external_id
       })
       |> Ecto.Changeset.put_change(:review_id, review.id)
-      |> Ecto.Changeset.put_change(:author_identity, "imported")
+      |> Ecto.Changeset.put_change(:author_identity, resolved_identity)
+      |> Ecto.Changeset.put_change(:user_id, resolved_user_id)
       |> Repo.insert()
       |> case do
         {:ok, comment} ->
-          case insert_replies(comment, replies_attrs) do
+          case insert_replies(
+                 comment,
+                 replies_attrs,
+                 current_user_id,
+                 existing_replies_by_external_id
+               ) do
             :ok -> {:cont, :ok}
             {:error, _} = error -> {:halt, error}
           end
@@ -324,6 +389,55 @@ defmodule Crit.Reviews do
       end
     end)
   end
+
+  # Decide (user_id, author_identity, author_display_name) for a comment
+  # arriving via the share API.
+  #
+  # An existing row matched by external_id wins outright: if it already has a
+  # verified user_id, preserve it. The current sharer (whether authed or not)
+  # cannot rewrite attribution on a comment authored by someone else — that's
+  # how foreign comments roundtrip safely through `crit fetch`/re-share.
+  #
+  # Otherwise, the only attribution the server trusts is the bearer token.
+  # The payload's per-comment user_id is treated as intent only:
+  #   * empty → anonymous (NULL), even when the request is authenticated.
+  #     Lets users who logged in mid-flow share earlier anonymous comments
+  #     without retroactively claiming them.
+  #   * matches current_user_id → write the verified id.
+  #   * any other value → treated as a spoof attempt; we have no row to
+  #     roundtrip-match against (the first clause would have caught it),
+  #     so we drop to NULL.
+  #
+  # Anonymous requests always end up with NULL user_id and the legacy
+  # "imported" sentinel in author_identity (kept as a back-compat contract
+  # for the Go CLI on unauthenticated shares).
+  defp resolve_attribution(%Comment{user_id: existing_uid} = existing, _attrs, _current_user_id)
+       when not is_nil(existing_uid) do
+    {existing_uid, nil, existing.author_display_name}
+  end
+
+  defp resolve_attribution(_existing, attrs, current_user_id) do
+    display_name = attrs["author_display_name"] || attrs["author"]
+    payload_user_id = attrs["user_id"]
+
+    cond do
+      current_user_id && blank?(payload_user_id) ->
+        {nil, "imported", display_name}
+
+      current_user_id && payload_user_id == current_user_id ->
+        {current_user_id, nil, display_name}
+
+      current_user_id ->
+        {nil, "imported", display_name}
+
+      true ->
+        {nil, "imported", display_name}
+    end
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(""), do: true
+  defp blank?(_), do: false
 
   defp insert_round_snapshots(review, round_number, files_attrs) do
     Enum.with_index(files_attrs)
@@ -349,25 +463,33 @@ defmodule Crit.Reviews do
     end)
   end
 
-  defp insert_imported_comments(review, comments_attrs) do
+  # Initial-share path (POST). No existing rows to carry forward — the rules
+  # collapse to:
+  #   * Authenticated → write current_user_id, clear author_identity.
+  #   * Anonymous → write "imported" sentinel into author_identity, NULL user_id.
+  defp insert_imported_comments(review, comments_attrs, current_user_id) do
     Enum.reduce_while(comments_attrs, :ok, fn attrs, :ok ->
       replies_attrs = attrs["replies"] || []
       scope = attrs["scope"] || infer_scope(attrs)
 
+      # Initial-share path has no existing-by-external_id rows to carry forward,
+      # but rules #5/#6/#8 still apply per-comment. Delegate to resolve_attribution
+      # with `nil` existing so per-payload `user_id` intent is honored.
+      {resolved_user_id, resolved_identity, resolved_display_name} =
+        resolve_attribution(nil, attrs, current_user_id)
+
       %Comment{}
       |> Comment.create_changeset(Map.put(attrs, "scope", scope))
       |> Ecto.Changeset.put_change(:review_id, review.id)
-      |> Ecto.Changeset.put_change(:author_identity, "imported")
+      |> Ecto.Changeset.put_change(:author_identity, resolved_identity)
+      |> Ecto.Changeset.put_change(:user_id, resolved_user_id)
       |> Ecto.Changeset.put_change(:file_path, attrs["file"])
       |> Ecto.Changeset.put_change(:resolved, attrs["resolved"] == true)
-      |> Ecto.Changeset.put_change(
-        :author_display_name,
-        attrs["author_display_name"] || attrs["author"]
-      )
+      |> Ecto.Changeset.put_change(:author_display_name, resolved_display_name)
       |> Repo.insert()
       |> case do
         {:ok, comment} ->
-          case insert_replies(comment, replies_attrs) do
+          case insert_replies(comment, replies_attrs, current_user_id) do
             :ok -> {:cont, :ok}
             error -> {:halt, error}
           end
@@ -389,19 +511,27 @@ defmodule Crit.Reviews do
     end
   end
 
-  defp insert_replies(_comment, []), do: :ok
+  defp insert_replies(comment, replies_attrs, current_user_id),
+    do: insert_replies(comment, replies_attrs, current_user_id, %{})
 
-  defp insert_replies(comment, replies_attrs) do
+  defp insert_replies(_comment, [], _current_user_id, _existing_by_external_id), do: :ok
+
+  defp insert_replies(comment, replies_attrs, current_user_id, existing_by_external_id) do
     Enum.reduce_while(replies_attrs, :ok, fn attrs, :ok ->
+      external_id = attrs["external_id"]
+      existing = external_id && Map.get(existing_by_external_id, external_id)
+
+      {resolved_user_id, resolved_identity, resolved_display_name} =
+        resolve_attribution(existing, attrs, current_user_id)
+
       %Comment{}
       |> Comment.reply_changeset(attrs)
       |> Ecto.Changeset.put_change(:parent_id, comment.id)
       |> Ecto.Changeset.put_change(:review_id, comment.review_id)
-      |> Ecto.Changeset.put_change(:author_identity, "imported")
-      |> Ecto.Changeset.put_change(
-        :author_display_name,
-        attrs["author_display_name"] || attrs["author"]
-      )
+      |> Ecto.Changeset.put_change(:author_identity, resolved_identity)
+      |> Ecto.Changeset.put_change(:user_id, resolved_user_id)
+      |> Ecto.Changeset.put_change(:author_display_name, resolved_display_name)
+      |> Ecto.Changeset.put_change(:external_id, external_id)
       |> Repo.insert()
       |> case do
         {:ok, _} -> {:cont, :ok}
@@ -606,8 +736,15 @@ defmodule Crit.Reviews do
     end
   end
 
-  @doc "Create a reply to an existing comment. Scoped to the given review."
-  def create_reply(comment_id, attrs, identity, display_name, review_id) do
+  @doc """
+  Create a reply to an existing comment. Scoped to the given review.
+
+  Same attribution rules as `create_comment/6`: when `opts[:user_id]` is set,
+  it takes precedence and `author_identity` is left NULL.
+  """
+  def create_reply(comment_id, attrs, identity, display_name, review_id, opts \\ []) do
+    user_id = Keyword.get(opts, :user_id)
+
     case Repo.get_by(Comment, id: comment_id, review_id: review_id) do
       nil ->
         {:error, :not_found}
@@ -620,18 +757,23 @@ defmodule Crit.Reviews do
         |> Comment.reply_changeset(attrs)
         |> Ecto.Changeset.put_change(:parent_id, comment_id)
         |> Ecto.Changeset.put_change(:review_id, parent.review_id)
-        |> Ecto.Changeset.put_change(:author_identity, identity)
+        |> Ecto.Changeset.put_change(:author_identity, if(user_id, do: nil, else: identity))
+        |> Ecto.Changeset.put_change(:user_id, user_id)
         |> Ecto.Changeset.put_change(:author_display_name, display_name)
         |> Repo.insert()
-        |> tap(fn
-          {:ok, _} -> Statistics.increment_comment()
-          _ -> :ok
-        end)
+        |> case do
+          {:ok, reply} ->
+            Statistics.increment_comment()
+            {:ok, Repo.preload(reply, :user)}
+
+          other ->
+            other
+        end
     end
   end
 
-  @doc "Update a reply's body if the identity matches the author."
-  def update_reply(reply_id, body, identity) do
+  @doc "Update a reply's body if the caller owns it. See `update_comment/4` for ownership rules."
+  def update_reply(reply_id, body, identity, opts \\ []) do
     case Repo.get(Comment, reply_id) do
       nil ->
         {:error, :not_found}
@@ -639,16 +781,17 @@ defmodule Crit.Reviews do
       %Comment{parent_id: nil} ->
         {:error, :not_found}
 
-      %Comment{author_identity: author} = reply when author == identity ->
-        reply |> Comment.reply_changeset(%{"body" => body}) |> Repo.update()
-
-      _ ->
-        {:error, :unauthorized}
+      %Comment{} = reply ->
+        if comment_owned_by?(reply, identity, Keyword.get(opts, :user_id)) do
+          reply |> Comment.reply_changeset(%{"body" => body}) |> Repo.update()
+        else
+          {:error, :unauthorized}
+        end
     end
   end
 
-  @doc "Delete a reply if the identity matches the author."
-  def delete_reply(reply_id, identity) do
+  @doc "Delete a reply if the caller owns it. See `update_comment/4` for ownership rules."
+  def delete_reply(reply_id, identity, opts \\ []) do
     case Repo.get(Comment, reply_id) do
       nil ->
         {:error, :not_found}
@@ -656,15 +799,24 @@ defmodule Crit.Reviews do
       %Comment{parent_id: nil} ->
         {:error, :not_found}
 
-      %Comment{author_identity: author} = reply when author == identity ->
-        Repo.delete(reply)
-
-      _ ->
-        {:error, :unauthorized}
+      %Comment{} = reply ->
+        if comment_owned_by?(reply, identity, Keyword.get(opts, :user_id)) do
+          Repo.delete(reply)
+        else
+          {:error, :unauthorized}
+        end
     end
   end
 
-  @doc "Serialize a comment to the API JSON shape."
+  @doc """
+  Serialize a comment to the API JSON shape.
+
+  `author_display_name` is resolved: when `user_id` is set and the `:user`
+  association is loaded, the joined `users.name` wins over the stored
+  display name (so renames propagate). Otherwise the stored value is used.
+  Preload `:user` (and `replies: [:user]`) to avoid N+1 — done by default
+  in `get_by_token/1` and `list_comments/1`.
+  """
   def serialize_comment(%Comment{} = c) do
     replies =
       case c.replies do
@@ -680,7 +832,8 @@ defmodule Crit.Reviews do
       quote: c.quote,
       scope: c.scope || "line",
       author_identity: c.author_identity,
-      author_display_name: c.author_display_name,
+      author_display_name: resolve_display_name(c),
+      user_id: c.user_id,
       review_round: c.review_round,
       file_path: c.file_path,
       resolved: c.resolved,
@@ -697,8 +850,17 @@ defmodule Crit.Reviews do
       id: r.id,
       body: r.body,
       author_identity: r.author_identity,
-      author_display_name: r.author_display_name,
+      author_display_name: resolve_display_name(r),
+      user_id: r.user_id,
       created_at: DateTime.to_iso8601(r.inserted_at)
     }
   end
+
+  defp resolve_display_name(%Comment{user_id: nil} = c), do: c.author_display_name
+
+  defp resolve_display_name(%Comment{user: %User{name: name}})
+       when is_binary(name) and name != "",
+       do: name
+
+  defp resolve_display_name(%Comment{} = c), do: c.author_display_name
 end

--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -135,17 +135,24 @@ defmodule CritWeb.ApiController do
     end
   end
 
+  # The demo review is open to anyone — anon visitors can comment on it. The
+  # API export must show only the seeded demo comments (and their seeded
+  # replies), not visitor comments. The demo content is seeded with a known
+  # set of comment IDs (config-driven so tests/dev can set their own); anything
+  # outside that set is a visitor comment and gets hidden in the export.
   defp visible_comments(review) do
     demo_token = Application.get_env(:crit, :demo_review_token)
 
     if review.token == demo_token do
+      demo_ids = MapSet.new(Application.get_env(:crit, :demo_comment_ids, []))
+
       review.comments
-      |> Enum.filter(&(&1.author_identity == "imported"))
+      |> Enum.filter(&MapSet.member?(demo_ids, &1.id))
       |> Enum.map(fn c ->
         filtered_replies =
           case c.replies do
             %Ecto.Association.NotLoaded{} -> %Ecto.Association.NotLoaded{}
-            replies -> Enum.filter(replies, &(&1.author_identity == "imported"))
+            replies -> Enum.filter(replies, &MapSet.member?(demo_ids, &1.id))
           end
 
         %{c | replies: filtered_replies}
@@ -158,8 +165,9 @@ defmodule CritWeb.ApiController do
   def update(conn, %{"token" => token} = params) do
     delete_token = params["delete_token"]
     payload = Map.take(params, ["files", "comments", "review_round", "cli_args"])
+    user_id = conn.assigns[:current_user] && conn.assigns[:current_user].id
 
-    case Reviews.upsert_review(token, delete_token, payload) do
+    case Reviews.upsert_review(token, delete_token, payload, user_id: user_id) do
       {:ok, :updated, review} ->
         url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
         json(conn, %{url: url, review_round: review.review_round, changed: true})
@@ -224,6 +232,24 @@ defmodule CritWeb.ApiController do
 
           json(conn, Reviews.serialize_comment(comment))
       end
+    end
+
+    def seed_user(conn, params) do
+      name = params["name"] || "Test User"
+      email = params["email"] || "test-#{System.unique_integer([:positive])}@example.com"
+      provider_uid = "test-#{System.unique_integer([:positive])}"
+
+      {:ok, user} =
+        Crit.Accounts.find_or_create_from_oauth("test", %{
+          "sub" => provider_uid,
+          "name" => name,
+          "email" => email,
+          "picture" => nil
+        })
+
+      {:ok, {plaintext, _record}} = Crit.Accounts.create_token(user, "integration-test")
+
+      json(conn, %{user_id: user.id, name: user.name, email: user.email, token: plaintext})
     end
 
     def seed_reply(conn, %{"token" => token, "comment_id" => comment_id} = params) do

--- a/lib/crit_web/controllers/auth_api_controller.ex
+++ b/lib/crit_web/controllers/auth_api_controller.ex
@@ -10,6 +10,7 @@ defmodule CritWeb.AuthApiController do
     user = conn.assigns.current_user
 
     json(conn, %{
+      id: user.id,
       name: user.name,
       email: user.email
     })

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -15,9 +15,12 @@ defmodule CritWeb.ReviewLive do
       Application.get_env(:crit, :selfhosted) == true &&
         Application.get_env(:crit, :oauth_provider) != nil
 
+    # When authenticated, attribution flows through `user_id` (a verified FK).
+    # `identity` (the session-owner token) is only used for anonymous
+    # visitors to scope edit/delete permission across page reloads.
     {identity, display_name} =
       if current_user do
-        {current_user.id, current_user.name || current_user.email}
+        {nil, current_user.name || current_user.email}
       else
         {Map.get(session, "identity", Ecto.UUID.generate()), Map.get(session, "display_name")}
       end
@@ -46,7 +49,9 @@ defmodule CritWeb.ReviewLive do
             Phoenix.PubSub.subscribe(@pubsub, "review:#{token}")
             Reviews.touch_last_activity(review)
 
-            comments = review.comments |> filter_demo_comments(demo?, identity)
+            comments =
+              review.comments
+              |> filter_demo_comments(demo?, identity, current_user_id(socket))
 
             push_event(socket, "init", %{
               comments: serialize_comments(comments),
@@ -202,7 +207,16 @@ defmodule CritWeb.ReviewLive do
         if q = params["quote"], do: Map.put(a, "quote", q), else: a
       end)
 
-    case Reviews.create_comment(review, attrs, identity, socket.assigns.display_name, file_path) do
+    user_id = current_user_id(socket)
+
+    case Reviews.create_comment(
+           review,
+           attrs,
+           identity,
+           socket.assigns.display_name,
+           file_path,
+           user_id: user_id
+         ) do
       {:ok, comment} ->
         payload = %{comment: Reviews.serialize_comment(comment)}
         socket = push_event(socket, "comment_added", payload)
@@ -218,7 +232,7 @@ defmodule CritWeb.ReviewLive do
   def handle_event("edit_comment", %{"id" => id, "body" => body}, socket) do
     %{identity: identity} = socket.assigns
 
-    case Reviews.update_comment(id, body, identity) do
+    case Reviews.update_comment(id, body, identity, user_id: current_user_id(socket)) do
       {:ok, comment} ->
         payload = %{
           id: comment.id,
@@ -242,7 +256,7 @@ defmodule CritWeb.ReviewLive do
   def handle_event("delete_comment", %{"id" => id}, socket) do
     %{identity: identity} = socket.assigns
 
-    case Reviews.delete_comment(id, identity) do
+    case Reviews.delete_comment(id, identity, user_id: current_user_id(socket)) do
       {:ok, _} ->
         payload = %{id: id}
         socket = push_event(socket, "comment_deleted", payload)
@@ -284,7 +298,14 @@ defmodule CritWeb.ReviewLive do
   def handle_event("add_reply", %{"comment_id" => comment_id, "body" => body}, socket) do
     %{review: review, identity: identity, display_name: display_name} = socket.assigns
 
-    case Reviews.create_reply(comment_id, %{"body" => body}, identity, display_name, review.id) do
+    case Reviews.create_reply(
+           comment_id,
+           %{"body" => body},
+           identity,
+           display_name,
+           review.id,
+           user_id: current_user_id(socket)
+         ) do
       {:ok, reply} ->
         payload = %{parent_id: comment_id, reply: Reviews.serialize_reply(reply)}
         socket = push_event(socket, "reply_added", payload)
@@ -300,7 +321,7 @@ defmodule CritWeb.ReviewLive do
   def handle_event("edit_reply", %{"id" => id, "body" => body}, socket) do
     %{identity: identity} = socket.assigns
 
-    case Reviews.update_reply(id, body, identity) do
+    case Reviews.update_reply(id, body, identity, user_id: current_user_id(socket)) do
       {:ok, reply} ->
         payload = %{parent_id: reply.parent_id, id: reply.id, body: reply.body}
         socket = push_event(socket, "reply_updated", payload)
@@ -319,7 +340,7 @@ defmodule CritWeb.ReviewLive do
   def handle_event("delete_reply", %{"id" => id}, socket) do
     %{identity: identity} = socket.assigns
 
-    case Reviews.delete_reply(id, identity) do
+    case Reviews.delete_reply(id, identity, user_id: current_user_id(socket)) do
       {:ok, deleted} ->
         payload = %{parent_id: deleted.parent_id, id: id}
         socket = push_event(socket, "reply_deleted", payload)
@@ -404,7 +425,7 @@ defmodule CritWeb.ReviewLive do
   @impl true
   def handle_info({:comments_full_sync, comments}, socket) do
     %{demo?: demo?, identity: identity} = socket.assigns
-    filtered = filter_demo_serialized_comments(comments, demo?, identity)
+    filtered = filter_demo_serialized_comments(comments, demo?, identity, current_user_id(socket))
     {:noreply, push_event(socket, "comments_full_sync", %{comments: filtered})}
   end
 
@@ -427,16 +448,25 @@ defmodule CritWeb.ReviewLive do
     Enum.map(comments, &Reviews.serialize_comment/1)
   end
 
-  defp filter_demo_comments(comments, false, _identity), do: comments
+  defp current_user_id(socket) do
+    case socket.assigns[:current_user] do
+      nil -> nil
+      %{id: id} -> id
+    end
+  end
 
-  defp filter_demo_comments(comments, true, identity) do
+  defp filter_demo_comments(comments, false, _identity, _user_id), do: comments
+
+  defp filter_demo_comments(comments, true, identity, user_id) do
+    keep? = fn c -> demo_visible?(c, identity, user_id) end
+
     comments
-    |> Enum.filter(fn c -> c.author_identity in ["imported", identity] end)
+    |> Enum.filter(keep?)
     |> Enum.map(fn c ->
       filtered_replies =
         case c.replies do
           %Ecto.Association.NotLoaded{} -> %Ecto.Association.NotLoaded{}
-          replies -> Enum.filter(replies, &(&1.author_identity in ["imported", identity]))
+          replies -> Enum.filter(replies, keep?)
         end
 
       %{c | replies: filtered_replies}
@@ -444,15 +474,21 @@ defmodule CritWeb.ReviewLive do
   end
 
   # Filters already-serialized comment maps (atom keys) for demo mode full sync.
-  defp filter_demo_serialized_comments(comments, false, _identity), do: comments
+  defp filter_demo_serialized_comments(comments, false, _identity, _user_id), do: comments
 
-  defp filter_demo_serialized_comments(comments, true, identity) do
+  defp filter_demo_serialized_comments(comments, true, identity, user_id) do
+    keep? = fn c -> demo_visible?(c, identity, user_id) end
+
     comments
-    |> Enum.filter(fn c -> c.author_identity in ["imported", identity] end)
+    |> Enum.filter(keep?)
     |> Enum.map(fn c ->
-      filtered_replies = Enum.filter(c.replies, &(&1.author_identity in ["imported", identity]))
-      %{c | replies: filtered_replies}
+      %{c | replies: Enum.filter(c.replies, keep?)}
     end)
+  end
+
+  defp demo_visible?(c, identity, user_id) do
+    c.author_identity in ["imported", identity] or
+      (not is_nil(user_id) and Map.get(c, :user_id) == user_id)
   end
 
   @doc false

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -129,6 +129,7 @@ defmodule CritWeb.Router do
     if Mix.env() in [:test, :dev] do
       post "/reviews/:token/seed-comment", ApiController, :seed_comment
       post "/reviews/:token/seed-reply/:comment_id", ApiController, :seed_reply
+      post "/test/seed-user", ApiController, :seed_user
     end
   end
 

--- a/priv/repo/migrations/20260426120000_add_user_id_to_comments.exs
+++ b/priv/repo/migrations/20260426120000_add_user_id_to_comments.exs
@@ -1,0 +1,11 @@
+defmodule Crit.Repo.Migrations.AddUserIdToComments do
+  use Ecto.Migration
+
+  def change do
+    alter table(:comments) do
+      add :user_id, references(:users, type: :binary_id, on_delete: :nilify_all), null: true
+    end
+
+    create index(:comments, [:user_id], where: "user_id IS NOT NULL")
+  end
+end

--- a/priv/repo/migrations/20260427120000_unique_external_id_per_review.exs
+++ b/priv/repo/migrations/20260427120000_unique_external_id_per_review.exs
@@ -1,0 +1,10 @@
+defmodule Crit.Repo.Migrations.UniqueExternalIdPerReview do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:comments, [:review_id, :external_id],
+             where: "external_id IS NOT NULL",
+             name: :comments_review_id_external_id_index
+           )
+  end
+end

--- a/test/crit/reviews_test.exs
+++ b/test/crit/reviews_test.exs
@@ -750,7 +750,14 @@ defmodule Crit.ReviewsTest do
       assert Map.has_key?(serialized, :created_at)
 
       expected_keys =
-        MapSet.new([:id, :body, :author_identity, :author_display_name, :created_at])
+        MapSet.new([
+          :id,
+          :body,
+          :author_identity,
+          :author_display_name,
+          :user_id,
+          :created_at
+        ])
 
       assert MapSet.new(Map.keys(serialized)) == expected_keys
     end

--- a/test/crit_web/live/review_live_test.exs
+++ b/test/crit_web/live/review_live_test.exs
@@ -541,6 +541,7 @@ defmodule CritWeb.ReviewLiveTest do
           :scope,
           :author_identity,
           :author_display_name,
+          :user_id,
           :review_round,
           :file_path,
           :resolved,
@@ -1079,7 +1080,10 @@ defmodule CritWeb.ReviewLiveTest do
 
       [comment] = Reviews.list_comments(review)
       assert comment.author_display_name == "Reviewer"
-      assert comment.author_identity == user.id
+      # Authenticated comments now flow through user_id (verified FK).
+      # author_identity (the session-owner token) is NULL for them.
+      assert comment.user_id == user.id
+      assert comment.author_identity == nil
     end
   end
 


### PR DESCRIPTION
## Summary

- Replaces the `"imported"` placeholder author with proper attribution: a cosmetic `author_display_name` and a verified `user_id` (UUID FK to `users.id`).
- Server treats payload-supplied `user_id` as untrusted intent — only the bearer token decides what gets stamped. Existing comments matched by `external_id` keep their original `user_id` on roundtrip (preserves foreign-author attribution).
- Demo export filter swapped from `author_identity == "imported"` to a configurable allowlist of comment IDs (`DEMO_COMMENT_IDS` env var).
- LiveView demo filter now also keeps `current_user_id`-matched comments so authed visitors see their own comments.
- Migrations: new `comments.user_id` nullable FK (`ON DELETE SET NULL`) + partial unique index on `(review_id, external_id)`.
- Test-only `POST /api/test/seed-user` (gated by `Mix.env() in [:test, :dev]`) for integration tests.
- `/api/auth/whoami` returns `id` so the CLI can cache it.

## Review
- [x] Code review: passed (elixir-expert fresh-eyes pass + targeted fixes)
- [x] Parity audit: N/A (no review-page files touched)

## Test plan
- [x] `mix precommit` — 460/460 pass
- [x] `mix test test/crit/reviews_test.exs test/crit_web/live/review_live_test.exs` — 130/130 pass
- [x] Full crit↔crit-web share integration suite (`./scripts/e2e-share.sh`) — all 24 attribution + share-sync tests pass
- [ ] Set `DEMO_COMMENT_IDS` fly secret post-deploy

See also: https://github.com/tomasz-tomczyk/crit/pull/371 (CLI side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)