### PR TITLE
ci: fix invalid codecov.yml so status checks wait for upload

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,8 @@
+codecov:
+  notify:
+    after_n_builds: 1
+    wait_for_ci: true
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary
- `after_n_builds` is not valid under `coverage.status.project.default` / `coverage.status.patch.default` — without a valid `codecov.notify` block, status checks fire as soon as the first upload arrives, against the base commit's data, leading to misleading early "failure" reports
- Add `codecov.notify.after_n_builds: 1` + `wait_for_ci: true` so the status waits for CI to complete before reporting
- Validated via https://codecov.io/validate

## Test plan
- [x] `curl -X POST --data-binary @codecov.yml https://codecov.io/validate` returns `Valid!`
- [ ] Next PR shows codecov status as pending until coverage upload completes, then reports cleanly

See also: tomasz-tomczyk/crit#402 (same fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)