### PR TITLE
Add login + selfhosted share_url steps to dashboard empty state

### DIFF
--- a/lib/crit_web/live/dashboard_live.ex
+++ b/lib/crit_web/live/dashboard_live.ex
@@ -17,6 +17,7 @@ defmodule CritWeb.DashboardLive do
       |> assign(:page_title, "Dashboard - Crit")
       |> assign(:noindex, true)
       |> assign(:selfhosted, Application.get_env(:crit, :selfhosted) == true)
+      |> assign(:instance_url, CritWeb.Endpoint.url())
       |> stream(:reviews, reviews)
       |> assign(:review_count, length(reviews))
 

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -124,27 +124,92 @@
               </div>
             </div>
 
-            <%!-- Step 3: Share --%>
+            <%= if @selfhosted do %>
+              <%!-- Step 3 (selfhosted): Point crit at this instance --%>
+              <div class="grid grid-cols-[40px_1fr] gap-x-5">
+                <div class="flex flex-col items-center">
+                  <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+                    3
+                  </div>
+                  <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
+                </div>
+                <div class="pb-8">
+                  <div class="text-xl font-bold tracking-tight leading-8">
+                    Point crit at this instance
+                  </div>
+                  <p class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed">
+                    By default, crit shares to <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">crit.md</code>. Set <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">share_url</code>
+                    so it talks to this self-hosted instance instead.
+                  </p>
+
+                  <div class="mt-3 flex items-center border border-(--crit-border) rounded-md overflow-hidden bg-(--crit-code-bg)">
+                    <pre class="flex-1 font-mono text-sm text-(--crit-fg-primary) m-0 px-4 py-3 overflow-x-auto whitespace-pre"><span class="text-(--crit-fg-muted) select-none">$ </span>export CRIT_SHARE_URL={@instance_url}</pre>
+                    <button
+                      class="copy-btn shrink-0 p-3 cursor-pointer text-(--crit-fg-muted) hover:text-(--crit-fg-primary) transition-colors"
+                      aria-label="Copy to clipboard"
+                      data-copy={"export CRIT_SHARE_URL=#{@instance_url}"}
+                    >
+                      <.icon name="hero-clipboard" class="size-4 icon-default" />
+                      <.icon name="hero-clipboard-document-check" class="size-4 icon-copied hidden" />
+                    </button>
+                  </div>
+
+                  <p class="mt-2 text-xs text-(--crit-fg-muted) leading-relaxed">
+                    Or pass <code class="font-mono">--share-url</code>
+                    per command, or set <code class="font-mono">share_url</code>
+                    in <code class="font-mono">~/.crit.config.json</code>.
+                  </p>
+                </div>
+              </div>
+            <% end %>
+
+            <%!-- Step: Log in --%>
             <div class="grid grid-cols-[40px_1fr] gap-x-5">
               <div class="flex flex-col items-center">
                 <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
-                  3
+                  {if @selfhosted, do: 4, else: 3}
+                </div>
+                <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
+              </div>
+              <div class="pb-8">
+                <div class="text-xl font-bold tracking-tight leading-8">Log in</div>
+                <p class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed">
+                  Run <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">crit auth login</code>
+                  to link shared reviews to your account. Opens your browser for a one-time confirmation.
+                </p>
+
+                <div class="mt-3 flex items-center border border-(--crit-border) rounded-md overflow-hidden bg-(--crit-code-bg)">
+                  <pre class="flex-1 font-mono text-sm text-(--crit-fg-primary) m-0 px-4 py-3 overflow-x-auto whitespace-pre"><span class="text-(--crit-fg-muted) select-none">$ </span>crit auth login</pre>
+                  <button
+                    class="copy-btn shrink-0 p-3 cursor-pointer text-(--crit-fg-muted) hover:text-(--crit-fg-primary) transition-colors"
+                    aria-label="Copy to clipboard"
+                    data-copy="crit auth login"
+                  >
+                    <.icon name="hero-clipboard" class="size-4 icon-default" />
+                    <.icon name="hero-clipboard-document-check" class="size-4 icon-copied hidden" />
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <%!-- Step: Share --%>
+            <div class="grid grid-cols-[40px_1fr] gap-x-5">
+              <div class="flex flex-col items-center">
+                <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+                  {if @selfhosted, do: 5, else: 4}
                 </div>
               </div>
               <div>
                 <div class="text-xl font-bold tracking-tight leading-8">Share to the web</div>
                 <p class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed">
-                  When you're ready, run
-                  <code class="font-mono text-[0.9em] text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">
-                    crit share
-                  </code>
+                  When you're ready, run <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">crit share</code>
                   to upload your review to a shareable URL.
                 </p>
 
                 <%!-- Terminal snippet --%>
                 <div class="mt-3 flex items-center border border-(--crit-border) rounded-md overflow-hidden bg-(--crit-code-bg)">
                   <pre class="flex-1 font-mono text-sm text-(--crit-fg-primary) m-0 px-4 py-3 overflow-x-auto whitespace-pre"><span class="text-(--crit-fg-muted) select-none">$ </span>crit share
-<span class="text-(--crit-fg-muted) italic">Shared at crit.md/r/abc123</span></pre>
+<span class="text-(--crit-fg-muted) italic">Shared at {if @selfhosted, do: String.replace(@instance_url, ~r{^https?://}, ""), else: "crit.md"}/r/abc123</span></pre>
                 </div>
 
                 <%!-- Share details --%>
@@ -176,10 +241,7 @@
                       class="size-4 text-(--crit-fg-muted) shrink-0 relative top-0.5"
                     />
                     <span>
-                      Unpublish anytime with
-                      <code class="font-mono text-[0.9em] text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">
-                        crit unpublish
-                      </code>
+                      Unpublish anytime with <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">crit unpublish</code>
                     </span>
                   </div>
                 </div>

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -137,7 +137,10 @@
                   <div class="text-xl font-bold tracking-tight leading-8">
                     Point crit at this instance
                   </div>
-                  <p class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed">
+                  <p
+                    class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed"
+                    phx-no-format
+                  >
                     By default, crit shares to <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">crit.md</code>. Set <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">share_url</code>
                     so it talks to this self-hosted instance instead.
                   </p>
@@ -150,7 +153,10 @@
                       data-copy={"export CRIT_SHARE_URL=#{@instance_url}"}
                     >
                       <.icon name="hero-clipboard" class="size-4 icon-default" />
-                      <.icon name="hero-clipboard-document-check" class="size-4 icon-copied hidden" />
+                      <.icon
+                        name="hero-clipboard-document-check"
+                        class="size-4 icon-copied hidden"
+                      />
                     </button>
                   </div>
 
@@ -173,7 +179,7 @@
               </div>
               <div class="pb-8">
                 <div class="text-xl font-bold tracking-tight leading-8">Log in</div>
-                <p class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed">
+                <p class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed" phx-no-format>
                   Run <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">crit auth login</code>
                   to link shared reviews to your account. Opens your browser for a one-time confirmation.
                 </p>
@@ -201,7 +207,7 @@
               </div>
               <div>
                 <div class="text-xl font-bold tracking-tight leading-8">Share to the web</div>
-                <p class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed">
+                <p class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed" phx-no-format>
                   When you're ready, run <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">crit share</code>
                   to upload your review to a shareable URL.
                 </p>
@@ -240,7 +246,7 @@
                       name="hero-trash"
                       class="size-4 text-(--crit-fg-muted) shrink-0 relative top-0.5"
                     />
-                    <span>
+                    <span phx-no-format>
                       Unpublish anytime with <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">crit unpublish</code>
                     </span>
                   </div>


### PR DESCRIPTION
## Summary

The dashboard empty state is the new-user setup guide. Two gaps:

1. **`crit auth login` was missing** — users had no prompt to authenticate, so shared reviews stayed anonymous.
2. **Self-hosted users had no signal that crit defaults to crit.md** — they'd install, share, and reviews would land on the wrong instance.

## Changes

- New **Log in** step with copyable \`crit auth login\` snippet (always shown).
- New **Point crit at this instance** step (selfhosted only) — copyable \`export CRIT_SHARE_URL=<instance_url>\` snippet plus mention of \`--share-url\` flag and \`~/.crit.config.json\`. The instance URL is pulled from \`CritWeb.Endpoint.url()\`.
- Share-step example output now shows the selfhosted hostname instead of \`crit.md\` when applicable.
- Step numbers shift to 1, 2, [3 selfhosted], 3/4 Log in, 4/5 Share.

## Test plan

- [ ] Visit \`/\` (public mode, no reviews) — should see steps 1, 2, 3 (Log in), 4 (Share to crit.md/r/abc123).
- [ ] Set \`config :crit, :selfhosted, true\`, restart, visit \`/\` — should see steps 1, 2, 3 (Point crit at this instance with \`CRIT_SHARE_URL=<your URL>\`), 4 (Log in), 5 (Share to your-host/r/abc123).
- [ ] Click copy buttons on the new snippets — clipboard receives the right text.