### PR TITLE
chore: migrate wt pre-start to pipeline form

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,5 +1,7 @@
-[pre-start]
+[[pre-start]]
 mise-trust = "mise trust ."
+
+[[pre-start]]
 direnv-allow = "direnv allow"
 
 # Copy build caches from source branch worktree


### PR DESCRIPTION
## Summary
- Convert \`[pre-start]\` table to \`[[pre-start]]\` array-of-tables in \`.config/wt.toml\` to clear the worktrunk deprecation warning.
- Preserves serial execution of \`mise-trust\` and \`direnv-allow\` hooks once the table form is repurposed for parallel execution.

## Test plan
- \`wt config show\` no longer reports the deprecation warning.
- New worktrees still trust mise and allow direnv on creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)