### PR TITLE
Reword empty-state subhead to avoid orphan

### DIFF
--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -86,7 +86,7 @@
               Get your first review on the web
             </h2>
             <p class="text-xl max-sm:text-base leading-relaxed text-(--crit-fg-secondary) max-w-2xl mx-auto mb-10">
-              Install the CLI, connect your agent, then share your review with a single command.
+              Install crit, connect your agent, share your review in one command.
             </p>
           </div>
 


### PR DESCRIPTION
Was: "Install the CLI, connect your agent, then share your review with a single command." — wrapped with "command." orphaned on its own line.

Now: "Install crit, connect your agent, share your review in one command." — punchier and fits without orphan.