### PR TITLE
fix: edit button + tailwind drift on review-level comments

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1205,6 +1205,24 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 .btn-primary:hover { background: var(--crit-brand-cta-hover); box-shadow: 0 2px 6px rgba(0,0,0,0.2); }
 .btn-sm { font-size: 12px; padding: 3px 10px; }
 
+/* Delete button used in review meta header (red outlined, fills on hover) */
+.crit-delete-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  margin-left: 4px;
+  border: 1px solid var(--crit-red);
+  border-radius: 6px;
+  background: var(--crit-bg-card);
+  color: var(--crit-red);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+.crit-delete-btn:hover { background: var(--crit-red); color: #fff; }
+.crit-delete-btn svg { width: 14px; height: 14px; }
+
 /* ===== User Pill (logged-in identity) ===== */
 .crit-user-pill {
   display: inline-flex;

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3910,7 +3910,7 @@ function createReviewConversationCard(ctx, comment) {
   const card = wrapper.querySelector('.comment-card') || wrapper
   card.style.cursor = ''
   // Append Edit button for owners (panel-card builds resolve+delete only for review scope).
-  if (comment.author_identity === ctx.identity) {
+  if (isOwnComment(comment, ctx)) {
     const actions = card.querySelector('.comment-actions')
     if (actions && !actions.querySelector('.edit-btn')) {
       const editBtn = document.createElement('button')

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -376,10 +376,10 @@
           <button
             phx-click="delete_review"
             data-confirm="Delete this review? This cannot be undone."
-            class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-(--crit-red) bg-(--crit-bg-card) text-(--crit-red) hover:bg-(--crit-red) hover:text-white transition-colors cursor-pointer ml-1 font-medium"
+            class="crit-delete-btn"
             aria-label="Delete review"
           >
-            <.icon name="hero-trash" class="size-3.5" />
+            <.icon name="hero-trash" />
             <span>Delete</span>
           </button>
         </:actions>


### PR DESCRIPTION
## Summary

- **P0:** `createReviewConversationCard` Edit button used `comment.author_identity === ctx.identity`, which never matched for authenticated authors (their `author_identity` is `nil`). Switched to the canonical `isOwnComment(comment, ctx)` helper used by Resolve and Delete elsewhere in the same file.
- **P1:** Owner Delete button on the review page used a 14-utility Tailwind cluster — review page is custom-CSS-only by repo policy. Replaced with `.crit-delete-btn` rule wired through `--crit-*` tokens.

Found via release audit (v0.5.0..HEAD) and validated by opus reviewers.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [ ] Sign in as a review owner who authored a review-level comment; verify Edit button appears and works
- [ ] Verify Delete button visual matches the prior Tailwind rendering (red outline, fills red on hover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)