### PR TITLE
fix: stop flashing disconnect banner on transient mobile websocket drops

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -22,6 +22,24 @@
 /* Make LiveView wrapper divs transparent for layout */
 [data-phx-session], [data-phx-teleported-src] { display: contents }
 
+/* LiveView connection-state indicators (#client-error / #server-error in
+   layouts.ex flash_group). Phoenix adds .phx-client-error / .phx-server-error
+   to <body> while the socket is down. We delay revealing the banner by
+   ~1.5s so routine sub-second mobile WebSocket drops (tab background, lock
+   screen, network handoff) don't flash a "disconnected" message. Hide
+   fades out over 200ms on reconnect. Pattern from Livebook / Fly.io. */
+#client-error, #server-error {
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 200ms ease-in 0s, visibility 0s linear 200ms;
+}
+.phx-client-error #client-error,
+.phx-server-error #server-error {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 200ms ease-in 1500ms, visibility 0s linear 1500ms;
+}
+
 /* This file is for your main application CSS */
 
 /* ===== Crit Review Page — CSS Variables ===== */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -64,21 +64,48 @@ function initSentry(liveSocket) {
       },
     })
 
-    // LiveView socket errors hit console.error, not window.onerror —
-    // wire them to Sentry explicitly. onError fires on every reconnect
-    // backoff tick during outages, so dedupe until the next successful open.
+    // LiveView socket errors hit console.error, not window.onerror.
+    // onError fires on every reconnect backoff tick — most are routine
+    // mobile WebSocket drops (tab background, lock screen, network handoff)
+    // that Phoenix recovers from in milliseconds. Only surface to Sentry
+    // when the failed state persists past 5s without a successful reconnect.
     const socket = liveSocket?.getSocket?.()
     if (socket) {
-      let reported = false
+      const PERSISTENCE_MS = 5000
+      let pendingTimer = null
+      let consecutiveErrors = 0
+      let firstErrorAt = null
+      let lastOpenAt = Date.now()
+
       socket.onError(err => {
-        if (reported) return
-        reported = true
-        Sentry.captureMessage("LiveSocket transport error", {
-          level: "error",
-          extra: { type: err?.type, message: String(err?.message ?? err) },
-        })
+        consecutiveErrors += 1
+        if (firstErrorAt === null) firstErrorAt = Date.now()
+        if (pendingTimer !== null) return
+        const errSnapshot = err
+        pendingTimer = setTimeout(() => {
+          pendingTimer = null
+          Sentry.captureMessage("LiveSocket transport error (persistent)", {
+            level: "warning",
+            extra: {
+              type: errSnapshot?.type,
+              message: String(errSnapshot?.message ?? errSnapshot),
+              consecutive_errors: consecutiveErrors,
+              ms_since_last_open: lastOpenAt ? Date.now() - lastOpenAt : null,
+              transport: socket.transport?.name || socket.transport?.constructor?.name || null,
+            },
+          })
+        }, PERSISTENCE_MS)
       })
-      socket.onOpen(() => { reported = false })
+
+      socket.onOpen(() => {
+        lastOpenAt = Date.now()
+        consecutiveErrors = 0
+        firstErrorAt = null
+        if (pendingTimer !== null) {
+          clearTimeout(pendingTimer)
+          pendingTimer = null
+        }
+      })
     }
   }).catch(() => {})
 }

--- a/lib/crit_web/components/layouts.ex
+++ b/lib/crit_web/components/layouts.ex
@@ -788,13 +788,15 @@ defmodule CritWeb.Layouts do
       <.flash kind={:info} flash={@flash} />
       <.flash kind={:error} flash={@flash} />
 
+      <%!-- Connection-state indicators. Visibility is driven entirely by
+            the body classes Phoenix toggles (.phx-client-error /
+            .phx-server-error) plus a CSS transition-delay (~1.5s) so
+            routine sub-second WebSocket blips on mobile don't flash a
+            "disconnected" banner. See app.css "#client-error". --%>
       <.flash
         id="client-error"
         kind={:error}
         title={gettext("We can't find the internet")}
-        phx-disconnected={show(".phx-client-error #client-error") |> JS.remove_attribute("hidden")}
-        phx-connected={hide("#client-error") |> JS.set_attribute({"hidden", ""})}
-        hidden
       >
         {gettext("Attempting to reconnect")}
         <.icon name="hero-arrow-path" class="ml-1 size-3 motion-safe:animate-spin" />
@@ -804,9 +806,6 @@ defmodule CritWeb.Layouts do
         id="server-error"
         kind={:error}
         title={gettext("Something went wrong!")}
-        phx-disconnected={show(".phx-server-error #server-error") |> JS.remove_attribute("hidden")}
-        phx-connected={hide("#server-error") |> JS.set_attribute({"hidden", ""})}
-        hidden
       >
         {gettext("Attempting to reconnect")}
         <.icon name="hero-arrow-path" class="ml-1 size-3 motion-safe:animate-spin" />


### PR DESCRIPTION
## Summary
- LiveSocket `onError` fires on every transport hiccup (tab background, lock screen, mobile network handoff). Phoenix recovers in ms, but users saw a "Disconnected" banner flash and Sentry logged it as `error`.
- Threshold the Sentry capture: only report after 5s of persistent failure without reconnect. Downgrade to `level: warning` with `consecutive_errors` / `ms_since_last_open` / `transport` context.
- Delay the disconnect banner reveal by 1.5s via CSS transition-delay on `.phx-client-error` / `.phx-server-error` body classes (Livebook / Fly.io pattern). Hide fades over 200ms on reconnect.

## Review
- [x] Code review: passed (frontend-expert + elixir-expert, no blockers)
- [x] Parity audit: N/A — touches Phoenix socket bootstrap, not the review-page renderer

## Test plan
- `mix precommit` passes (516/516 tests)
- Manual verification deferred — fix targets routine mobile transport blips that don't reproduce locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)