### PR TITLE
fix: rename comment submit button to "Comment"

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -2586,7 +2586,7 @@ function createCommentForm(formObj, ctx) {
 
   const submitBtn = document.createElement("button")
   submitBtn.className = "btn btn-sm btn-primary"
-  submitBtn.textContent = "Submit"
+  submitBtn.textContent = "Comment"
   submitBtn.addEventListener("click", () => submitNewComment(textarea.value, formObj, ctx))
 
   actions.appendChild(leftGroup)
@@ -3198,7 +3198,7 @@ function renderCommentFormUI(ctx, formObj) {
   cancelBtn.addEventListener('click', () => cancelComment(formObj, ctx))
   const submitBtn = document.createElement('button')
   submitBtn.className = 'btn btn-sm btn-primary'
-  submitBtn.textContent = 'Submit'
+  submitBtn.textContent = 'Comment'
   submitBtn.addEventListener('click', () => submitNewComment(textarea.value, formObj, ctx))
   actions.appendChild(cancelBtn)
   actions.appendChild(submitBtn)
@@ -3969,7 +3969,7 @@ function renderShortcutsPane() {
       { key: '<kbd>e</kbd>', action: 'Edit comment on focused block' },
       { key: '<kbd>d</kbd>', action: 'Delete comment on focused block' },
       { key: '<kbd>Shift</kbd>+<kbd>G</kbd>', action: 'General comment' },
-      { key: '<kbd>Ctrl</kbd>+<kbd>Enter</kbd>', action: 'Submit comment' },
+      { key: '<kbd>Ctrl</kbd>+<kbd>Enter</kbd>', action: 'Comment' },
     ]},
     { label: 'Review', shortcuts: [
       { key: '<kbd>Shift</kbd>+<kbd>C</kbd>', action: 'Toggle comments panel' },

--- a/e2e/comments.spec.ts
+++ b/e2e/comments.spec.ts
@@ -85,8 +85,8 @@ test.describe("Comments — Add via UI", () => {
     const textarea = commentForm.locator("textarea");
     await textarea.fill("New comment from E2E test");
 
-    // Click Submit
-    await commentForm.locator('button:has-text("Submit")').click();
+    // Click Comment
+    await commentForm.locator('button:has-text("Comment")').click();
 
     // The comment card should appear
     await waitForCommentCard(page, "New comment from E2E test");

--- a/e2e/draft-autosave.spec.ts
+++ b/e2e/draft-autosave.spec.ts
@@ -112,7 +112,7 @@ test.describe("Draft Autosave", () => {
     }).toPass({ timeout: 3_000 });
 
     // Submit the comment
-    await page.locator('.comment-form button:has-text("Submit")').click();
+    await page.locator('.comment-form button:has-text("Comment")').click();
     await waitForCommentCard(page, "Will be submitted");
 
     // Draft should be cleared

--- a/e2e/suggestion-diff.spec.ts
+++ b/e2e/suggestion-diff.spec.ts
@@ -41,7 +41,7 @@ test.describe("Suggestion Diff Rendering", () => {
       "Here is my suggestion:\n\n```suggestion\nreplacement line\n```\n\nPlease consider this change."
     );
 
-    await page.locator('.comment-form button:has-text("Submit")').click();
+    await page.locator('.comment-form button:has-text("Comment")').click();
 
     // Wait for comment to render
     await waitForCommentCard(page, "Here is my suggestion");
@@ -81,7 +81,7 @@ test.describe("Suggestion Diff Rendering", () => {
     await expect(textarea).toBeVisible({ timeout: 5_000 });
     await textarea.fill('```javascript\nconsole.log("hello")\n```');
 
-    await page.locator('.comment-form button:has-text("Submit")').click();
+    await page.locator('.comment-form button:has-text("Comment")').click();
 
     // Wait for comment to render
     await expect(page.locator(".comment-card").first()).toBeVisible({
@@ -106,7 +106,7 @@ test.describe("Suggestion Diff Rendering", () => {
     await expect(textarea).toBeVisible({ timeout: 5_000 });
     await textarea.fill("```suggestion\n```");
 
-    await page.locator('.comment-form button:has-text("Submit")').click();
+    await page.locator('.comment-form button:has-text("Comment")').click();
 
     await expect(page.locator(".comment-card").first()).toBeVisible({
       timeout: 5_000,


### PR DESCRIPTION
## Summary
- Rename the comment form submit button from "Submit" to "Comment" so it's clear it only adds a comment, not finishes the review
- Updates the keyboard-shortcut pane label to match
- Mirrors tomasz-tomczyk/crit#385

## Review
- [x] Precommit: passed (format, sobelow, audit, 471 tests)
- [x] Parity audit: matches crit/ PR #385

## Test plan
- [x] `mix precommit` clean
- See also: tomasz-tomczyk/crit#385

🤖 Generated with [Claude Code](https://claude.com/claude-code)