### PR TITLE
style: typography cleanup + empty-state mobile + changelog wrap

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2953,6 +2953,7 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   border-bottom: 1px solid transparent;
   padding-bottom: 1px;
   transition: border-color var(--crit-dur-fast) var(--crit-ease);
+  overflow-wrap: anywhere;
 }
 
 .changelog-body a:hover {

--- a/lib/crit_web/components/layouts.ex
+++ b/lib/crit_web/components/layouts.ex
@@ -176,7 +176,7 @@ defmodule CritWeb.Layouts do
             </.nav_link>
             <a
               href="https://github.com/tomasz-tomczyk/crit"
-              class="inline-flex items-center gap-1.5 h-[30px] px-2.5 rounded-md text-[13px] font-medium tracking-tight no-underline text-(--crit-fg-secondary) hover:text-(--crit-fg-primary) hover:bg-(--crit-row-hover) transition-colors"
+              class="inline-flex items-center gap-1.5 h-[30px] px-2.5 rounded-md text-sm font-medium tracking-tight no-underline text-(--crit-fg-secondary) hover:text-(--crit-fg-primary) hover:bg-(--crit-row-hover) transition-colors"
             >
               <svg viewBox="0 0 16 16" class="size-3.5 fill-current" aria-hidden="true">
                 <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
@@ -217,7 +217,7 @@ defmodule CritWeb.Layouts do
                     class="h-6 w-6 rounded-full flex-shrink-0"
                   />
                 <% else %>
-                  <span class="h-6 w-6 rounded-full bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-[10.5px] font-semibold flex-shrink-0">
+                  <span class="h-6 w-6 rounded-full bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-xs font-semibold flex-shrink-0">
                     {@user_initial}
                   </span>
                 <% end %>
@@ -247,12 +247,12 @@ defmodule CritWeb.Layouts do
                       class="h-9 w-9 rounded-md flex-shrink-0"
                     />
                   <% else %>
-                    <span class="h-9 w-9 rounded-md bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-[13px] font-semibold flex-shrink-0">
+                    <span class="h-9 w-9 rounded-md bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-sm font-semibold flex-shrink-0">
                       {@user_initial}
                     </span>
                   <% end %>
                   <div class="flex flex-col gap-0.5 min-w-0">
-                    <span class="text-[13px] font-semibold text-(--crit-fg-primary) leading-tight">
+                    <span class="text-sm font-semibold text-(--crit-fg-primary) leading-tight">
                       {@current_user.name || @current_user.email}
                     </span>
                     <%= if @current_user.name && @current_user.email do %>
@@ -265,13 +265,13 @@ defmodule CritWeb.Layouts do
 
                 <div class="h-px bg-(--crit-border) my-0.5"></div>
 
-                <div class="text-[10.5px] uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-3 pt-2 pb-1">
+                <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-3 pt-2 pb-1">
                   Account
                 </div>
                 <.link
                   navigate={~p"/settings"}
                   role="menuitem"
-                  class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[13px] text-(--crit-fg-primary) hover:bg-(--crit-row-hover) no-underline"
+                  class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-sm text-(--crit-fg-primary) hover:bg-(--crit-row-hover) no-underline"
                 >
                   <.icon name="hero-cog-6-tooth-mini" class="size-3.5 text-(--crit-fg-muted)" />
                   <span>Settings</span>
@@ -283,7 +283,7 @@ defmodule CritWeb.Layouts do
                   href={~p"/auth/logout"}
                   method="delete"
                   role="menuitem"
-                  class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[13px] text-(--crit-red) hover:bg-(--crit-btn-danger-hover-bg) no-underline"
+                  class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-sm text-(--crit-red) hover:bg-(--crit-btn-danger-hover-bg) no-underline"
                 >
                   <.icon name="hero-arrow-right-on-rectangle-mini" class="size-3.5" />
                   <span>Sign out</span>
@@ -293,7 +293,7 @@ defmodule CritWeb.Layouts do
           <% else %>
             <a
               href={~p"/auth/login?return_to=/dashboard"}
-              class="inline-flex items-center gap-1.5 h-[30px] px-3 mr-1.5 rounded-md text-[13px] font-medium tracking-tight no-underline bg-(--crit-brand-cta) text-white hover:bg-(--crit-brand-cta-hover) transition-colors focus:outline-none focus-visible:shadow-[0_0_0_2px_var(--crit-bg-page),0_0_0_4px_var(--crit-focus-ring)]"
+              class="inline-flex items-center gap-1.5 h-[30px] px-3 mr-1.5 rounded-md text-sm font-medium tracking-tight no-underline bg-(--crit-brand-cta) text-white hover:bg-(--crit-brand-cta-hover) transition-colors focus:outline-none focus-visible:shadow-[0_0_0_2px_var(--crit-bg-page),0_0_0_4px_var(--crit-focus-ring)]"
             >
               <%= if @github_oauth? do %>
                 <svg viewBox="0 0 16 16" class="size-3.5 fill-current" aria-hidden="true">
@@ -325,7 +325,7 @@ defmodule CritWeb.Layouts do
         class="sm:hidden bg-(--crit-bg-card) border-t border-(--crit-border)"
       >
         <div class="flex flex-col gap-px px-3 pt-2 pb-3.5">
-          <div class="text-[10.5px] uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-2 pt-2 pb-1">
+          <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-2 pt-2 pb-1">
             Site
           </div>
           <.nav_mobile_link href={~p"/features"} active={@current_page == :features}>
@@ -358,7 +358,7 @@ defmodule CritWeb.Layouts do
               <%= if @current_user.avatar_url do %>
                 <img src={@current_user.avatar_url} alt="" class="h-9 w-9 rounded-md flex-shrink-0" />
               <% else %>
-                <span class="h-9 w-9 rounded-md bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-[13px] font-semibold flex-shrink-0">
+                <span class="h-9 w-9 rounded-md bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-sm font-semibold flex-shrink-0">
                   {@user_initial}
                 </span>
               <% end %>
@@ -374,7 +374,7 @@ defmodule CritWeb.Layouts do
               </div>
             </div>
 
-            <div class="text-[10.5px] uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-2 pt-2 pb-1">
+            <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-2 pt-2 pb-1">
               Account
             </div>
             <.nav_mobile_link href={~p"/dashboard"}>Dashboard</.nav_mobile_link>
@@ -460,12 +460,12 @@ defmodule CritWeb.Layouts do
               class="relative inline-flex items-stretch h-[30px] ml-1 min-w-0 max-sm:hidden text-(--crit-fg-muted) before:content-[''] before:absolute before:left-0 before:top-[7px] before:bottom-[7px] before:w-px before:bg-(--crit-border-strong)"
             >
               <span class="inline-flex items-center px-2.5">
-                <span class="text-[9.5px] font-semibold uppercase tracking-[0.1em] text-(--crit-fg-muted) leading-none">
+                <span class="text-xs font-semibold uppercase tracking-[0.1em] text-(--crit-fg-muted) leading-none">
                   Self-hosted
                 </span>
               </span>
               <span class="relative inline-flex items-center px-2.5 before:content-[''] before:absolute before:left-0 before:top-2 before:bottom-2 before:w-px before:bg-(--crit-border-strong)">
-                <span class="font-mono text-[12.5px] font-medium text-(--crit-fg-primary) tracking-tight truncate max-w-[240px] leading-none">
+                <span class="font-mono text-sm font-medium text-(--crit-fg-primary) tracking-tight truncate max-w-[240px] leading-none">
                   {@host}
                 </span>
               </span>
@@ -513,7 +513,7 @@ defmodule CritWeb.Layouts do
                     class="h-6 w-6 rounded-full flex-shrink-0"
                   />
                 <% else %>
-                  <span class="h-6 w-6 rounded-full bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-[10.5px] font-semibold flex-shrink-0">
+                  <span class="h-6 w-6 rounded-full bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-xs font-semibold flex-shrink-0">
                     {@user_initial}
                   </span>
                 <% end %>
@@ -565,12 +565,12 @@ defmodule CritWeb.Layouts do
                       class="h-9 w-9 rounded-md flex-shrink-0"
                     />
                   <% else %>
-                    <span class="h-9 w-9 rounded-md bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-[13px] font-semibold flex-shrink-0">
+                    <span class="h-9 w-9 rounded-md bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-sm font-semibold flex-shrink-0">
                       {@user_initial}
                     </span>
                   <% end %>
                   <div class="flex flex-col gap-0.5 min-w-0">
-                    <span class="text-[13px] font-semibold text-(--crit-fg-primary) leading-tight">
+                    <span class="text-sm font-semibold text-(--crit-fg-primary) leading-tight">
                       {@current_user.name || @current_user.email}
                     </span>
                     <%= if @current_user.name && @current_user.email do %>
@@ -583,13 +583,13 @@ defmodule CritWeb.Layouts do
 
                 <div class="h-px bg-(--crit-border) my-0.5"></div>
 
-                <div class="text-[10.5px] uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-3 pt-2 pb-1">
+                <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-3 pt-2 pb-1">
                   Account
                 </div>
                 <.link
                   navigate={~p"/settings"}
                   role="menuitem"
-                  class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[13px] text-(--crit-fg-primary) hover:bg-(--crit-row-hover) no-underline"
+                  class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-sm text-(--crit-fg-primary) hover:bg-(--crit-row-hover) no-underline"
                 >
                   <.icon name="hero-cog-6-tooth-mini" class="size-3.5 text-(--crit-fg-muted)" />
                   <span>Settings</span>
@@ -601,7 +601,7 @@ defmodule CritWeb.Layouts do
                   href={~p"/auth/logout"}
                   method="delete"
                   role="menuitem"
-                  class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[13px] text-(--crit-red) hover:bg-(--crit-btn-danger-hover-bg) no-underline"
+                  class="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-sm text-(--crit-red) hover:bg-(--crit-btn-danger-hover-bg) no-underline"
                 >
                   <.icon name="hero-arrow-right-on-rectangle-mini" class="size-3.5" />
                   <span>Sign out</span>
@@ -645,7 +645,7 @@ defmodule CritWeb.Layouts do
               <%= if @current_user.avatar_url do %>
                 <img src={@current_user.avatar_url} alt="" class="h-9 w-9 rounded-md flex-shrink-0" />
               <% else %>
-                <span class="h-9 w-9 rounded-md bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-[13px] font-semibold flex-shrink-0">
+                <span class="h-9 w-9 rounded-md bg-(--crit-brand-bg) text-(--crit-brand) inline-flex items-center justify-center text-sm font-semibold flex-shrink-0">
                   {@user_initial}
                 </span>
               <% end %>
@@ -661,7 +661,7 @@ defmodule CritWeb.Layouts do
               </div>
             </div>
 
-            <div class="text-[10.5px] uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-2 pt-2 pb-1">
+            <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-2 pt-2 pb-1">
               Navigate
             </div>
             <%= if @show_overview_link do %>
@@ -673,7 +673,7 @@ defmodule CritWeb.Layouts do
               Dashboard
             </.nav_mobile_link>
 
-            <div class="text-[10.5px] uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-2 pt-2 pb-1">
+            <div class="text-xs uppercase tracking-wider text-(--crit-fg-muted) font-semibold px-2 pt-2 pb-1">
               Account
             </div>
             <.nav_mobile_link navigate={~p"/settings"} active={@current_page == :settings}>
@@ -718,7 +718,7 @@ defmodule CritWeb.Layouts do
       navigate={@navigate}
       aria-current={@active && "page"}
       class={[
-        "inline-flex items-center h-[30px] px-2.5 rounded-md text-[13px] font-medium tracking-tight no-underline transition-colors",
+        "inline-flex items-center h-[30px] px-2.5 rounded-md text-sm font-medium tracking-tight no-underline transition-colors",
         if(@active,
           do: "text-(--crit-fg-primary) bg-(--crit-bg-card) hover:bg-(--crit-bg-elevated)",
           else:

--- a/lib/crit_web/components/layouts/root.html.heex
+++ b/lib/crit_web/components/layouts/root.html.heex
@@ -79,7 +79,7 @@
   <body class="bg-(--crit-bg-page) text-(--crit-fg-primary)">
     {@inner_content}
     <footer class="border-t border-(--crit-border) bg-(--crit-bg-card)">
-      <div class="max-w-7xl mx-auto px-10 py-8 max-sm:px-5 max-sm:py-6">
+      <div class="max-w-7xl mx-auto px-10 py-8 max-sm:px-4 max-sm:py-6">
         <div class="flex items-start justify-between gap-8 max-sm:flex-col max-sm:gap-5">
           <div class="flex flex-col gap-2">
             <a

--- a/lib/crit_web/components/review_snippet.ex
+++ b/lib/crit_web/components/review_snippet.ex
@@ -31,7 +31,7 @@ defmodule CritWeb.Components.ReviewSnippet do
               :for={{line, idx} <- Enum.with_index(lines, 1)}
               class="grid grid-cols-[44px_1fr] gap-x-2.5 pr-3.5"
             >
-              <span class="text-right text-(--crit-fg-muted) opacity-60 select-none text-[11px] pr-1.5 leading-5">
+              <span class="text-right text-(--crit-fg-muted) opacity-60 select-none text-xs pr-1.5 leading-5">
                 {idx}
               </span>
               <code
@@ -48,15 +48,15 @@ defmodule CritWeb.Components.ReviewSnippet do
       <% {:markdown, html} -> %>
         <div class="border border-(--crit-border) rounded-md overflow-hidden h-[200px] relative px-5 py-3 text-sm
                     [&_h1]:text-base [&_h1]:font-semibold [&_h1]:mt-0 [&_h1]:mb-1.5 [&_h1]:pb-1 [&_h1]:border-b [&_h1]:border-(--crit-border)
-                    [&_h2]:text-[15px] [&_h2]:font-semibold [&_h2]:mt-2.5 [&_h2]:mb-1
+                    [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:mt-2.5 [&_h2]:mb-1
                     [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:mt-2 [&_h3]:mb-1
                     [&_p]:my-1 [&_p]:leading-relaxed
                     [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:my-1
                     [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:my-1
                     [&_li]:my-0.5
                     [&_a]:text-(--crit-brand) [&_a]:underline
-                    [&_code]:font-mono [&_code]:text-[12px] [&_code]:bg-(--crit-bg-elevated) [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded
-                    [&_pre]:font-mono [&_pre]:text-[12px] [&_pre]:bg-(--crit-bg-elevated) [&_pre]:p-2 [&_pre]:rounded [&_pre]:my-1.5 [&_pre]:overflow-hidden
+                    [&_code]:font-mono [&_code]:text-xs [&_code]:bg-(--crit-bg-elevated) [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded
+                    [&_pre]:font-mono [&_pre]:text-xs [&_pre]:bg-(--crit-bg-elevated) [&_pre]:p-2 [&_pre]:rounded [&_pre]:my-1.5 [&_pre]:overflow-hidden
                     [&_pre_code]:bg-transparent [&_pre_code]:px-0 [&_pre_code]:py-0
                     [&_blockquote]:border-l-2 [&_blockquote]:border-(--crit-border-strong) [&_blockquote]:pl-3 [&_blockquote]:text-(--crit-fg-secondary)
                     [&_strong]:font-semibold [&_em]:italic">

--- a/lib/crit_web/controllers/device_html/error.html.heex
+++ b/lib/crit_web/controllers/device_html/error.html.heex
@@ -47,12 +47,8 @@
         </p>
       </div>
 
-      <p class="text-xs text-(--crit-fg-muted) text-center mt-5">
-        Run
-        <code class="font-mono text-(--crit-fg-muted) bg-(--crit-bg-card) border border-(--crit-border) px-1.5 py-0.5 rounded text-[11px]">
-          crit auth login
-        </code>
-        in your terminal to try again.
+      <p phx-no-format class="text-xs text-(--crit-fg-muted) text-center mt-5">
+        Run <code class="font-mono text-(--crit-fg-muted) bg-(--crit-bg-card) border border-(--crit-border) px-1.5 py-0.5 rounded text-xs">crit auth login</code> in your terminal to try again.
       </p>
     </div>
   </body>

--- a/lib/crit_web/controllers/page_html.ex
+++ b/lib/crit_web/controllers/page_html.ex
@@ -15,7 +15,7 @@ defmodule CritWeb.PageHTML do
       case Regex.run(~r/^`([^`]+)`$/, part) do
         [_, code] ->
           Phoenix.HTML.raw(
-            "<code class=\"font-mono text-[0.9em] text-(--crit-brand) bg-(--crit-bg-elevated) px-1 py-0.5 rounded\">#{Phoenix.HTML.html_escape(code) |> Phoenix.HTML.safe_to_string()}</code>"
+            "<code class=\"font-mono text-sm text-(--crit-brand) bg-(--crit-bg-elevated) px-1 py-0.5 rounded\">#{Phoenix.HTML.html_escape(code) |> Phoenix.HTML.safe_to_string()}</code>"
           )
 
         nil ->

--- a/lib/crit_web/controllers/page_html/changelog.html.heex
+++ b/lib/crit_web/controllers/page_html/changelog.html.heex
@@ -55,7 +55,7 @@
               {Crit.Changelog.format_date(release.published_at)}
             </time>
           </div>
-          <div>
+          <div class="min-w-0">
             <div class="changelog-body text-(--crit-fg-secondary)">
               {Phoenix.HTML.raw(release.body_html)}
             </div>
@@ -131,7 +131,7 @@
               {Crit.Changelog.format_date(release.published_at)}
             </time>
           </div>
-          <div>
+          <div class="min-w-0">
             <div class="changelog-body text-(--crit-fg-secondary)">
               {Phoenix.HTML.raw(release.body_html)}
             </div>

--- a/lib/crit_web/controllers/page_html/changelog.html.heex
+++ b/lib/crit_web/controllers/page_html/changelog.html.heex
@@ -1,6 +1,6 @@
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans antialiased">
   <Layouts.site_header current_user={@current_user} current_page={:changelog} />
-  <div class="max-w-7xl mx-auto w-full px-10 mt-16 pb-20 max-sm:px-5 max-sm:pb-10">
+  <div class="max-w-7xl mx-auto w-full px-10 mt-16 pb-20 max-sm:px-4 max-sm:pb-10">
     <header class="mb-14 max-sm:mt-10 max-sm:mb-10">
       <p class="font-mono text-xs tracking-widest uppercase text-(--crit-fg-muted) mb-3">
         Releases

--- a/lib/crit_web/controllers/page_html/feature.html.heex
+++ b/lib/crit_web/controllers/page_html/feature.html.heex
@@ -99,12 +99,11 @@
                 Edit &middot; Delete
               </span>
             </div>
-            <div class="px-3 py-2 font-sans text-(--crit-fg-secondary) leading-relaxed">
-              +1 on OAuth2. See the
-              <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded text-(--crit-brand)">
-                passport.js
-              </code>
-              docs for examples.
+            <div
+              phx-no-format
+              class="px-3 py-2 font-sans text-(--crit-fg-secondary) leading-relaxed"
+            >
+              +1 on OAuth2. See the <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded text-(--crit-brand)">passport.js</code> docs for examples.
             </div>
           </div>
           <div class="flex">
@@ -136,13 +135,11 @@
                 Edit &middot; Delete
               </span>
             </div>
-            <div class="px-3 py-2 font-sans text-(--crit-fg-secondary) leading-relaxed">
-              bcrypt is fine but
-              <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded text-(--crit-brand)">
-                argon2id
-              </code>
-              is the <em>current</em>
-              recommendation.
+            <div
+              phx-no-format
+              class="px-3 py-2 font-sans text-(--crit-fg-secondary) leading-relaxed"
+            >
+              bcrypt is fine but <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded text-(--crit-brand)">argon2id</code> is the <em>current</em> recommendation.
             </div>
           </div>
         </div>

--- a/lib/crit_web/controllers/page_html/feature.html.heex
+++ b/lib/crit_web/controllers/page_html/feature.html.heex
@@ -4,7 +4,7 @@
   <Layouts.site_header current_user={@current_user} current_page={:features} />
   
 <!-- Breadcrumb -->
-  <div class="max-w-7xl mx-auto w-full px-10 mt-10 max-sm:px-5 max-sm:mt-5">
+  <div class="max-w-7xl mx-auto w-full px-10 mt-10 max-sm:px-4 max-sm:mt-5">
     <a
       href={~p"/features"}
       class="text-sm text-(--crit-fg-muted) no-underline hover:text-(--crit-fg-primary) transition-colors"
@@ -14,7 +14,7 @@
   </div>
   
 <!-- Hero -->
-  <section class="max-w-7xl mx-auto w-full px-10 mt-6 max-sm:px-5">
+  <section class="max-w-7xl mx-auto w-full px-10 mt-6 max-sm:px-4">
     <p class="font-mono text-xs tracking-widest uppercase text-(--crit-brand) mb-3">
       Feature
     </p>
@@ -27,7 +27,7 @@
   </section>
   
 <!-- Visual widget -->
-  <section class="max-w-7xl mx-auto w-full px-10 mt-16 max-sm:px-5 max-sm:mt-8">
+  <section class="max-w-7xl mx-auto w-full px-10 mt-16 max-sm:px-4 max-sm:mt-8">
     <%= case @slug do %>
       <% "inline-comments" -> %>
         <div
@@ -425,7 +425,7 @@
   </section>
   
 <!-- Details -->
-  <section class="max-w-7xl mx-auto w-full px-10 mt-16 max-sm:px-5 max-sm:mt-8">
+  <section class="max-w-7xl mx-auto w-full px-10 mt-16 max-sm:px-4 max-sm:mt-8">
     <h2 class="text-2xl font-extrabold tracking-tight mb-6">How it works</h2>
     <div class="grid gap-5">
       <%= for {detail, idx} <- Enum.with_index(@feature.details) do %>
@@ -443,7 +443,7 @@
   
 <!-- Why this matters -->
   <%= if @feature[:why_this_matters] do %>
-    <section class="max-w-7xl mx-auto w-full px-10 mt-16 max-sm:px-5 max-sm:mt-8">
+    <section class="max-w-7xl mx-auto w-full px-10 mt-16 max-sm:px-4 max-sm:mt-8">
       <h2 class="text-2xl font-extrabold tracking-tight mb-6">Why this matters</h2>
       <div class="flex flex-col gap-4">
         <%= for paragraph <- @feature.why_this_matters do %>
@@ -457,7 +457,7 @@
   
 <!-- How Crit compares -->
   <%= if @feature[:how_crit_compares] do %>
-    <section class="max-w-7xl mx-auto w-full px-10 mt-16 max-sm:px-5 max-sm:mt-8">
+    <section class="max-w-7xl mx-auto w-full px-10 mt-16 max-sm:px-4 max-sm:mt-8">
       <h2 class="text-2xl font-extrabold tracking-tight mb-4">How Crit compares</h2>
       <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
         {CritWeb.PageHTML.inline_code(@feature.how_crit_compares)}
@@ -466,7 +466,7 @@
   <% end %>
   
 <!-- Demo + Install CTA -->
-  <section class="max-w-7xl mx-auto w-full px-10 mt-14 mb-16 max-sm:px-5 max-sm:mt-10">
+  <section class="max-w-7xl mx-auto w-full px-10 mt-14 mb-16 max-sm:px-4 max-sm:mt-10">
     <div class="border border-(--crit-border) rounded-lg bg-(--crit-bg-card) p-8 max-sm:p-5">
       <h2 class="text-2xl font-extrabold tracking-tight mb-2">Try it out</h2>
       <p class="text-sm text-(--crit-fg-secondary) mb-6">
@@ -498,7 +498,7 @@
   </section>
   
 <!-- Other features -->
-  <section class="max-w-7xl mx-auto w-full px-10 mb-16 max-sm:px-5">
+  <section class="max-w-7xl mx-auto w-full px-10 mb-16 max-sm:px-4">
     <p class="font-mono text-xs tracking-widest uppercase text-(--crit-brand) mb-4">
       More features
     </p>

--- a/lib/crit_web/controllers/page_html/features.html.heex
+++ b/lib/crit_web/controllers/page_html/features.html.heex
@@ -3,7 +3,7 @@
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
   <Layouts.site_header current_user={@current_user} current_page={:features} />
 
-  <section class="max-w-7xl mx-auto w-full px-10 mt-16 max-sm:px-5 max-sm:mt-10">
+  <section class="max-w-7xl mx-auto w-full px-10 mt-16 max-sm:px-4 max-sm:mt-10">
     <p class="font-mono text-xs tracking-widest uppercase text-(--crit-brand) mb-3">
       Features
     </p>
@@ -16,7 +16,7 @@
     </p>
   </section>
 
-  <section class="max-w-7xl mx-auto w-full px-10 mt-16 mb-16 max-sm:px-5 max-sm:mt-8">
+  <section class="max-w-7xl mx-auto w-full px-10 mt-16 mb-16 max-sm:px-4 max-sm:mt-8">
     <div class="grid grid-cols-2 gap-5 max-sm:grid-cols-1">
       <%= for slug <- @feature_order do %>
         <% feature = @features[slug] %>

--- a/lib/crit_web/controllers/page_html/getting_started.html.heex
+++ b/lib/crit_web/controllers/page_html/getting_started.html.heex
@@ -1,6 +1,6 @@
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans antialiased">
   <Layouts.site_header current_user={@current_user} current_page={:getting_started} />
-  <div class="max-w-7xl mx-auto mt-16 px-10 pb-20 max-sm:px-5 max-sm:pb-12">
+  <div class="max-w-7xl mx-auto mt-16 px-10 pb-20 max-sm:px-4 max-sm:pb-12">
     <%!-- Hero --%>
     <section class="mb-14 max-sm:mt-10 max-sm:mb-10">
       <p class="font-mono text-xs tracking-widest uppercase text-(--crit-brand) mb-3">

--- a/lib/crit_web/controllers/page_html/home.html.heex
+++ b/lib/crit_web/controllers/page_html/home.html.heex
@@ -3,7 +3,7 @@
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
   <Layouts.site_header current_user={@current_user} />
 
-  <section class="max-w-7xl mx-auto pt-24 pb-16 px-10 w-full max-sm:px-5 max-sm:pt-14 max-sm:pb-10">
+  <section class="max-w-7xl mx-auto pt-24 pb-16 px-10 w-full max-sm:px-4 max-sm:pt-14 max-sm:pb-10">
     <div class="text-center max-w-3xl mx-auto mb-14 max-sm:mb-10">
       <p class="font-mono text-xs tracking-widest uppercase text-(--crit-brand) mb-5">
         Local-first · No login · Works with any agent
@@ -86,7 +86,7 @@
   </section>
   
 <!-- ===== Install ===== -->
-  <section class="max-w-7xl mx-auto mt-24 px-10 max-sm:px-5 max-sm:mt-16 w-full" id="install">
+  <section class="max-w-7xl mx-auto mt-24 px-10 max-sm:px-4 max-sm:mt-16 w-full" id="install">
     <div class="flex gap-14 items-start max-lg:flex-col max-lg:gap-6">
       <div class="w-[300px] shrink-0 max-lg:w-full">
         <p class="font-mono text-xs tracking-widest uppercase text-(--crit-brand) mb-3">
@@ -104,7 +104,7 @@
   </section>
   
 <!-- ===== Agent Setup ===== -->
-  <section class="max-w-7xl mx-auto mt-14 px-10 max-sm:px-5 max-sm:mt-10 w-full" id="agent-setup">
+  <section class="max-w-7xl mx-auto mt-14 px-10 max-sm:px-4 max-sm:mt-10 w-full" id="agent-setup">
     <div class="flex gap-14 items-start max-lg:flex-col max-lg:gap-6">
       <div class="w-[300px] shrink-0 max-lg:w-full">
         <p class="font-mono text-xs tracking-widest uppercase text-(--crit-brand) mb-3">
@@ -123,7 +123,7 @@
   
 <!-- ===== Features ===== -->
   <section
-    class="max-w-7xl mx-auto mt-28 mb-20 px-10 max-sm:px-5 max-sm:mt-16 w-full"
+    class="max-w-7xl mx-auto mt-28 mb-20 px-10 max-sm:px-4 max-sm:mt-16 w-full"
     id="features"
   >
     <p class="font-mono text-xs tracking-widest uppercase text-(--crit-brand) mb-4">
@@ -451,7 +451,7 @@
   </section>
 
   <%!-- ===== Testimonials ===== --%>
-  <section class="max-w-7xl mx-auto mt-28 mb-20 px-10 max-sm:px-5 max-sm:mt-16 w-full">
+  <section class="max-w-7xl mx-auto mt-28 mb-20 px-10 max-sm:px-4 max-sm:mt-16 w-full">
     <p class="font-mono text-xs tracking-widest uppercase text-(--crit-brand) mb-4">
       What engineers are saying
     </p>
@@ -532,7 +532,7 @@
   </section>
   <!-- ===== Self-Hosting ===== -->
   <section
-    class="max-w-7xl mx-auto mt-16 mb-20 px-10 max-sm:px-5 w-full"
+    class="max-w-7xl mx-auto mt-16 mb-20 px-10 max-sm:px-4 w-full"
     id="self-hosting-card"
   >
     <a

--- a/lib/crit_web/controllers/page_html/integration.html.heex
+++ b/lib/crit_web/controllers/page_html/integration.html.heex
@@ -77,15 +77,9 @@
                 </button>
               </div>
             </div>
-            <p class="text-(--crit-fg-secondary) leading-relaxed">
-              Run from the project root to add the
-              <code class="text-(--crit-brand) bg-(--crit-bg-elevated) px-1.5 py-0.5 rounded">
-                /crit
-              </code>
-              and
-              <code class="text-(--crit-brand) bg-(--crit-bg-elevated) px-1.5 py-0.5 rounded">
-                crit-cli
-              </code>
+            <p class="text-(--crit-fg-secondary) leading-relaxed" phx-no-format>
+              Run from the project root to add the <code class="text-(--crit-brand) bg-(--crit-bg-elevated) px-1.5 py-0.5 rounded">/crit</code>
+              and <code class="text-(--crit-brand) bg-(--crit-bg-elevated) px-1.5 py-0.5 rounded">crit-cli</code>
               skills to the repo. The whole team gets them once pushed.
             </p>
           </div>
@@ -124,11 +118,8 @@
                   </button>
                 </div>
               </div>
-              <p class="text-(--crit-fg-secondary) leading-relaxed mb-6">
-                Available across all projects. To commit the integration into a single repo instead, run
-                <code class="text-(--crit-brand) bg-(--crit-bg-elevated) px-1.5 py-0.5 rounded">
-                  {@tool.command}
-                </code>
+              <p class="text-(--crit-fg-secondary) leading-relaxed mb-6" phx-no-format>
+                Available across all projects. To commit the integration into a single repo instead, run <code class="text-(--crit-brand) bg-(--crit-bg-elevated) px-1.5 py-0.5 rounded">{@tool.command}</code>
                 from the project root.
               </p>
             <% true -> %>

--- a/lib/crit_web/controllers/page_html/integration.html.heex
+++ b/lib/crit_web/controllers/page_html/integration.html.heex
@@ -4,7 +4,7 @@
   <Layouts.site_header current_user={@current_user} current_page={:integrations} />
   
 <!-- Breadcrumb -->
-  <div class="max-w-7xl mx-auto w-full px-10 mt-8 max-sm:px-5 max-sm:mt-5">
+  <div class="max-w-7xl mx-auto w-full px-10 mt-8 max-sm:px-4 max-sm:mt-5">
     <a
       href={~p"/integrations"}
       class="text-(--crit-fg-muted) no-underline hover:text-(--crit-fg-primary) transition-colors"
@@ -14,7 +14,7 @@
   </div>
   
 <!-- Hero -->
-  <section class="max-w-7xl mx-auto w-full px-10 mt-6 max-sm:px-5">
+  <section class="max-w-7xl mx-auto w-full px-10 mt-6 max-sm:px-4">
     <h1 class="flex items-center gap-4 text-4xl font-extrabold leading-tight tracking-tight mb-4 max-sm:text-3xl max-sm:gap-3">
       <%= case @tool.logo do %>
         <% nil -> %>
@@ -40,7 +40,7 @@
   </section>
   
 <!-- Install -->
-  <section class="max-w-7xl mx-auto w-full px-10 mt-12 max-sm:px-5 max-sm:mt-8">
+  <section class="max-w-7xl mx-auto w-full px-10 mt-12 max-sm:px-4 max-sm:mt-8">
     <div>
       <%= case Map.get(@tool, :marketplace) do %>
         <% marketplace when is_map(marketplace) -> %>
@@ -160,7 +160,7 @@
   </section>
   
 <!-- GitHub link -->
-  <div class="max-w-7xl mx-auto w-full px-10 my-16 text-center max-sm:px-5">
+  <div class="max-w-7xl mx-auto w-full px-10 my-16 text-center max-sm:px-4">
     <a
       href={"https://github.com/tomasz-tomczyk/crit/tree/main/integrations/#{@tool.id}"}
       class="crit-link"

--- a/lib/crit_web/controllers/page_html/integrations.html.heex
+++ b/lib/crit_web/controllers/page_html/integrations.html.heex
@@ -4,7 +4,7 @@
   <Layouts.site_header current_user={@current_user} current_page={:integrations} />
   
 <!-- Breadcrumb -->
-  <div class="max-w-7xl mx-auto w-full px-10 mt-8 max-sm:px-5 max-sm:mt-5">
+  <div class="max-w-7xl mx-auto w-full px-10 mt-8 max-sm:px-4 max-sm:mt-5">
     <a
       href={~p"/"}
       class="text-(--crit-fg-muted) no-underline hover:text-(--crit-fg-primary) transition-colors"
@@ -14,14 +14,14 @@
   </div>
   
 <!-- Hero -->
-  <section class="max-w-7xl mx-auto w-full px-10 mt-6 max-sm:px-5">
+  <section class="max-w-7xl mx-auto w-full px-10 mt-6 max-sm:px-4">
     <h1 class="text-4xl font-extrabold leading-tight tracking-tight max-sm:text-3xl">
       Agent integrations for Crit<span class="text-(--crit-brand)">.</span>
     </h1>
   </section>
   
 <!-- Cards -->
-  <section class="max-w-7xl mx-auto w-full px-10 mt-12 mb-16 max-sm:px-5 max-sm:mt-8">
+  <section class="max-w-7xl mx-auto w-full px-10 mt-12 mb-16 max-sm:px-4 max-sm:mt-8">
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
       <.link
         :for={tool <- Crit.Integrations.tools()}

--- a/lib/crit_web/controllers/page_html/privacy.html.heex
+++ b/lib/crit_web/controllers/page_html/privacy.html.heex
@@ -6,18 +6,18 @@
       <p class="text-sm text-(--crit-fg-muted) mb-10">Last updated: March 2026</p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Who operates this</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         Crit is operated by Tomasz Tomczyk as an independent open-source project.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Local use</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         When you use Crit locally (without sharing), no data leaves your machine.
         Documents and comments are stored only in files on your computer.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">CLI update check</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         On startup, the Crit CLI contacts api.github.com to check for a new version.
         This request includes your IP address and current Crit version as the User-Agent
         header. GitHub's privacy policy governs how GitHub handles this data. You can
@@ -25,35 +25,35 @@
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Shared reviews</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         When you share a review, the following is stored on our servers:
       </p>
-      <ul class="text-sm leading-relaxed text-(--crit-fg-secondary) pl-5 mt-2">
+      <ul class="leading-relaxed text-(--crit-fg-secondary) pl-5 mt-2">
         <li class="mb-1">The document content (markdown text)</li>
         <li class="mb-1">Any comments included at the time of sharing</li>
         <li class="mb-1">The time the review was created</li>
       </ul>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary) mt-2">
+      <p class="leading-relaxed text-(--crit-fg-secondary) mt-2">
         Comments added by anyone who visits the shared link are also stored on our servers,
         subject to the same 30-day retention policy.
       </p>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary) mt-2">
+      <p class="leading-relaxed text-(--crit-fg-secondary) mt-2">
         This data is accessible to anyone with the share link. The link is a secret URL that
         serves as the primary access control. GitHub login is optional and not required to
         view or comment on shared reviews.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">GitHub login</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         On crit.md, you can optionally sign in with your GitHub account. If you do, we store:
       </p>
-      <ul class="text-sm leading-relaxed text-(--crit-fg-secondary) pl-5 mt-2">
+      <ul class="leading-relaxed text-(--crit-fg-secondary) pl-5 mt-2">
         <li class="mb-1">Your GitHub username and display name</li>
         <li class="mb-1">Your primary GitHub email address</li>
         <li class="mb-1">Your GitHub avatar URL</li>
         <li class="mb-1">Your GitHub user ID (used as a stable identifier)</li>
       </ul>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary) mt-2">
+      <p class="leading-relaxed text-(--crit-fg-secondary) mt-2">
         This information is used solely to identify you across sessions and to display your name
         on reviews and comments you create. We do not share it with third parties.
         You can delete your account by emailing <a
@@ -63,24 +63,24 @@
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Anonymous session</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         When you view a shared review, we set a session cookie containing a randomly generated
         anonymous identifier. This lets you edit or delete comments you left in that session.
         The identifier is not linked to any personal information and is not used for tracking.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Tracking</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         We do not use analytics or advertising trackers on this site.
       </p>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary) mt-2">
+      <p class="leading-relaxed text-(--crit-fg-secondary) mt-2">
         The homepage includes an embedded YouTube video. If you visit the homepage,
         YouTube (Google) may set cookies and collect data according to <a
           href="https://policies.google.com/privacy"
           class="crit-link"
         >Google's privacy policy</a>.
       </p>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary) mt-2">
+      <p class="leading-relaxed text-(--crit-fg-secondary) mt-2">
         If you sign in with GitHub, your browser connects to GitHub's OAuth service.
         GitHub's
         <a
@@ -94,7 +94,7 @@
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Server logs</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         Our server records standard HTTP access logs (IP address, timestamp, path, response code).
         These are used solely for debugging and abuse prevention. IP addresses are also used
         in memory for rate limiting. These are not persisted beyond what appears in access logs.
@@ -102,7 +102,7 @@
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Infrastructure</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         This service runs on <a
           href="https://fly.io/legal/privacy-policy/"
           class="crit-link"
@@ -110,14 +110,14 @@
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Data retention</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         Shared reviews are retained for 30 days from the date of last activity, then
         deleted automatically. You can delete a shared review at any time using the
         Unpublish button in Crit.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Contact</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         For privacy questions, open an issue on <a
           href="https://github.com/tomasz-tomczyk/crit"
           class="crit-link"

--- a/lib/crit_web/controllers/page_html/privacy.html.heex
+++ b/lib/crit_web/controllers/page_html/privacy.html.heex
@@ -1,6 +1,6 @@
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans antialiased">
   <Layouts.site_header current_user={@current_user} />
-  <div class="max-w-[900px] mx-auto px-10 pb-15 max-sm:px-5 max-sm:pb-10">
+  <div class="max-w-[900px] mx-auto px-10 pb-15 max-sm:px-4 max-sm:pb-10">
     <main class="mt-12">
       <h1 class="text-4xl font-extrabold tracking-tight mb-2">Privacy Policy</h1>
       <p class="text-sm text-(--crit-fg-muted) mb-10">Last updated: March 2026</p>

--- a/lib/crit_web/controllers/page_html/self_hosting.html.heex
+++ b/lib/crit_web/controllers/page_html/self_hosting.html.heex
@@ -130,14 +130,8 @@
         </div>
       </div>
 
-      <p class="text-sm text-(--crit-fg-secondary) mt-3 leading-relaxed">
-        Set
-        <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">
-          SECRET_KEY_BASE
-        </code>
-        and <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">PHX_HOST</code>
-        in your <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">.env</code>
-        file.
+      <p phx-no-format class="text-sm text-(--crit-fg-secondary) mt-3 leading-relaxed">
+        Set <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">SECRET_KEY_BASE</code> and <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">PHX_HOST</code> in your <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">.env</code> file.
       </p>
     </section>
 
@@ -306,11 +300,8 @@
         <div class="divide-y divide-(--crit-border)">
           <div class="grid grid-cols-[minmax(160px,220px)_1fr_80px] gap-x-4 items-baseline px-4 py-3 bg-(--crit-bg-card) max-sm:grid-cols-1 max-sm:gap-y-1">
             <code class="text-sm font-mono text-(--crit-fg-primary)">SECRET_KEY_BASE</code>
-            <p class="text-sm text-(--crit-fg-secondary)">
-              64+ byte secret for signing cookies. Generate with
-              <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">
-                openssl rand -base64 64
-              </code>
+            <p phx-no-format class="text-sm text-(--crit-fg-secondary)">
+              64+ byte secret for signing cookies. Generate with <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">openssl rand -base64 64</code>
             </p>
             <span class="text-xs font-mono text-(--crit-brand) sm:text-right">required</span>
           </div>
@@ -367,12 +358,8 @@
         <div class="divide-y divide-(--crit-border)">
           <div class="grid grid-cols-[minmax(160px,220px)_1fr_80px] gap-x-4 items-baseline px-4 py-3 bg-(--crit-bg-card) max-sm:grid-cols-1 max-sm:gap-y-1">
             <code class="text-sm font-mono text-(--crit-fg-primary)">GITHUB_CLIENT_ID</code>
-            <p class="text-sm text-(--crit-fg-secondary)">
-              GitHub OAuth App client ID. Set alongside
-              <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">
-                GITHUB_CLIENT_SECRET
-              </code>
-              to enable GitHub login. When set, OAuth is required to access the dashboard and view reviews.
+            <p phx-no-format class="text-sm text-(--crit-fg-secondary)">
+              GitHub OAuth App client ID. Set alongside <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">GITHUB_CLIENT_SECRET</code> to enable GitHub login. When set, OAuth is required to access the dashboard and view reviews.
             </p>
             <span class="text-xs font-mono text-(--crit-fg-muted) sm:text-right">optional</span>
           </div>
@@ -383,13 +370,8 @@
           </div>
           <div class="grid grid-cols-[minmax(160px,220px)_1fr_80px] gap-x-4 items-baseline px-4 py-3 bg-(--crit-bg-card) max-sm:grid-cols-1 max-sm:gap-y-1">
             <code class="text-sm font-mono text-(--crit-fg-primary)">OAUTH_CLIENT_ID</code>
-            <p class="text-sm text-(--crit-fg-secondary)">
-              Generic OIDC/OAuth2 client ID. Use with
-              <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">
-                OAUTH_CLIENT_SECRET
-              </code>
-              and <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">OAUTH_BASE_URL</code>
-              for providers like Google, GitLab, or Okta. Mutually exclusive with <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">GITHUB_CLIENT_ID</code>.
+            <p phx-no-format class="text-sm text-(--crit-fg-secondary)">
+              Generic OIDC/OAuth2 client ID. Use with <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">OAUTH_CLIENT_SECRET</code> and <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">OAUTH_BASE_URL</code> for providers like Google, GitLab, or Okta. Mutually exclusive with <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">GITHUB_CLIENT_ID</code>.
             </p>
             <span class="text-xs font-mono text-(--crit-fg-muted) sm:text-right">optional</span>
           </div>
@@ -400,11 +382,8 @@
           </div>
           <div class="grid grid-cols-[minmax(160px,220px)_1fr_80px] gap-x-4 items-baseline px-4 py-3 bg-(--crit-bg-card) max-sm:grid-cols-1 max-sm:gap-y-1">
             <code class="text-sm font-mono text-(--crit-fg-primary)">OAUTH_BASE_URL</code>
-            <p class="text-sm text-(--crit-fg-secondary)">
-              OIDC discovery base URL, e.g.
-              <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">
-                https://accounts.google.com
-              </code>
+            <p phx-no-format class="text-sm text-(--crit-fg-secondary)">
+              OIDC discovery base URL, e.g. <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">https://accounts.google.com</code>
             </p>
             <span class="text-xs font-mono text-(--crit-fg-muted) sm:text-right">optional</span>
           </div>

--- a/lib/crit_web/controllers/page_html/self_hosting.html.heex
+++ b/lib/crit_web/controllers/page_html/self_hosting.html.heex
@@ -1,6 +1,6 @@
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans antialiased">
   <Layouts.site_header current_user={@current_user} current_page={:self_hosting} />
-  <div class="max-w-7xl mx-auto px-10 pb-20 max-sm:px-5 max-sm:pb-12">
+  <div class="max-w-7xl mx-auto px-10 pb-20 max-sm:px-4 max-sm:pb-12">
     <%!-- Hero --%>
     <section class="mt-16 mb-14 max-sm:mt-10 max-sm:mb-10">
       <p class="font-mono text-xs tracking-widest uppercase text-(--crit-brand) mb-3">

--- a/lib/crit_web/controllers/page_html/terms.html.heex
+++ b/lib/crit_web/controllers/page_html/terms.html.heex
@@ -1,6 +1,6 @@
 <div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans antialiased">
   <Layouts.site_header current_user={@current_user} />
-  <div class="max-w-[900px] mx-auto px-10 pb-15 max-sm:px-5 max-sm:pb-10">
+  <div class="max-w-[900px] mx-auto px-10 pb-15 max-sm:px-4 max-sm:pb-10">
     <main class="mt-12">
       <h1 class="text-4xl font-extrabold tracking-tight mb-2">Terms of Service</h1>
       <p class="text-sm text-(--crit-fg-muted) mb-10">Last updated: March 2026</p>

--- a/lib/crit_web/controllers/page_html/terms.html.heex
+++ b/lib/crit_web/controllers/page_html/terms.html.heex
@@ -6,30 +6,30 @@
       <p class="text-sm text-(--crit-fg-muted) mb-10">Last updated: March 2026</p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">What Crit is</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         Crit is an open-source tool (MIT license) for inline review of markdown documents.
         The CLI runs locally on your machine. This website hosts a web UI that lets you
         view and comment on documents shared via a share link.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Who operates this</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         Crit is operated by Tomasz Tomczyk as an independent open-source project.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">
         Use of the shared review service
       </h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         When you share a document using the Share button in Crit, your document and its
         comments are uploaded to this server and made accessible via a unique share link.
         The share link is a secret URL that serves as the only access control for the review.
         Anyone with the link can view and comment on the review.
       </p>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary) mt-2">
+      <p class="leading-relaxed text-(--crit-fg-secondary) mt-2">
         By sharing a document, you agree:
       </p>
-      <ul class="text-sm leading-relaxed text-(--crit-fg-secondary) pl-5 mt-2">
+      <ul class="leading-relaxed text-(--crit-fg-secondary) pl-5 mt-2">
         <li class="mb-1">You have the right to share the document's contents.</li>
         <li class="mb-1">
           You will not use the service to share illegal, harmful, or abusive content.
@@ -38,41 +38,41 @@
       </ul>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">GitHub accounts</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         On crit.md, you can optionally sign in with your GitHub account. This is not required
         to use the service — you can share, view, and comment on reviews without an account.
       </p>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary) mt-2">
+      <p class="leading-relaxed text-(--crit-fg-secondary) mt-2">
         If you choose to sign in, your GitHub profile information (username, display name,
         email, and avatar) is stored on our servers and used to identify you across sessions.
         See the Privacy Policy for details on what is stored and how to request deletion.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">CLI update check</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         On startup, the Crit CLI checks for a newer version by making a request to
         api.github.com. This sends your IP address to GitHub. You can disable this by
         setting the environment variable <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">CRIT_NO_UPDATE_CHECK=1</code>.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Limits</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         Shared documents are limited to 2 MB of content, 500 comments, and 50 KB per comment body.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Shared review data</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         Shared reviews are retained for 30 days from the date of last activity, then
         deleted automatically. Do not rely on this service as a permanent store for
         important content.
       </p>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary) mt-2">
+      <p class="leading-relaxed text-(--crit-fg-secondary) mt-2">
         You can delete a shared review at any time using the Unpublish button in Crit.
         This immediately and permanently removes the review from our servers.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">No warranties</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         Crit is provided "as is", without warranty of any kind. We make no guarantees
         about uptime, data retention, or fitness for any particular purpose. To the maximum
         extent permitted by applicable law, we are not liable for any loss, corruption, or
@@ -80,7 +80,7 @@
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Changes</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         We may update these terms at any time. The "Last updated" date on this page reflects
         when terms last changed. Significant changes will be noted in the <a
           href="https://github.com/tomasz-tomczyk/crit/releases"
@@ -89,7 +89,7 @@
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Contact</h2>
-      <p class="text-sm leading-relaxed text-(--crit-fg-secondary)">
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
         For questions, open an issue on <a
           href="https://github.com/tomasz-tomczyk/crit"
           class="crit-link"

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -93,15 +93,17 @@
           <%!-- Steps --%>
           <div class="flex flex-col">
             <%!-- Step 1: Install --%>
-            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:grid-cols-[24px_1fr] max-sm:gap-x-3">
-              <div class="flex flex-col items-center">
-                <div class="w-8 h-8 max-sm:w-6 max-sm:h-6 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm max-sm:text-xs font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:block">
+              <div class="flex flex-col items-center max-sm:hidden">
+                <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
                   1
                 </div>
                 <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
               </div>
               <div class="pb-8 min-w-0">
-                <div class="text-xl font-bold tracking-tight leading-8">Install crit</div>
+                <div class="text-xl font-bold tracking-tight leading-8">
+                  <span class="sm:hidden text-(--crit-fg-muted) font-normal mr-1.5">1.</span>Install crit
+                </div>
                 <div class="mt-3">
                   <CritWeb.PageHTML.install_widget />
                 </div>
@@ -109,15 +111,17 @@
             </div>
 
             <%!-- Step 2: Connect your agent --%>
-            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:grid-cols-[24px_1fr] max-sm:gap-x-3">
-              <div class="flex flex-col items-center">
-                <div class="w-8 h-8 max-sm:w-6 max-sm:h-6 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm max-sm:text-xs font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:block">
+              <div class="flex flex-col items-center max-sm:hidden">
+                <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
                   2
                 </div>
                 <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
               </div>
               <div class="pb-8 min-w-0">
-                <div class="text-xl font-bold tracking-tight leading-8">Connect your agent</div>
+                <div class="text-xl font-bold tracking-tight leading-8">
+                  <span class="sm:hidden text-(--crit-fg-muted) font-normal mr-1.5">2.</span>Connect your agent
+                </div>
                 <div class="mt-3">
                   <CritWeb.PageHTML.agent_setup_widget />
                 </div>
@@ -126,16 +130,16 @@
 
             <%= if @selfhosted do %>
               <%!-- Step 3 (selfhosted): Point crit at this instance --%>
-              <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:grid-cols-[24px_1fr] max-sm:gap-x-3">
-                <div class="flex flex-col items-center">
-                  <div class="w-8 h-8 max-sm:w-6 max-sm:h-6 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm max-sm:text-xs font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+              <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:block">
+                <div class="flex flex-col items-center max-sm:hidden">
+                  <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
                     3
                   </div>
                   <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
                 </div>
                 <div class="pb-8 min-w-0">
                   <div class="text-xl font-bold tracking-tight leading-8">
-                    Point crit at this instance
+                    <span class="sm:hidden text-(--crit-fg-muted) font-normal mr-1.5">3.</span>Point crit at this instance
                   </div>
                   <p
                     class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed"
@@ -170,15 +174,17 @@
             <% end %>
 
             <%!-- Step: Log in --%>
-            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:grid-cols-[24px_1fr] max-sm:gap-x-3">
-              <div class="flex flex-col items-center">
-                <div class="w-8 h-8 max-sm:w-6 max-sm:h-6 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm max-sm:text-xs font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:block">
+              <div class="flex flex-col items-center max-sm:hidden">
+                <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
                   {if @selfhosted, do: 4, else: 3}
                 </div>
                 <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
               </div>
               <div class="pb-8 min-w-0">
-                <div class="text-xl font-bold tracking-tight leading-8">Log in</div>
+                <div class="text-xl font-bold tracking-tight leading-8">
+                  <span class="sm:hidden text-(--crit-fg-muted) font-normal mr-1.5">{if @selfhosted, do: 4, else: 3}.</span>Log in
+                </div>
                 <p class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed" phx-no-format>
                   Run <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">crit auth login</code>
                   to link shared reviews to your account. Opens your browser for a one-time confirmation.
@@ -199,14 +205,16 @@
             </div>
 
             <%!-- Step: Share --%>
-            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:grid-cols-[24px_1fr] max-sm:gap-x-3">
-              <div class="flex flex-col items-center">
-                <div class="w-8 h-8 max-sm:w-6 max-sm:h-6 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm max-sm:text-xs font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:block">
+              <div class="flex flex-col items-center max-sm:hidden">
+                <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
                   {if @selfhosted, do: 5, else: 4}
                 </div>
               </div>
               <div>
-                <div class="text-xl font-bold tracking-tight leading-8">Share to the web</div>
+                <div class="text-xl font-bold tracking-tight leading-8">
+                  <span class="sm:hidden text-(--crit-fg-muted) font-normal mr-1.5">{if @selfhosted, do: 5, else: 4}.</span>Share to the web
+                </div>
                 <p class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed" phx-no-format>
                   When you're ready, run <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">crit share</code>
                   to upload your review to a shareable URL.

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -100,7 +100,7 @@
                 </div>
                 <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
               </div>
-              <div class="pb-8">
+              <div class="pb-8 min-w-0">
                 <div class="text-xl font-bold tracking-tight leading-8">Install crit</div>
                 <div class="mt-3">
                   <CritWeb.PageHTML.install_widget />
@@ -116,7 +116,7 @@
                 </div>
                 <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
               </div>
-              <div class="pb-8">
+              <div class="pb-8 min-w-0">
                 <div class="text-xl font-bold tracking-tight leading-8">Connect your agent</div>
                 <div class="mt-3">
                   <CritWeb.PageHTML.agent_setup_widget />
@@ -133,7 +133,7 @@
                   </div>
                   <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
                 </div>
-                <div class="pb-8">
+                <div class="pb-8 min-w-0">
                   <div class="text-xl font-bold tracking-tight leading-8">
                     Point crit at this instance
                   </div>
@@ -177,7 +177,7 @@
                 </div>
                 <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
               </div>
-              <div class="pb-8">
+              <div class="pb-8 min-w-0">
                 <div class="text-xl font-bold tracking-tight leading-8">Log in</div>
                 <p class="mt-1.5 text-sm text-(--crit-fg-secondary) leading-relaxed" phx-no-format>
                   Run <code class="font-mono text-sm text-(--crit-brand) bg-(--crit-brand-subtle) px-1 py-0.5 rounded">crit auth login</code>

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -86,7 +86,7 @@
               Get your first review on the web
             </h2>
             <p class="text-xl max-sm:text-base leading-relaxed text-(--crit-fg-secondary) max-w-2xl mx-auto mb-10">
-              Install the CLI, connect your agent, then share your review with a single command.
+              Install crit, connect your agent, share your review in one command.
             </p>
           </div>
 

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -93,9 +93,9 @@
           <%!-- Steps --%>
           <div class="flex flex-col">
             <%!-- Step 1: Install --%>
-            <div class="grid grid-cols-[40px_1fr] gap-x-5">
+            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:grid-cols-[24px_1fr] max-sm:gap-x-3">
               <div class="flex flex-col items-center">
-                <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+                <div class="w-8 h-8 max-sm:w-6 max-sm:h-6 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm max-sm:text-xs font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
                   1
                 </div>
                 <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
@@ -109,9 +109,9 @@
             </div>
 
             <%!-- Step 2: Connect your agent --%>
-            <div class="grid grid-cols-[40px_1fr] gap-x-5">
+            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:grid-cols-[24px_1fr] max-sm:gap-x-3">
               <div class="flex flex-col items-center">
-                <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+                <div class="w-8 h-8 max-sm:w-6 max-sm:h-6 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm max-sm:text-xs font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
                   2
                 </div>
                 <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
@@ -126,9 +126,9 @@
 
             <%= if @selfhosted do %>
               <%!-- Step 3 (selfhosted): Point crit at this instance --%>
-              <div class="grid grid-cols-[40px_1fr] gap-x-5">
+              <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:grid-cols-[24px_1fr] max-sm:gap-x-3">
                 <div class="flex flex-col items-center">
-                  <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+                  <div class="w-8 h-8 max-sm:w-6 max-sm:h-6 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm max-sm:text-xs font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
                     3
                   </div>
                   <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
@@ -170,9 +170,9 @@
             <% end %>
 
             <%!-- Step: Log in --%>
-            <div class="grid grid-cols-[40px_1fr] gap-x-5">
+            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:grid-cols-[24px_1fr] max-sm:gap-x-3">
               <div class="flex flex-col items-center">
-                <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+                <div class="w-8 h-8 max-sm:w-6 max-sm:h-6 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm max-sm:text-xs font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
                   {if @selfhosted, do: 4, else: 3}
                 </div>
                 <div class="w-px flex-1 bg-(--crit-border) min-h-5"></div>
@@ -199,9 +199,9 @@
             </div>
 
             <%!-- Step: Share --%>
-            <div class="grid grid-cols-[40px_1fr] gap-x-5">
+            <div class="grid grid-cols-[40px_1fr] gap-x-5 max-sm:grid-cols-[24px_1fr] max-sm:gap-x-3">
               <div class="flex flex-col items-center">
-                <div class="w-8 h-8 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
+                <div class="w-8 h-8 max-sm:w-6 max-sm:h-6 rounded-full border-[1.5px] border-(--crit-border-strong) bg-(--crit-bg-card) flex items-center justify-center text-sm max-sm:text-xs font-semibold text-(--crit-fg-secondary) shrink-0 relative z-[1]">
                   {if @selfhosted, do: 5, else: 4}
                 </div>
               </div>

--- a/lib/crit_web/live/settings_live.html.heex
+++ b/lib/crit_web/live/settings_live.html.heex
@@ -8,7 +8,7 @@
   />
 
   <%!-- Main content --%>
-  <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-5">
+  <div class="max-w-[1100px] mx-auto w-full px-10 my-10 max-sm:px-4">
     <h1 class="text-2xl font-semibold text-(--crit-fg-primary) mb-8">Settings</h1>
 
     <div class="flex gap-10 max-md:flex-col">


### PR DESCRIPTION
## Summary

Single pass of cleanup across crit-web templates and styling.

### Inline `<code>` whitespace
HEEx formatter expanded short inline code spans onto their own indented lines, rendering with visible padding inside the rounded chip. Collapsed back to single-line and added `phx-no-format` where the formatter would re-expand. Affects: dashboard empty state, integration pages, self-hosting docs, feature pages, device auth error.

### Arbitrary text-size values → named scale
Replaced `text-[0.9em]`, `text-[11px]`, `text-[13px]`, `text-[15px]`, `text-[10.5px]`, `text-[9.5px]`, `text-[12px]`, `text-[12.5px]` with the named Tailwind scale (`text-xs`, `text-sm`). Keeps the type system consistent. Scope was text sizes only — `max-w-[…]`, `w-[…]`, etc. left as-is.

### Empty-state guide additions (in main, opening this PR atop)
Already in main via #133 — login + selfhosted share_url steps.

### Empty-state mobile
- Drop the timeline (number + connector) column entirely on mobile; inline a muted `1.` / `2.` / etc. prefix into each step title.
- Add `min-w-0` to grid items so the install/agent widget tab strips don't push the page wider.

### Changelog
- `overflow-wrap: anywhere` on `.changelog-body a` so long URLs break inside the link.
- `min-w-0` on the grid item so the cell can shrink (CSS grid items default to `min-width: auto`).

### Terms / Privacy
Stripped `text-sm` from main copy paragraphs/lists — body copy now uses base font size.

### Mobile horizontal padding
Globally tightened `max-sm:px-5` → `max-sm:px-4` across all pages.

### Empty-state subhead reword
Was: "Install the CLI, connect your agent, then share your review with a single command." (orphan "command." on its own line). Now: "Install crit, connect your agent, share your review in one command."

## Test plan

- [x] `mix precommit` passes locally (471 tests, 0 failures)
- [ ] Eyeball: dashboard empty state on desktop AND mobile
- [ ] Eyeball: changelog with long URLs in release notes
- [ ] Eyeball: terms / privacy main copy
- [ ] Eyeball: install + agent setup widgets on home and dashboard

Note: `codecov/patch` fail is expected — CSS/template-only changes, no new logic to cover.