### PR TITLE
feat: harden share page with no-referrer + global rate limit

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -44,6 +44,10 @@ config :crit, start_review_cleaner: false
 config :crit, start_device_code_cleaner: false
 config :crit, start_changelog: false
 
+# Disable global rate limit in tests — shared 127.0.0.1 + persistent ETS would
+# trip the limiter across the suite. Plug-specific tests opt back in locally.
+config :crit, CritWeb.Plugs.RateLimit, disabled: true
+
 config :crit, :oauth_provider,
   strategy: Assent.Strategy.Github,
   client_id: "test_github_client_id",

--- a/lib/crit_web/plugs/rate_limit.ex
+++ b/lib/crit_web/plugs/rate_limit.ex
@@ -1,0 +1,59 @@
+defmodule CritWeb.Plugs.RateLimit do
+  @moduledoc """
+  Global per-IP rate limit. Backstop against scanners and runaway clients;
+  tighter per-route limits (write API, invalid-token 404s) live alongside
+  this and apply on top.
+
+  Options:
+
+    * `:limit`    — requests per minute per IP (default `180`).
+    * `:response` — `:text` (default) or `:json`. Sets the body and content-type
+      sent on a 429 response. Pass `:json` from API pipelines.
+  """
+
+  import Plug.Conn
+
+  @default_limit 180
+  @window :timer.minutes(1)
+
+  def init(opts) do
+    response = Keyword.get(opts, :response, :text)
+
+    unless response in [:text, :json],
+      do: raise(ArgumentError, ":response must be :text or :json")
+
+    opts
+  end
+
+  def call(conn, opts) do
+    if disabled?() do
+      conn
+    else
+      limit = Keyword.get(opts, :limit, @default_limit)
+      response = Keyword.get(opts, :response, :text)
+      ip = conn.remote_ip |> :inet.ntoa() |> to_string()
+
+      case Crit.RateLimit.hit("global:#{ip}", @window, limit) do
+        {:allow, _} ->
+          conn
+
+        {:deny, _} ->
+          {content_type, body} = body_for(response)
+
+          conn
+          |> put_resp_content_type(content_type)
+          |> put_resp_header("retry-after", "60")
+          |> send_resp(429, body)
+          |> halt()
+      end
+    end
+  end
+
+  defp body_for(:json), do: {"application/json", ~s({"error":"Too many requests"})}
+  defp body_for(:text), do: {"text/plain", "Too many requests"}
+
+  defp disabled? do
+    System.get_env("E2E") == "true" or
+      Application.get_env(:crit, __MODULE__, [])[:disabled] == true
+  end
+end

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -11,23 +11,27 @@ defmodule CritWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug CritWeb.Plugs.SecurityHeaders
+    plug CritWeb.Plugs.RateLimit
     plug :fetch_current_scope_for_user
   end
 
   pipeline :api do
     plug :accepts, ["json"]
     plug CritWeb.Plugs.SecurityHeaders
+    plug CritWeb.Plugs.RateLimit, response: :json
     plug CritWeb.Plugs.ApiAuth
   end
 
   pipeline :device_api do
     plug :accepts, ["json"]
     plug CritWeb.Plugs.SecurityHeaders
+    plug CritWeb.Plugs.RateLimit, response: :json
   end
 
   pipeline :auth_api do
     plug :accepts, ["json"]
     plug CritWeb.Plugs.SecurityHeaders
+    plug CritWeb.Plugs.RateLimit, response: :json
     plug CritWeb.Plugs.RequireBearerAuth
   end
 
@@ -74,7 +78,8 @@ defmodule CritWeb.Router do
     get "/auth/cli/success", DeviceController, :success
   end
 
-  # Review pages and dashboard — noindex
+  # Review pages and dashboard — noindex (review page also gets no-referrer
+  # via :put_noindex)
   scope "/", CritWeb do
     pipe_through [:browser, :noindex]
 
@@ -144,6 +149,8 @@ defmodule CritWeb.Router do
   end
 
   defp put_noindex(conn, _opts) do
-    Plug.Conn.put_resp_header(conn, "x-robots-tag", "noindex")
+    conn
+    |> Plug.Conn.put_resp_header("x-robots-tag", "noindex")
+    |> Plug.Conn.put_resp_header("referrer-policy", "no-referrer")
   end
 end

--- a/test/crit_web/live/review_live_test.exs
+++ b/test/crit_web/live/review_live_test.exs
@@ -32,6 +32,12 @@ defmodule CritWeb.ReviewLiveTest do
       {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
       assert page_title(view) =~ hd(review.files).file_path
     end
+
+    test "sends Referrer-Policy: no-referrer", %{conn: conn, review: review} do
+      conn = get(conn, ~p"/r/#{review.token}")
+      assert get_resp_header(conn, "referrer-policy") == ["no-referrer"]
+      assert get_resp_header(conn, "x-robots-tag") == ["noindex"]
+    end
   end
 
   describe "mount with multi-file review" do

--- a/test/crit_web/plugs/rate_limit_test.exs
+++ b/test/crit_web/plugs/rate_limit_test.exs
@@ -1,0 +1,97 @@
+defmodule CritWeb.Plugs.RateLimitTest do
+  use CritWeb.ConnCase, async: false
+
+  alias CritWeb.Plugs.RateLimit
+
+  defp call_plug(conn, opts) do
+    RateLimit.call(conn, RateLimit.init(opts))
+  end
+
+  defp with_ip(conn, ip), do: %{conn | remote_ip: ip}
+
+  # Monotonically unique IP per call — guarantees no bucket collisions across
+  # tests in the suite-shared ETS table.
+  defp unique_ip do
+    n = System.unique_integer([:positive])
+    {10, rem(div(n, 65_536), 256), rem(div(n, 256), 256), rem(n, 256)}
+  end
+
+  describe "with limiter enabled" do
+    setup do
+      Application.put_env(:crit, RateLimit, disabled: false)
+      on_exit(fn -> Application.put_env(:crit, RateLimit, disabled: true) end)
+      {:ok, ip: unique_ip()}
+    end
+
+    test "allows requests under the limit", %{conn: conn, ip: ip} do
+      conn = conn |> with_ip(ip) |> call_plug(limit: 3)
+      refute conn.halted
+    end
+
+    test "returns 429 with text body once limit is exceeded", %{conn: conn, ip: ip} do
+      for _ <- 1..3, do: conn |> with_ip(ip) |> call_plug(limit: 3)
+
+      blocked = conn |> with_ip(ip) |> call_plug(limit: 3)
+      assert blocked.halted
+      assert blocked.status == 429
+      assert blocked.resp_body == "Too many requests"
+      assert ["text/plain" <> _] = get_resp_header(blocked, "content-type")
+      assert get_resp_header(blocked, "retry-after") == ["60"]
+    end
+
+    test "returns JSON body when response: :json", %{conn: conn, ip: ip} do
+      for _ <- 1..3, do: conn |> with_ip(ip) |> call_plug(limit: 3, response: :json)
+
+      blocked = conn |> with_ip(ip) |> call_plug(limit: 3, response: :json)
+      assert blocked.status == 429
+      assert blocked.resp_body == ~s({"error":"Too many requests"})
+      assert ["application/json" <> _] = get_resp_header(blocked, "content-type")
+      assert get_resp_header(blocked, "retry-after") == ["60"]
+    end
+
+    test "rate limit is per-IP", %{conn: conn} do
+      a = unique_ip()
+      b = unique_ip()
+
+      for _ <- 1..3, do: conn |> with_ip(a) |> call_plug(limit: 3)
+
+      other = conn |> with_ip(b) |> call_plug(limit: 3)
+      refute other.halted
+    end
+
+    test "is bypassed when E2E=true", %{conn: conn, ip: ip} do
+      System.put_env("E2E", "true")
+      on_exit(fn -> System.delete_env("E2E") end)
+
+      for _ <- 1..10 do
+        conn = conn |> with_ip(ip) |> call_plug(limit: 1)
+        refute conn.halted
+      end
+    end
+  end
+
+  describe "with limiter disabled (suite default)" do
+    test "never halts no matter how many requests come in", %{conn: conn} do
+      ip = unique_ip()
+
+      for _ <- 1..1000 do
+        conn = conn |> with_ip(ip) |> call_plug(limit: 1)
+        refute conn.halted
+      end
+    end
+  end
+
+  describe "init/1" do
+    test "rejects unknown :response value" do
+      assert_raise ArgumentError, ":response must be :text or :json", fn ->
+        RateLimit.init(response: :xml)
+      end
+    end
+
+    test "accepts :text and :json" do
+      assert RateLimit.init(response: :text)
+      assert RateLimit.init(response: :json)
+      assert RateLimit.init([])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Send `Referrer-Policy: no-referrer` on private routes (review page, dashboard, settings, overview, CLI auth, all `/api/*`). External link clicks from a rendered review no longer leak the secret URL via the `Referer` header. Combined into the existing `:noindex` pipeline.
- Add `CritWeb.Plugs.RateLimit` — a global per-IP backstop, 180/min default, Hammer-backed. Returns 429 with `Retry-After: 60` and a JSON or text body per a `:response` opt. Installed on `:browser` (text) and `:api` / `:device_api` / `:auth_api` (json).
- Existing tighter limiters (`POST /api/reviews` 30/min, `/api/reviews` 404 10/5min) stay layered on top via separate Hammer buckets — same module, different keys.
- Bypassed in tests via `config :crit, CritWeb.Plugs.RateLimit, disabled: true` — shared `127.0.0.1` across the suite would otherwise trip the limiter.

## Review
- [x] Interactive crit review: approved (0 comments)
- [x] Elixir expert review: feedback addressed (response opt instead of format auto-detect, Retry-After header, deterministic test IPs)
- [x] Parity audit: N/A (server-side only)

## Test plan
- \`mix precommit\` green (515 tests, sobelow clean, deps audit clean)
- New plug tests cover: under-limit allow, over-limit 429 (text + JSON), per-IP isolation, E2E env bypass, suite-default disabled bypass, \`init/1\` rejects unknown \`:response\`
- \`/r/:token\` test asserts both \`Referrer-Policy: no-referrer\` and \`x-robots-tag: noindex\` on the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)