### PR TITLE
fix: review conversation reply UI + always-centered layout

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3801,12 +3801,8 @@ function renderReviewConversation(ctx) {
   section.hidden = false
   section.innerHTML = ''
 
-  // Multi-file (git-style) view → left-anchor; single-doc view → centered.
-  if (!ctx.multiFile) {
-    section.dataset.docLayout = 'centered'
-  } else {
-    delete section.dataset.docLayout
-  }
+  // crit-web is always doc-centered (no git-mode side-by-side diff view).
+  section.dataset.docLayout = 'centered'
 
   const reviewForm = ctx.activeForms.find(f => f.scope === 'review')
   const reviewComments = ctx.comments.filter(c => c.scope === 'review')
@@ -3884,14 +3880,13 @@ function renderReviewConversation(ctx) {
 // already builds resolve/edit/delete actions for own review comments) but
 // rewires the edit button to open the inline editor instead of a panel form.
 function createReviewConversationCard(ctx, comment) {
-  const card = renderPanelCard(ctx, comment, null)
+  const wrapper = renderPanelCard(ctx, comment, null)
   // Drop the panel-comment-block class so width rules don't fight the inline section.
-  card.classList.remove('panel-comment-block')
-  // Inline cards should not navigate on click.
+  wrapper.classList.remove('panel-comment-block')
+  // The actual card lives inside the wrapper; we need it to append replies + reply input.
+  const card = wrapper.querySelector('.comment-card') || wrapper
   card.style.cursor = ''
-  // Replace the panel "delete" event-driven flow's edit affordance: panel-card
-  // for review scope renders only resolve+delete (no edit). Append an Edit
-  // button if the user owns this comment and one isn't already there.
+  // Append Edit button for owners (panel-card builds resolve+delete only for review scope).
   if (comment.author_identity === ctx.identity) {
     const actions = card.querySelector('.comment-actions')
     if (actions && !actions.querySelector('.edit-btn')) {
@@ -3906,7 +3901,13 @@ function createReviewConversationCard(ctx, comment) {
       actions.appendChild(editBtn)
     }
   }
-  return card
+  // Render existing replies + a reply input — review-level threads support replies
+  // exactly like line-anchored ones (parity with crit local).
+  if (comment.replies && comment.replies.length > 0) {
+    card.appendChild(renderReplyList(comment, ctx))
+  }
+  card.appendChild(createReplyInput(comment.id, ctx))
+  return wrapper
 }
 
 function buildReviewConversationTreeRow(ctx) {

--- a/test/crit_web/live/review_live_test.exs
+++ b/test/crit_web/live/review_live_test.exs
@@ -800,6 +800,34 @@ defmodule CritWeb.ReviewLiveTest do
       assert reply_id == reply.id
     end
 
+    test "add_reply works on review-scope comments (parity with line-anchored)", %{
+      conn: conn,
+      review: review
+    } do
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+      view
+      |> element("#document-renderer")
+      |> render_hook("add_comment", %{
+        "scope" => "review",
+        "body" => "General feedback"
+      })
+
+      [comment] = Reviews.list_comments(review)
+      assert comment.scope == "review"
+
+      view
+      |> element("#document-renderer")
+      |> render_hook("add_reply", %{"comment_id" => comment.id, "body" => "reply on review"})
+
+      assert_push_event view, "reply_added", %{parent_id: parent_id, reply: reply}
+      assert parent_id == comment.id
+      assert reply.body == "reply on review"
+
+      [updated] = Reviews.list_comments(review)
+      assert [%{body: "reply on review"}] = updated.replies
+    end
+
     test "delete_reply pushes reply_deleted with parent_id and id", %{
       conn: conn,
       review: review


### PR DESCRIPTION
## Summary
- Adds the missing **reply input + reply list** to review-level comment cards on crit-web. Line-anchored cards already had it; review-level didn't, even though the LiveView \`add_reply\` handler is generic.
- crit-web is always doc-centered (no git side-by-side mode), so the Review conversation block always uses \`data-doc-layout="centered"\` instead of branching on \`ctx.multiFile\`.
- Adds a LiveView test (\`add_reply works on review-scope comments\`) so this parity gap can't regress silently.

## Why we missed it
The share integration tests in crit/ pass replies through the API directly (\`POST /api/reviews/{token}/seed-reply\`) — they verify the round-trip *data* path, not the *UI* affordance. The reply API worked; the button to trigger it from the web UI didn't exist.

Crit-side follow-up: a \`TestShareSyncFetchRepliesOnReviewLevelComment\` that exercises the full review→reply→fetch loop will land in a separate crit/ PR.

## Review
- [x] Manual smoke: reply on a review-level comment from web UI, see it broadcast back via PubSub.
- [x] LiveView test: 516 tests pass (was 515).

## Test plan
- [x] \`DB_PORT=5433 mix precommit\` — green
- [x] Open a shared review → review conversation → "Write a reply..." appears → expand, type, submit, see the reply land

Refs:
- crit-web/#147 (initial parity port)
- crit/#405 (the originating feature)
- crit/#374

🤖 Generated with [Claude Code](https://claude.com/claude-code)