### PR TITLE
ci: register Sentry releases on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,19 @@ jobs:
       url: https://crit.md
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Register Sentry release
+        uses: getsentry/action-release@v3
+        with:
+          environment: production
+          version: ${{ github.sha }}
+          projects: crit-web-backend crit-web-frontend
+          set_commits: auto
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: crit-md
       - run: flyctl deploy --remote-only --env SENTRY_RELEASE=${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- We currently set `SENTRY_RELEASE=<sha>` on the Fly app so events are tagged with a release, but never register the release with Sentry. As a result, "Resolve in next release" never triggers, source maps aren't uploaded, and suspect-commit / regression detection don't work.
- Adds `getsentry/action-release@v3` before `flyctl deploy` to register the sha as a release for both `crit-web-backend` and `crit-web-frontend`, with `set_commits: auto` for commit association.
- Enables the per-issue "Resolve in next release" workflow: mark a fixed issue in Sentry → next deploy auto-resolves it; regressions auto-reopen.

## Setup
- Added `SENTRY_AUTH_TOKEN` repo secret (Sentry Internal Integration with `project:releases` admin + `event:write` scopes).

## Test plan
- After merge, watch the Deploy workflow run for the new "Register Sentry release" step
- Verify a release appears at https://crit-md.sentry.io/releases/ tagged with the merge sha
- Mark `CRIT-WEB-FRONTEND-1` as "Resolve in next release" — confirm it auto-resolves on the next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)