### PR TITLE
feat: review conversation parity (crit/#374, crit#405)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1858,21 +1858,6 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   align-items: center;
   gap: 8px;
 }
-.comments-panel-add-btn {
-  background: none;
-  border: 1px solid var(--crit-border);
-  color: var(--crit-editor-fg-muted);
-  cursor: pointer;
-  font-size: 11px;
-  padding: 3px 8px;
-  border-radius: 4px;
-  font-weight: 500;
-  line-height: 1;
-}
-.comments-panel-add-btn:hover {
-  color: var(--crit-editor-fg);
-  border-color: var(--crit-editor-fg-muted);
-}
 .comments-panel-close {
   background: none;
   border: none;
@@ -3054,4 +3039,202 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 @media (prefers-color-scheme: light) {
   html:not([data-theme]) .logo-light { display: inline-block; }
   html:not([data-theme]) .logo-dark { display: none; }
+}
+
+/* ===== Review Conversation (top-of-doc section) ===== */
+/* Linear-inspired: no card chrome around the container, no brand rails.
+   Hierarchy is carried by typography, rhythm, and a hairline divider in
+   the sidebar. */
+.review-conversation {
+  max-width: var(--crit-content-width);
+  margin: 20px 24px 24px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+}
+.review-conversation[data-doc-layout="centered"] { margin: 20px auto 24px; }
+.review-conversation.collapsed .review-conversation-body { display: none; }
+
+.review-conversation-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  user-select: none;
+}
+.review-conversation.collapsed .review-conversation-header { margin-bottom: 0; }
+.review-conversation-toggle {
+  background: none;
+  border: none;
+  color: var(--crit-editor-fg-muted);
+  cursor: pointer;
+  padding: 0;
+  width: 18px;
+  height: 18px;
+  margin-left: -2px;
+  border-radius: var(--crit-r-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--crit-dur-fast) var(--crit-ease),
+              color var(--crit-dur-fast) var(--crit-ease);
+}
+.review-conversation-toggle svg { width: 12px; height: 12px; }
+.review-conversation-toggle:hover { color: var(--crit-editor-fg); }
+.review-conversation.collapsed .review-conversation-toggle { transform: rotate(-90deg); }
+.review-conversation-header .icon {
+  display: inline-flex;
+  color: var(--crit-editor-fg-muted);
+}
+.review-conversation-header .icon svg {
+  width: 13px;
+  height: 13px;
+}
+.review-conversation-header .label {
+  color: var(--crit-editor-fg);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+.review-conversation-header .count {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--crit-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--crit-editor-fg-muted);
+  background: none;
+  padding: 0;
+  min-width: 0;
+  height: auto;
+  border-radius: 0;
+}
+
+/* Linear's "calm invitation": ghost button with a dashed plus chip that
+   becomes solid on hover. No solid border around the whole button. */
+.review-conversation-add-more {
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--crit-editor-fg-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--crit-r-md);
+  padding: 7px 10px;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: background var(--crit-dur-fast) var(--crit-ease),
+              color var(--crit-dur-fast) var(--crit-ease),
+              border-color var(--crit-dur-fast) var(--crit-ease);
+}
+.review-conversation-add-more::before {
+  content: "";
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--crit-r-sm);
+  border: 1px dashed var(--crit-border-strong);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%23646c85' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+  background-repeat: no-repeat;
+  background-position: center;
+  transition: border-color var(--crit-dur-fast) var(--crit-ease),
+              border-style var(--crit-dur-fast) var(--crit-ease);
+}
+.review-conversation-add-more:hover::before {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%2385aaf8' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+  border-style: solid;
+  border-color: var(--crit-brand);
+}
+[data-theme="light"] .review-conversation-add-more::before {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%238892a6' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+}
+[data-theme="light"] .review-conversation-add-more:hover::before {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%232960bc' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+}
+@media (prefers-color-scheme: light) {
+  html:not([data-theme]) .review-conversation-add-more::before {
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%238892a6' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+  }
+  html:not([data-theme]) .review-conversation-add-more:hover::before {
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none' stroke='%232960bc' stroke-width='1.5' stroke-linecap='round'><path d='M8 5.5v5M5.5 8h5'/></svg>");
+  }
+}
+.review-conversation-add-more:hover {
+  background: var(--crit-editor-bg-elevated);
+  color: var(--crit-editor-fg);
+  border-color: var(--crit-border);
+}
+
+/* Threads + form inside the section reuse the same renderers — strip the
+   line-anchored 56px gutter so they span the full section width. */
+.review-conversation .comment-block { padding: 0; margin: 0; }
+.review-conversation .comment-block + .comment-block { margin-top: 10px; }
+.review-conversation .comment-form-wrapper { padding-left: 0; }
+
+/* ===== Tree section: review-conversation row sits in its own section
+   above FILES, separated by the file-tree-header's bottom border. ===== */
+.tree-section--conversation {
+  padding: 8px 4px;
+  flex-shrink: 0;
+}
+.tree-conversation-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 28px;
+  padding: 0 10px;
+  margin: 0 4px;
+  cursor: pointer;
+  color: var(--crit-editor-fg-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: var(--crit-r-md);
+  transition: background var(--crit-dur-fast) var(--crit-ease),
+              color var(--crit-dur-fast) var(--crit-ease);
+}
+.tree-conversation-row:hover {
+  background: var(--crit-editor-bg-elevated);
+  color: var(--crit-editor-fg);
+}
+.tree-conversation-row.active {
+  background: var(--crit-brand-subtle);
+  color: var(--crit-editor-fg);
+}
+.tree-conversation-icon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  color: var(--crit-editor-fg-muted);
+  flex-shrink: 0;
+  transition: color var(--crit-dur-fast) var(--crit-ease);
+}
+.tree-conversation-row:hover .tree-conversation-icon,
+.tree-conversation-row.active .tree-conversation-icon {
+  color: var(--crit-editor-fg-secondary);
+}
+.tree-conversation-icon svg { width: 14px; height: 14px; }
+.tree-conversation-name {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: -0.005em;
+}
+.tree-conversation-badge {
+  font-family: var(--crit-font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--crit-editor-fg-muted);
+  background: none;
+  padding: 0;
+}
+.tree-conversation-row.active .tree-conversation-badge {
+  color: var(--crit-brand);
 }

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -363,6 +363,7 @@ function openForm(ctx, newForm) {
     return
   }
   closeEmptyForms(ctx, fk)
+  closeEmptyReviewForm(ctx)
   addForm(ctx, newForm)
   ctx.selectionStart = newForm.startLine
   ctx.selectionEnd = newForm.endLine
@@ -1257,6 +1258,13 @@ function renderFileTree(ctx) {
     headerEl.appendChild(collapseBtn)
   }
 
+  // Review conversation pseudo-row sits in its own section above FILES.
+  const conversationSection = document.getElementById('treeConversationSection')
+  if (conversationSection) {
+    conversationSection.innerHTML = ''
+    conversationSection.appendChild(buildReviewConversationTreeRow(ctx))
+  }
+
   // Build and render tree
   const tree = collapseCommonPrefixes(buildFileTree(ctx.files))
   const body = document.getElementById('fileTreeBody')
@@ -1326,6 +1334,7 @@ function render(ctx) {
   } else {
     renderDocument(ctx)
   }
+  renderReviewConversation(ctx)
   applyHideResolved(ctx)
 }
 
@@ -2836,6 +2845,8 @@ function createReplyInput(commentId, ctx) {
 
   function expand() {
     if (form.classList.contains('expanded')) return
+    closeEmptyReviewForm(ctx)
+    closeEmptyForms(ctx, null)
     form.classList.add('expanded')
     textarea.value = input.value
     input.replaceWith(textarea)
@@ -3136,6 +3147,7 @@ function openFileCommentForm(ctx, filePath) {
   const fk = 'file:' + filePath
   if (ctx.activeForms.find(f => f.formKey === fk)) return
   closeEmptyForms(ctx, fk)
+  closeEmptyReviewForm(ctx)
   const form = { formKey: fk, scope: 'file', filePath: filePath, startLine: null, endLine: null, editingId: null }
   ctx.activeForms.push(form)
   render(ctx)
@@ -3151,18 +3163,51 @@ function openReviewCommentForm(ctx) {
   closeEmptyForms(ctx, fk)
   const form = { formKey: fk, scope: 'review', filePath: null, startLine: null, endLine: null, editingId: null }
   ctx.activeForms.push(form)
-  // Open panel if not open
-  const panel = ctx._commentsPanel
-  if (panel && !panel.classList.contains('comments-panel-open')) {
-    panel.classList.add('comments-panel-open')
-    syncCommentsPanelAria(true)
-    updateTocPosition(ctx)
-  }
-  renderCommentsPanel(ctx)
+  renderReviewConversation(ctx)
+  scrollToReviewConversation(ctx)
   requestAnimationFrame(() => {
-    const ta = panel.querySelector('.panel-review-comment-form textarea')
+    const section = document.getElementById('reviewConversation')
+    const ta = section && section.querySelector('.comment-form textarea')
     if (ta) ta.focus()
   })
+}
+
+function openReviewCommentEditForm(ctx, comment) {
+  // Close any other forms (matches crit/ behaviour)
+  closeEmptyForms(ctx, null)
+  const fk = 'review:edit:' + comment.id
+  if (ctx.activeForms.find(f => f.formKey === fk)) return
+  // Drop any existing review compose/edit form
+  ctx.activeForms = ctx.activeForms.filter(f => f.scope !== 'review')
+  const form = {
+    formKey: fk,
+    scope: 'review',
+    filePath: null,
+    startLine: null,
+    endLine: null,
+    editingId: comment.id,
+    draftBody: comment.body,
+  }
+  ctx.activeForms.push(form)
+  renderReviewConversation(ctx)
+  scrollToReviewConversation(ctx)
+  requestAnimationFrame(() => {
+    const section = document.getElementById('reviewConversation')
+    const ta = section && section.querySelector('.comment-form textarea')
+    if (ta) ta.focus()
+  })
+}
+
+// Auto-close an empty review compose form when the user starts another form.
+// Mirrors crit/'s closeEmptyReviewForm.
+function closeEmptyReviewForm(ctx) {
+  const reviewForm = ctx.activeForms.find(f => f.scope === 'review' && !f.editingId)
+  if (!reviewForm) return
+  const section = document.getElementById('reviewConversation')
+  const ta = section && section.querySelector('.comment-form textarea')
+  if (ta && ta.value.trim()) return
+  removeForm(ctx, reviewForm.formKey)
+  renderReviewConversation(ctx)
 }
 
 function renderCommentFormUI(ctx, formObj) {
@@ -3171,17 +3216,25 @@ function renderCommentFormUI(ctx, formObj) {
 
   const form = document.createElement('div')
   form.className = 'comment-form'
+  form.dataset.formKey = formObj.formKey
+
+  const isEdit = !!formObj.editingId
 
   const textarea = document.createElement('textarea')
+  textarea.dataset.formKey = formObj.formKey
   textarea.placeholder = formObj.scope === 'review'
     ? 'Leave a comment\u2026 (Ctrl+Enter to submit, Escape to cancel)'
     : 'Add a file comment\u2026 (Ctrl+Enter to submit, Escape to cancel)'
   textarea.value = formObj.draftBody || ''
+  function submitForm() {
+    if (isEdit) submitEditComment(formObj.editingId, textarea.value, formObj, ctx)
+    else submitNewComment(textarea.value, formObj, ctx)
+  }
   textarea.addEventListener('keydown', function(e) {
     e.stopPropagation()
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
       e.preventDefault()
-      submitNewComment(textarea.value, formObj, ctx)
+      submitForm()
     }
     if (e.key === 'Escape') {
       e.preventDefault()
@@ -3198,8 +3251,8 @@ function renderCommentFormUI(ctx, formObj) {
   cancelBtn.addEventListener('click', () => cancelComment(formObj, ctx))
   const submitBtn = document.createElement('button')
   submitBtn.className = 'btn btn-sm btn-primary'
-  submitBtn.textContent = 'Comment'
-  submitBtn.addEventListener('click', () => submitNewComment(textarea.value, formObj, ctx))
+  submitBtn.textContent = isEdit ? 'Save' : 'Comment'
+  submitBtn.addEventListener('click', submitForm)
   actions.appendChild(cancelBtn)
   actions.appendChild(submitBtn)
   form.appendChild(actions)
@@ -3325,6 +3378,14 @@ function rerenderPanel(ctx) {
   if (ctx._commentsPanel?.classList.contains('comments-panel-open')) {
     renderCommentsPanel(ctx)
   }
+  // Keep the inline Review Conversation section + tree row in sync with any
+  // comment change (additions, edits, resolves, replies). These are cheap.
+  renderReviewConversation(ctx)
+  const conversationSection = document.getElementById('treeConversationSection')
+  if (conversationSection && ctx.multiFile) {
+    conversationSection.innerHTML = ''
+    conversationSection.appendChild(buildReviewConversationTreeRow(ctx))
+  }
 }
 
 // ---- Comments panel helpers -------------------------------------------------
@@ -3366,24 +3427,22 @@ function renderCommentsPanel(ctx) {
     return true
   }
 
-  // Review comment form at top
-  const reviewForm = ctx.activeForms.find(f => f.scope === 'review')
-  if (reviewForm) {
-    body.appendChild(renderCommentFormUI(ctx, reviewForm))
-  }
+  // Review-level (general) comments are composed/edited from the inline
+  // Review Conversation section at the top of the document; the panel only
+  // mirrors them as read-only cards that link back to the inline section.
 
   // Separate and filter comments by scope
   const reviewComments = ctx.comments.filter(c => c.scope === 'review').filter(visibleFilter)
   const fileAndLineComments = ctx.comments.filter(c => c.scope !== 'review').filter(visibleFilter)
 
-  if (ctx.comments.length === 0 && !reviewForm) {
+  if (ctx.comments.length === 0) {
     body.innerHTML += '<div class="comments-panel-empty">No comments yet</div>'
     updateExpandAllLabel(ctx)
     return
   }
 
   const filteredTotal = reviewComments.length + fileAndLineComments.length
-  if (filteredTotal === 0 && !reviewForm) {
+  if (filteredTotal === 0) {
     const emptyMsg = activeFilter === 'open' ? 'No open comments' : activeFilter === 'resolved' ? 'No resolved comments' : 'No comments yet'
     body.innerHTML += '<div class="comments-panel-empty">' + emptyMsg + '</div>'
     updateExpandAllLabel(ctx)
@@ -3395,7 +3454,7 @@ function renderCommentsPanel(ctx) {
     const group = document.createElement('div')
     group.className = 'comments-panel-file-group'
 
-    const groupName = createFileGroupHeader('Review', reviewComments.length, group)
+    const groupName = createFileGroupHeader('Review conversation', reviewComments.length, group)
     group.appendChild(groupName)
 
     const cards = document.createElement('div')
@@ -3672,8 +3731,16 @@ function renderPanelCard(ctx, comment, filePath) {
 
   wrapper.appendChild(card)
 
-  // Click to scroll for file/line comments (not review)
-  if (!isGeneral) {
+  // Click-to-scroll
+  if (isGeneral) {
+    // Panel cards for review comments link back to the inline Review
+    // Conversation section, mirroring crit/'s behaviour.
+    wrapper.style.cursor = 'pointer'
+    wrapper.addEventListener('click', function(e) {
+      if (e.target.closest('button')) return
+      scrollToReviewComment(ctx, comment.id)
+    })
+  } else {
     wrapper.style.cursor = 'pointer'
     wrapper.addEventListener('click', function(e) {
       if (e.target.closest('button')) return
@@ -3699,6 +3766,196 @@ function scrollToInlineComment(comment, ctx) {
     top: card.getBoundingClientRect().top + window.scrollY - offset,
     behavior: 'smooth'
   })
+  card.classList.add('comment-flash')
+  card.addEventListener('animationend', () => card.classList.remove('comment-flash'), { once: true })
+}
+
+// ===== Inline Review Conversation Section (top of document) =====
+
+const REVIEW_CONVERSATION_PATH = '__review_conversation__'
+const ICON_REVIEW_CONVERSATION =
+  '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+  '<path d="M2 3.5A1.5 1.5 0 0 1 3.5 2h9A1.5 1.5 0 0 1 14 3.5v6A1.5 1.5 0 0 1 12.5 11H8.5l-3 2.75V11H3.5A1.5 1.5 0 0 1 2 9.5Z"/>' +
+  '</svg>'
+const ICON_REVIEW_CHEVRON =
+  '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">' +
+  '<path d="M4 6l4 4 4-4" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+
+function isReviewConversationCollapsed() {
+  return localStorage.getItem('crit-review-conversation-collapsed') === '1'
+}
+
+function setReviewConversationCollapsed(collapsed) {
+  localStorage.setItem('crit-review-conversation-collapsed', collapsed ? '1' : '0')
+}
+
+function renderReviewConversation(ctx) {
+  const section = document.getElementById('reviewConversation')
+  if (!section) return
+
+  if (!ctx || !Array.isArray(ctx.comments)) {
+    section.hidden = true
+    return
+  }
+
+  section.hidden = false
+  section.innerHTML = ''
+
+  // Multi-file (git-style) view → left-anchor; single-doc view → centered.
+  if (!ctx.multiFile) {
+    section.dataset.docLayout = 'centered'
+  } else {
+    delete section.dataset.docLayout
+  }
+
+  const reviewForm = ctx.activeForms.find(f => f.scope === 'review')
+  const reviewComments = ctx.comments.filter(c => c.scope === 'review')
+
+  const collapsed = isReviewConversationCollapsed() && !reviewForm
+  section.classList.toggle('collapsed', collapsed)
+
+  // Header
+  const header = document.createElement('div')
+  header.className = 'review-conversation-header'
+
+  const toggle = document.createElement('button')
+  toggle.type = 'button'
+  toggle.className = 'review-conversation-toggle'
+  toggle.title = collapsed ? 'Expand review conversation' : 'Collapse review conversation'
+  toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true')
+  toggle.setAttribute('aria-label', toggle.title)
+  toggle.innerHTML = ICON_REVIEW_CHEVRON
+  toggle.addEventListener('click', function() {
+    setReviewConversationCollapsed(!isReviewConversationCollapsed())
+    renderReviewConversation(ctx)
+  })
+  header.appendChild(toggle)
+
+  const iconSpan = document.createElement('span')
+  iconSpan.className = 'icon'
+  iconSpan.innerHTML = ICON_REVIEW_CONVERSATION
+  header.appendChild(iconSpan)
+
+  const labelText = document.createElement('span')
+  labelText.className = 'label'
+  labelText.textContent = 'Review conversation'
+  header.appendChild(labelText)
+
+  const unresolvedCount = reviewComments.filter(c => !c.resolved).length
+  if (unresolvedCount > 0) {
+    const count = document.createElement('span')
+    count.className = 'count'
+    count.textContent = String(unresolvedCount)
+    header.appendChild(count)
+  }
+  section.appendChild(header)
+
+  if (collapsed) return
+
+  const body = document.createElement('div')
+  body.className = 'review-conversation-body'
+  section.appendChild(body)
+
+  // Threads (existing comments). The editor renders inline at the matching
+  // position when the user is editing one.
+  for (const comment of reviewComments) {
+    if (reviewForm && reviewForm.editingId === comment.id) {
+      body.appendChild(renderCommentFormUI(ctx, reviewForm))
+    } else {
+      body.appendChild(createReviewConversationCard(ctx, comment))
+    }
+  }
+
+  // Footer: compose form (when active) or ghost "Add comment" button.
+  if (reviewForm && !reviewForm.editingId) {
+    body.appendChild(renderCommentFormUI(ctx, reviewForm))
+  } else {
+    const addMore = document.createElement('button')
+    addMore.className = 'review-conversation-add-more'
+    if (reviewComments.length === 0) addMore.classList.add('review-conversation-empty')
+    addMore.type = 'button'
+    addMore.textContent = 'Add comment'
+    addMore.addEventListener('click', function() { openReviewCommentForm(ctx) })
+    body.appendChild(addMore)
+  }
+}
+
+// A review-level card shown inline. Reuses renderPanelCard's structure (which
+// already builds resolve/edit/delete actions for own review comments) but
+// rewires the edit button to open the inline editor instead of a panel form.
+function createReviewConversationCard(ctx, comment) {
+  const card = renderPanelCard(ctx, comment, null)
+  // Drop the panel-comment-block class so width rules don't fight the inline section.
+  card.classList.remove('panel-comment-block')
+  // Inline cards should not navigate on click.
+  card.style.cursor = ''
+  // Replace the panel "delete" event-driven flow's edit affordance: panel-card
+  // for review scope renders only resolve+delete (no edit). Append an Edit
+  // button if the user owns this comment and one isn't already there.
+  if (comment.author_identity === ctx.identity) {
+    const actions = card.querySelector('.comment-actions')
+    if (actions && !actions.querySelector('.edit-btn')) {
+      const editBtn = document.createElement('button')
+      editBtn.className = 'edit-btn'
+      editBtn.title = 'Edit'
+      editBtn.innerHTML = '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M11.5 2.5l2 2L5 13H3v-2L11.5 2.5z" stroke-linejoin="round"/></svg>'
+      editBtn.addEventListener('click', function(e) {
+        e.stopPropagation()
+        openReviewCommentEditForm(ctx, comment)
+      })
+      actions.appendChild(editBtn)
+    }
+  }
+  return card
+}
+
+function buildReviewConversationTreeRow(ctx) {
+  const row = document.createElement('div')
+  row.className = 'tree-conversation-row'
+  row.dataset.treePath = REVIEW_CONVERSATION_PATH
+  let inner =
+    '<span class="tree-conversation-icon">' + ICON_REVIEW_CONVERSATION + '</span>' +
+    '<span class="tree-conversation-name">Review conversation</span>'
+  const reviewComments = ctx.comments.filter(c => c.scope === 'review')
+  const unresolved = reviewComments.filter(c => !c.resolved).length
+  if (unresolved > 0) {
+    inner += '<span class="tree-conversation-badge">' + unresolved + '</span>'
+  }
+  row.innerHTML = inner
+  row.addEventListener('click', function() { scrollToReviewConversation(ctx) })
+  return row
+}
+
+function scrollToReviewConversation(ctx) {
+  if (isReviewConversationCollapsed()) {
+    setReviewConversationCollapsed(false)
+    renderReviewConversation(ctx)
+  }
+  const section = document.getElementById('reviewConversation')
+  if (!section) return
+  const rect = section.getBoundingClientRect()
+  const headerEl = document.querySelector('.crit-header')
+  const headerOffset = headerEl ? headerEl.offsetHeight : 0
+  if (rect.top < headerOffset || rect.top > window.innerHeight) {
+    section.scrollIntoView({ block: 'start', behavior: 'instant' })
+  }
+}
+
+function scrollToReviewComment(ctx, commentId) {
+  if (isReviewConversationCollapsed()) {
+    setReviewConversationCollapsed(false)
+    renderReviewConversation(ctx)
+  }
+  const section = document.getElementById('reviewConversation')
+  if (!section) return
+  const card = section.querySelector(`.comment-card[data-comment-id="${CSS.escape(commentId)}"]`)
+  if (!card) {
+    scrollToReviewConversation(ctx)
+    return
+  }
+  card.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  card.classList.remove('comment-flash')
+  void card.offsetWidth
   card.classList.add('comment-flash')
   card.addEventListener('animationend', () => card.classList.remove('comment-flash'), { once: true })
 }
@@ -3734,7 +3991,10 @@ function toggleCommentsPanel(ctx) {
 
 function getInlineCommentCards(ctx) {
   const panel = ctx._commentsPanel
-  return Array.from(ctx.el.querySelectorAll('.comment-card')).filter(card => {
+  // Search the whole main-content area so review-conversation cards (which
+  // live as siblings to ctx.el) are included in ] / [ navigation.
+  const root = document.querySelector('.crit-main-content') || ctx.el
+  return Array.from(root.querySelectorAll('.comment-card')).filter(card => {
     return !panel || !panel.contains(card)
   })
 }
@@ -4172,7 +4432,6 @@ export const DocumentRenderer = {
             <span class="comments-panel-count-badge" id="commentsPanelCountBadge">0</span>
           </div>
           <div class="comments-panel-header-actions">
-            <button class="comments-panel-add-btn" title="Add a general comment (Shift+G)">+ Add</button>
             <button class="comments-panel-close" title="Close comments panel" aria-label="Close comments panel">&#x2715;</button>
           </div>
         </div>
@@ -4190,9 +4449,6 @@ export const DocumentRenderer = {
     // Track active filter: 'all', 'open', 'resolved'
     ctx._commentsActiveFilter = 'all'
 
-    commentsPanel.querySelector('.comments-panel-add-btn').addEventListener('click', () => {
-      openReviewCommentForm(ctx)
-    })
     commentsPanel.querySelector('.comments-panel-close').addEventListener('click', () => {
       commentsPanel.classList.remove('comments-panel-open')
       syncCommentsPanelAria(false)

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -388,6 +388,7 @@
   </div>
   <div id="crit-main-layout" class="crit-main-layout">
     <div id="fileTreePanel" class="tree-panel" style="display:none">
+      <div id="treeConversationSection" class="tree-section--conversation"></div>
       <div class="tree-header">
         <span class="tree-title">Files</span>
         <span id="fileTreeStats" class="tree-stats"></span>
@@ -396,6 +397,7 @@
     </div>
 
     <div class="crit-main-content">
+      <div id="reviewConversation" class="review-conversation" hidden></div>
       <div
         id="document-renderer"
         phx-hook=".DocumentRenderer"


### PR DESCRIPTION
## Summary

Ports the Review Conversation feature from `crit/` ([PR #405](https://github.com/tomasz-tomczyk/crit/pull/405)) to `crit-web/`.

Replaces the hidden "+ Add" button in the comments panel with a top-of-document **Review Conversation** section and a sibling tree-section above FILES in the sidebar. Both surfaces use the typography-driven Linear treatment from `crit/` — no card chrome, no rails — and a shared ghost "Add comment" button that auto-closes when the user starts another comment form.

## Changes

- New `#reviewConversation` section above `#document-renderer`; threads + compose/edit form render inline. `data-doc-layout="centered"` in single-doc mode, left-anchored in multi-file (git-style) view.
- New `#treeConversationSection` row above the file tree FILES header, with a tabular-nums unresolved badge.
- `Shift+G` opens the inline form (no longer the panel form). `Esc` cancels, `Ctrl+Enter` submits. Editing review comments now happens inline — the panel cards are read-only mirrors that scroll back to the inline section and flash via `.comment-flash`.
- `] / [` comment navigation now picks up inline review-conversation cards (was scoped to `#document-renderer` only).
- Auto-close: opening another comment/reply form closes an empty review form, and vice-versa.
- Section is collapsible, persisted via `localStorage` (`crit-review-conversation-collapsed`) — matches other view prefs in `crit-web`.
- Removed the `.comments-panel-add-btn` (and its CSS). Its function moved to the inline ghost button.

## Backend

`Comment.scope == "review"` was already supported by the schema and the `add_comment` / `edit_comment` / `delete_comment` / `resolve` / `reply` LiveView events — **no schema or context changes needed**.

## Naming adapted to crit-web conventions

- `--crit-content-width` (not `--content-width`)
- `--crit-editor-bg-elevated` (no `--crit-editor-bg-hover` exists in crit-web)
- `localStorage` (not cookies — matches crit-web's other prefs)
- `.comment-flash` (not `.comment-card-highlight`)

## Test plan

- [ ] `Shift+G` opens the inline form with focus
- [ ] `Esc` cancels, `Ctrl+Enter` submits
- [ ] Submitting a review comment renders it in the inline section, the file-tree row badge, and the comments panel
- [ ] Clicking a review card in the comments panel scrolls to and flashes the inline card
- [ ] `]` / `[` navigation cycles through review-conversation cards alongside line/file cards
- [ ] Resolve/Unresolve/Edit/Delete buttons work on own review comments
- [ ] Replies on review comments save and render
- [ ] Section collapse persists across reload
- [ ] Empty review form auto-closes when the user starts a line or file comment, and vice-versa
- [ ] Multi-file review (left-anchored) and single-doc review (centered) both render correctly
- [ ] Light theme + dark theme + system theme all show the dashed-→-solid plus chip correctly
- [ ] `mix precommit` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)