### PR TITLE
refactor: post-release audit cleanups

### DIFF
--- a/lib/crit/comment.ex
+++ b/lib/crit/comment.ex
@@ -59,6 +59,19 @@ defmodule Crit.Comment do
     end
   end
 
+  @doc """
+  Changeset for editing only the body of an existing comment. Mirrors the
+  `:body` validations in `create_changeset/2` but does not re-validate
+  immutable fields (start_line/end_line/scope) which the caller would
+  otherwise need to re-pass.
+  """
+  def body_changeset(comment, attrs) do
+    comment
+    |> cast(attrs, [:body])
+    |> validate_required([:body])
+    |> validate_length(:body, max: 51_200, message: "must be at most 50 KB")
+  end
+
   @doc "Changeset for creating a reply (comment with parent_id)."
   def reply_changeset(comment, attrs) do
     comment

--- a/lib/crit/config.ex
+++ b/lib/crit/config.ex
@@ -9,11 +9,22 @@ defmodule Crit.Config do
   Returns true when this instance is running in selfhosted mode AND has an
   OAuth provider configured. This is the predicate that turns on auth
   enforcement for both the JSON API (`CritWeb.Plugs.ApiAuth`) and the
-  `/r/:token` review LiveView (`CritWeb.Live.Hooks.:require_review_auth`).
+  `/r/:token` review LiveView (`CritWeb.UserAuth.:require_review_scope`).
   """
   @spec selfhosted_oauth?() :: boolean()
   def selfhosted_oauth? do
     Application.get_env(:crit, :selfhosted) == true &&
       Application.get_env(:crit, :oauth_provider) != nil
+  end
+
+  @doc """
+  Returns true when an OAuth provider is configured, regardless of selfhosted
+  mode. Use this for sites that gate purely on OAuth presence (device flow,
+  public-mode auth-required redirects). Distinct from `selfhosted_oauth?/0`,
+  which also requires `:selfhosted == true`.
+  """
+  @spec oauth_configured?() :: boolean()
+  def oauth_configured? do
+    Application.get_env(:crit, :oauth_provider) != nil
   end
 end

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -18,7 +18,7 @@ defmodule Crit.Reviews do
             comments:
               ^from(c in Comment,
                 where: is_nil(c.parent_id),
-                order_by: [asc: c.start_line, asc: c.end_line],
+                order_by: [asc: c.start_line, asc: c.end_line, asc: c.inserted_at],
                 preload: [:user, replies: [:user]]
               )
           ]
@@ -59,7 +59,7 @@ defmodule Crit.Reviews do
     Repo.all(
       from c in Comment,
         where: c.review_id == ^review_id and is_nil(c.parent_id),
-        order_by: [asc: c.start_line, asc: c.end_line],
+        order_by: [asc: c.start_line, asc: c.end_line, asc: c.inserted_at],
         preload: [:user, replies: [:user]]
     )
   end
@@ -111,12 +111,7 @@ defmodule Crit.Reviews do
       %Comment{} = comment ->
         if comment_owned_by?(scope, comment) do
           comment
-          |> Comment.create_changeset(%{
-            "start_line" => comment.start_line,
-            "end_line" => comment.end_line,
-            "body" => body,
-            "scope" => comment.scope || "line"
-          })
+          |> Comment.body_changeset(%{"body" => body})
           |> Repo.update()
         else
           {:error, :unauthorized}
@@ -165,11 +160,17 @@ defmodule Crit.Reviews do
         review_comments_attrs \\ [],
         opts \\ []
       ) do
-    total_size = files_attrs |> Enum.map(&byte_size(&1["content"] || "")) |> Enum.sum()
+    total_bytes = files_attrs |> Enum.map(&byte_size(&1["content"] || "")) |> Enum.sum()
+
+    total_lines =
+      files_attrs
+      |> Enum.map(&((&1["content"] || "") |> String.split("\n") |> length()))
+      |> Enum.sum()
+
     user_id = Scope.user_id(scope)
     cli_args = Keyword.get(opts, :cli_args) || []
 
-    if total_size > @max_total_size do
+    if total_bytes > @max_total_size do
       {:error, :total_size_exceeded}
     else
       review_changeset =
@@ -206,12 +207,6 @@ defmodule Crit.Reviews do
       |> case do
         {:ok, %{review: review}} ->
           comment_count = length(comments_attrs) + length(review_comments_attrs)
-          total_bytes = files_attrs |> Enum.map(&byte_size(&1["content"] || "")) |> Enum.sum()
-
-          total_lines =
-            files_attrs
-            |> Enum.map(&((&1["content"] || "") |> String.split("\n") |> length()))
-            |> Enum.sum()
 
           Statistics.increment_review(
             length(files_attrs),

--- a/lib/crit_web/controllers/device_api_controller.ex
+++ b/lib/crit_web/controllers/device_api_controller.ex
@@ -82,9 +82,7 @@ defmodule CritWeb.DeviceApiController do
     conn |> put_status(400) |> json(%{error: "device_code is required"})
   end
 
-  defp oauth_configured? do
-    Application.get_env(:crit, :oauth_provider) != nil
-  end
+  defp oauth_configured?, do: Crit.Config.oauth_configured?()
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -87,7 +87,7 @@ defmodule CritWeb.ReviewLive do
         {:ok,
          socket
          |> assign(:review, review)
-         |> assign(:oauth_configured, Application.get_env(:crit, :oauth_provider) != nil)
+         |> assign(:oauth_configured, Crit.Config.oauth_configured?())
          |> assign(:auth_required, auth_required)
          |> assign(:demo?, demo?)
          |> assign(:local_prompt_text, local_prompt_text)

--- a/lib/crit_web/plugs/rate_limit.ex
+++ b/lib/crit_web/plugs/rate_limit.ex
@@ -37,12 +37,12 @@ defmodule CritWeb.Plugs.RateLimit do
         {:allow, _} ->
           conn
 
-        {:deny, _} ->
+        {:deny, retry_after} ->
           {content_type, body} = body_for(response)
 
           conn
           |> put_resp_content_type(content_type)
-          |> put_resp_header("retry-after", "60")
+          |> put_resp_header("retry-after", Integer.to_string(div(retry_after, 1000)))
           |> send_resp(429, body)
           |> halt()
       end

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -59,6 +59,8 @@ defmodule CritWeb.Router do
     get "/changelog", PageController, :changelog
 
     post "/set-name", ReviewController, :set_name
+    # POST /auth/login = legacy admin password login (selfhosted instances).
+    # GET  /auth/login = OAuth provider redirect (initiates the OAuth flow).
     post "/auth/login", AuthController, :login
     post "/auth/logout", AuthController, :logout
 

--- a/lib/crit_web/user_auth.ex
+++ b/lib/crit_web/user_auth.ex
@@ -106,7 +106,7 @@ defmodule CritWeb.UserAuth do
     if socket.assigns.current_scope.user do
       {:cont, socket}
     else
-      if Application.get_env(:crit, :oauth_provider) do
+      if Crit.Config.oauth_configured?() do
         request_path = Map.get(session, "request_path", "/dashboard")
         {:halt, redirect(socket, to: "/auth/login?return_to=#{request_path}")}
       else
@@ -120,7 +120,7 @@ defmodule CritWeb.UserAuth do
       socket = assign_scope(socket, session)
       password_required = Application.get_env(:crit, :admin_password) != nil
       admin_authenticated = Map.get(session, "admin_authenticated", false) == true
-      oauth_configured = Application.get_env(:crit, :oauth_provider) != nil
+      oauth_configured = Crit.Config.oauth_configured?()
 
       authenticated =
         cond do

--- a/test/crit_web/plugs/rate_limit_test.exs
+++ b/test/crit_web/plugs/rate_limit_test.exs
@@ -36,7 +36,9 @@ defmodule CritWeb.Plugs.RateLimitTest do
       assert blocked.status == 429
       assert blocked.resp_body == "Too many requests"
       assert ["text/plain" <> _] = get_resp_header(blocked, "content-type")
-      assert get_resp_header(blocked, "retry-after") == ["60"]
+      [retry] = get_resp_header(blocked, "retry-after")
+      assert {n, ""} = Integer.parse(retry)
+      assert n >= 0 and n <= 60
     end
 
     test "returns JSON body when response: :json", %{conn: conn, ip: ip} do
@@ -46,7 +48,9 @@ defmodule CritWeb.Plugs.RateLimitTest do
       assert blocked.status == 429
       assert blocked.resp_body == ~s({"error":"Too many requests"})
       assert ["application/json" <> _] = get_resp_header(blocked, "content-type")
-      assert get_resp_header(blocked, "retry-after") == ["60"]
+      [retry] = get_resp_header(blocked, "retry-after")
+      assert {n, ""} = Integer.parse(retry)
+      assert n >= 0 and n <= 60
     end
 
     test "rate limit is per-IP", %{conn: conn} do


### PR DESCRIPTION
## Summary

Backend cleanups surfaced by the v0.5.0..HEAD release audit. No behavior changes user-visible apart from rate-limit `retry-after` (now correct) and a new stable order for review/file-level comments.

- `Comment.body_changeset/2`: body-only edits no longer re-validate immutable `start_line`/`end_line`/`scope` through `create_changeset`
- `create_review` computes `total_bytes`/`total_lines` once before the size guard, reuses for the Statistics increment
- `Crit.Config.oauth_configured?/0` helper replaces 4 inline `Application.get_env/2` checks (kept distinct from `selfhosted_oauth?/0`, which has different semantics)
- Doc reference fix: `CritWeb.Live.Hooks.:require_review_auth` → `CritWeb.UserAuth.:require_review_scope`
- Router comment distinguishing `POST /auth/login` (legacy admin password) from `GET /auth/login` (OAuth)
- Comment ordering: add `inserted_at` tertiary sort so review-level/file-level comments (`start_line=0`) get a stable order
- `RateLimit` plug emits Hammer's actual `retry_after` value instead of hardcoded `60`

## Test plan

- [x] `mix precommit` — 516 tests, 0 failures
- [ ] Trigger global rate limit; confirm `retry-after` header reflects window remaining
- [ ] Add multiple review-level comments rapidly; confirm stable display order on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)