### PR TITLE
fix: expand hljs language coverage via alias resolution

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -703,24 +703,38 @@ function splitHighlightedCode(html) {
 
 // ---- Code file detection ----------------------------------------------------
 
+// Most extensions are resolved via hljs's built-in alias system
+// (e.g. .feature → gherkin, .md → markdown, .tsx → typescript, .toml → ini,
+// .scss → scss, .h/.hpp → c/cpp, .yml → yaml, .kt → kotlin, .rb → ruby,
+// .dockerfile → dockerfile, .makefile → makefile). Only extensions that hljs
+// does NOT cover via aliases need entries here.
+const EXT_OVERRIDES = {
+  tf: 'hcl',         // Terraform — hljs has no .tf alias
+  htm: 'xml',        // hljs aliases html but not htm
+  svg: 'xml',
+  cs: 'csharp',
+  sh: 'bash',
+  zig: 'zig',
+  md: 'markdown',    // normalize: callers compare lang against 'markdown'
+}
+// Files identified by basename rather than extension.
+const BASENAME_LANG = {
+  dockerfile: 'dockerfile',
+  makefile: 'makefile',
+  gemfile: 'ruby',
+  rakefile: 'ruby',
+}
 function langFromPath(filePath) {
-  const ext = (filePath || '').split('.').pop().toLowerCase()
-  const map = {
-    js: 'javascript', jsx: 'javascript', ts: 'typescript', tsx: 'typescript',
-    go: 'go', py: 'python', rb: 'ruby', rs: 'rust',
-    sql: 'sql', sh: 'bash', bash: 'bash', zsh: 'bash',
-    json: 'json', yaml: 'yaml', yml: 'yaml',
-    html: 'xml', htm: 'xml', xml: 'xml', svg: 'xml',
-    css: 'css', scss: 'css', less: 'css',
-    ex: 'elixir', exs: 'elixir',
-    md: 'markdown', java: 'java', kt: 'kotlin',
-    c: 'c', h: 'c', cpp: 'cpp', hpp: 'cpp',
-    cs: 'csharp', swift: 'swift', php: 'php',
-    r: 'r', lua: 'lua', zig: 'zig', nim: 'nim',
-    toml: 'ini', ini: 'ini', dockerfile: 'dockerfile',
-    makefile: 'makefile', tf: 'hcl',
+  if (!filePath) return null
+  const base = filePath.split('/').pop() || ''
+  const baseLower = base.toLowerCase()
+  if (!baseLower.includes('.') && BASENAME_LANG[baseLower]) {
+    return BASENAME_LANG[baseLower]
   }
-  return map[ext] || null
+  const ext = baseLower.includes('.') ? baseLower.split('.').pop() : ''
+  if (ext && EXT_OVERRIDES[ext]) return EXT_OVERRIDES[ext]
+  if (ext && hljs.getLanguage(ext)) return ext
+  return BASENAME_LANG[baseLower] || null
 }
 
 function isCodeFile(filePath) {


### PR DESCRIPTION
## Summary
- Replace hand-curated extension→language map with `hljs.getLanguage()` alias resolution + small override map for cases where the extension isn't a registered hljs alias.
- Adds Gherkin (`.feature`) and many other languages that were missing despite being bundled in highlight.js.

Related to tomasz-tomczyk/crit#375.

## Review
- [x] Code review: passed
- [x] Parity audit: paired with tomasz-tomczyk/crit (separate PR)

## Test plan
- [x] Verified `hljs.getLanguage('feature')` resolves to Gherkin in the bundled hljs build
- [x] Visually confirmed `.feature` files render with hljs spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)