### PR TITLE
feat: include user_id in device-flow token response

### DIFF
--- a/lib/crit/device_codes.ex
+++ b/lib/crit/device_codes.ex
@@ -135,7 +135,9 @@ defmodule Crit.DeviceCodes do
   Polls for the token associated with a raw device code.
 
   Returns one of:
-  - `{:ok, access_token, user_name}` — success, token redeemed
+  - `{:ok, access_token, user_info}` — success, token redeemed. `user_info`
+     is a map with `:id`, `:name`, `:email` (any field may be `nil`) or `nil`
+     when no user is associated with the device code.
   - `{:error, :authorization_pending}` — user hasn't authorized yet
   - `{:error, :slow_down}` — client is polling too fast
   - `{:error, :expired_token}` — device code has expired
@@ -188,7 +190,7 @@ defmodule Crit.DeviceCodes do
               )
 
             if count == 1 do
-              {:ok, dc.access_token, display_name(dc.user)}
+              {:ok, dc.access_token, user_info(dc.user)}
             else
               # Another poll beat us — token already redeemed
               {:error, :expired_token}
@@ -233,9 +235,13 @@ defmodule Crit.DeviceCodes do
     diff < @poll_interval_seconds
   end
 
-  defp display_name(nil), do: nil
+  defp user_info(nil), do: nil
 
-  defp display_name(%Crit.User{} = user) do
-    user.name || user.email || user.provider_uid
+  defp user_info(%Crit.User{} = user) do
+    %{
+      id: user.id,
+      name: user.name || user.email || user.provider_uid,
+      email: user.email
+    }
   end
 end

--- a/lib/crit_web/controllers/device_api_controller.ex
+++ b/lib/crit_web/controllers/device_api_controller.ex
@@ -53,9 +53,12 @@ defmodule CritWeb.DeviceApiController do
   """
   def token(conn, %{"device_code" => device_code}) do
     case DeviceCodes.poll_device_code(device_code) do
-      {:ok, access_token, user_name} ->
-        response = %{access_token: access_token, token_type: "bearer"}
-        response = if user_name, do: Map.put(response, :user_name, user_name), else: response
+      {:ok, access_token, user_info} ->
+        response =
+          %{access_token: access_token, token_type: "bearer"}
+          |> maybe_put(:user_id, user_info && user_info.id)
+          |> maybe_put(:user_name, user_info && user_info.name)
+          |> maybe_put(:user_email, user_info && user_info.email)
 
         conn
         |> put_status(200)
@@ -82,6 +85,9 @@ defmodule CritWeb.DeviceApiController do
   defp oauth_configured? do
     Application.get_env(:crit, :oauth_provider) != nil
   end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   # Rate-limit device code creation: 10 per minute per IP.
   defp rate_limit_create(conn, _opts) do

--- a/test/crit/device_codes_test.exs
+++ b/test/crit/device_codes_test.exs
@@ -133,14 +133,16 @@ defmodule Crit.DeviceCodesTest do
       assert {:error, :authorization_pending} = DeviceCodes.poll_device_code(raw)
     end
 
-    test "returns the access_token and user_name for an authorized device code" do
+    test "returns the access_token and user info for an authorized device code" do
       user = create_user()
       {:ok, %{device_code: raw, record: record}} = DeviceCodes.create_device_code()
       {:ok, _authorized} = DeviceCodes.authorize_device_code(record.id, user)
 
-      assert {:ok, access_token, user_name} = DeviceCodes.poll_device_code(raw)
+      assert {:ok, access_token, user_info} = DeviceCodes.poll_device_code(raw)
       assert String.starts_with?(access_token, "crit_")
-      assert user_name == "Test User"
+      assert user_info.id == user.id
+      assert user_info.name == "Test User"
+      assert user_info.email == user.email
     end
 
     test "marks device code as redeemed and clears access_token after successful poll" do
@@ -148,7 +150,7 @@ defmodule Crit.DeviceCodesTest do
       {:ok, %{device_code: raw, record: record}} = DeviceCodes.create_device_code()
       {:ok, _authorized} = DeviceCodes.authorize_device_code(record.id, user)
 
-      {:ok, _token, _name} = DeviceCodes.poll_device_code(raw)
+      {:ok, _token, _info} = DeviceCodes.poll_device_code(raw)
 
       redeemed = Repo.get!(DeviceCode, record.id)
       assert redeemed.status == :redeemed
@@ -160,7 +162,7 @@ defmodule Crit.DeviceCodesTest do
       {:ok, %{device_code: raw, record: record}} = DeviceCodes.create_device_code()
       {:ok, _authorized} = DeviceCodes.authorize_device_code(record.id, user)
 
-      {:ok, _token, _name} = DeviceCodes.poll_device_code(raw)
+      {:ok, _token, _info} = DeviceCodes.poll_device_code(raw)
       assert {:error, :expired_token} = DeviceCodes.poll_device_code(raw)
     end
 

--- a/test/crit_web/controllers/device_api_controller_test.exs
+++ b/test/crit_web/controllers/device_api_controller_test.exs
@@ -55,7 +55,7 @@ defmodule CritWeb.DeviceApiControllerTest do
       assert %{"error" => "authorization_pending"} = json_response(conn, 400)
     end
 
-    test "returns access_token for an authorized device code", %{conn: conn} do
+    test "returns access_token and user identity for an authorized device code", %{conn: conn} do
       {:ok, user} = Accounts.find_or_create_from_oauth("github", @oauth_params)
       {:ok, %{device_code: raw, record: record}} = DeviceCodes.create_device_code()
       {:ok, _authorized} = DeviceCodes.authorize_device_code(record.id, user)
@@ -65,9 +65,12 @@ defmodule CritWeb.DeviceApiControllerTest do
       assert %{
                "access_token" => token,
                "token_type" => "bearer",
-               "user_name" => "API Test User"
+               "user_id" => user_id,
+               "user_name" => "API Test User",
+               "user_email" => "apitest@example.com"
              } = json_response(conn, 200)
 
+      assert user_id == user.id
       assert String.starts_with?(token, "crit_")
     end
 


### PR DESCRIPTION
## Summary
- POST /api/device/token now returns `user_id`, `user_name`, `user_email` (was: `user_name` only).
- `Crit.DeviceCodes.poll_device_code/1` returns `{:ok, access_token, %{id, name, email}}` instead of `{:ok, access_token, user_name}`.
- Tests updated.

## Why

Closes a prod attribution bug where `crit` CLI sent shares with blank `user_id` on the comments — the server then wrote them with `user_id = nil` and `author_identity = "imported"`, even though the bearer token authenticated the request correctly. Without `user_id` in this response, the CLI had no way to cache the verified id at login time.

## Review
- [x] Code review: not requested (small, surgical change)
- [x] Parity audit: N/A (no frontend touched)

## Test plan
- [x] `mix precommit` — clean (471 tests, 0 failures)
- [x] `device_codes_test.exs` and `device_api_controller_test.exs` updated to assert the new shape
- [x] Full crit↔crit-web share integration suite (`./scripts/e2e-share.sh` from crit/) — all tests pass

See also: tomasz-tomczyk/crit#393 (CLI side that consumes this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)