### PR TITLE
fix: confirm before discarding non-empty comment drafts on Esc

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -2575,7 +2575,7 @@ function createCommentForm(formObj, ctx) {
     } else if (e.key === "Escape") {
       e.preventDefault()
       e.stopPropagation()
-      cancelComment(formObj, ctx)
+      if (confirmDiscardIfDirty(formObj)) cancelComment(formObj, ctx)
     }
   })
 
@@ -2652,7 +2652,7 @@ function createInlineEditor(comment, formObj, ctx) {
     } else if (e.key === "Escape") {
       e.preventDefault()
       e.stopPropagation()
-      cancelComment(formObj, ctx)
+      if (confirmDiscardIfDirty(formObj)) cancelComment(formObj, ctx)
     }
   })
 
@@ -2722,6 +2722,15 @@ function submitEditComment(id, body, formObj, ctx) {
   ctx.pushEvent("edit_comment", { id, body: body.trim() })
   removeForm(ctx, formObj.formKey)
   render(ctx)
+}
+
+// Returns true if the user confirms discarding (or the draft is empty).
+// Returns false if the user cancels the confirm — caller should keep the form open.
+function confirmDiscardIfDirty(formObj) {
+  const ta = document.querySelector('textarea[data-form-key="' + formObj.formKey + '"]')
+  if (!ta) return true
+  if (!ta.value.trim()) return true
+  return window.confirm("Discard comment?")
 }
 
 function cancelComment(formObj, ctx) {
@@ -2948,7 +2957,7 @@ function editReply(commentId, reply, ctx) {
   replyEl.appendChild(btnRow)
 
   cancelBtn.addEventListener('click', () => {
-    // Re-render to restore the original state
+    // Cancel button is an explicit, labeled discard — no confirm.
     render(ctx)
   })
 
@@ -2967,7 +2976,9 @@ function editReply(commentId, reply, ctx) {
     if (e.key === 'Escape') {
       e.preventDefault()
       e.stopPropagation()
-      cancelBtn.click()
+      const changed = textarea.value !== currentText
+      if (changed && textarea.value.trim() && !window.confirm("Discard comment?")) return
+      render(ctx)
     }
   })
 }
@@ -3257,7 +3268,7 @@ function renderCommentFormUI(ctx, formObj) {
     }
     if (e.key === 'Escape') {
       e.preventDefault()
-      cancelComment(formObj, ctx)
+      if (confirmDiscardIfDirty(formObj)) cancelComment(formObj, ctx)
     }
   })
   form.appendChild(textarea)
@@ -4928,7 +4939,8 @@ export const DocumentRenderer = {
         case 'Escape': {
           e.preventDefault()
           if (ctx.activeForms.length > 0) {
-            cancelComment(ctx.activeForms[ctx.activeForms.length - 1], ctx)
+            const top = ctx.activeForms[ctx.activeForms.length - 1]
+            if (confirmDiscardIfDirty(top)) cancelComment(top, ctx)
           } else if (ctx.focusedBlockIndex >= 0) {
             clearFocus(ctx)
           }

--- a/e2e/comments.spec.ts
+++ b/e2e/comments.spec.ts
@@ -141,24 +141,78 @@ test.describe("Comments — Add via UI", () => {
     await expect(page.locator('.comment-form textarea').first()).toHaveValue("draft text");
   });
 
-  test("cancels a comment form with Escape", async ({ page }) => {
+  test("Escape on empty comment form closes silently", async ({ page }) => {
     await loadReview(page, token);
 
-    const firstGutter = page.locator(".line-gutter").first();
-    await firstGutter.click();
-
+    await page.locator(".line-gutter").first().click();
     const textarea = page.locator(".comment-form textarea");
     await expect(textarea).toBeVisible({ timeout: 5_000 });
-    await textarea.fill("This will be cancelled");
 
-    // Press Escape to cancel
+    // No content -> no confirm dialog, form just closes
     await textarea.press("Escape");
 
-    // The comment form should disappear
     await expect(page.locator(".comment-form")).not.toBeVisible();
-
-    // No comment card should appear
     expect(await page.locator(".comment-card").count()).toBe(0);
+  });
+
+  test("Escape on non-empty comment form prompts confirm; OK discards", async ({ page }) => {
+    await loadReview(page, token);
+
+    await page.locator(".line-gutter").first().click();
+    const textarea = page.locator(".comment-form textarea");
+    await expect(textarea).toBeVisible({ timeout: 5_000 });
+    await textarea.fill("Detailed draft we don't want to lose by accident");
+
+    // Accept the confirm dialog -> discard
+    page.once("dialog", (dialog) => {
+      expect(dialog.type()).toBe("confirm");
+      expect(dialog.message()).toMatch(/discard/i);
+      dialog.accept();
+    });
+    await textarea.press("Escape");
+
+    await expect(page.locator(".comment-form")).not.toBeVisible();
+    expect(await page.locator(".comment-card").count()).toBe(0);
+  });
+
+  test("Escape on non-empty comment form prompts confirm; Cancel keeps draft", async ({ page }) => {
+    await loadReview(page, token);
+
+    await page.locator(".line-gutter").first().click();
+    const textarea = page.locator(".comment-form textarea");
+    await expect(textarea).toBeVisible({ timeout: 5_000 });
+    const draft = "Detailed draft we don't want to lose by accident";
+    await textarea.fill(draft);
+
+    // Dismiss the confirm dialog -> keep the form with content
+    page.once("dialog", (dialog) => {
+      expect(dialog.type()).toBe("confirm");
+      dialog.dismiss();
+    });
+    await textarea.press("Escape");
+
+    await expect(page.locator(".comment-form textarea")).toBeVisible();
+    await expect(page.locator(".comment-form textarea")).toHaveValue(draft);
+  });
+
+  test("Cancel button on non-empty comment form discards immediately (no confirm)", async ({ page }) => {
+    await loadReview(page, token);
+
+    await page.locator(".line-gutter").first().click();
+    const textarea = page.locator(".comment-form textarea");
+    await expect(textarea).toBeVisible({ timeout: 5_000 });
+    await textarea.fill("Important draft");
+
+    // Cancel is an explicit, labeled discard — no confirm should appear.
+    let dialogShown = false;
+    page.on("dialog", (dialog) => {
+      dialogShown = true;
+      dialog.dismiss();
+    });
+
+    await page.locator(".comment-form").getByRole("button", { name: "Cancel" }).click();
+    await expect(page.locator(".comment-form")).not.toBeVisible();
+    expect(dialogShown).toBe(false);
   });
 });
 

--- a/e2e/draft-autosave.spec.ts
+++ b/e2e/draft-autosave.spec.ts
@@ -144,7 +144,8 @@ test.describe("Draft Autosave", () => {
       expect(count).toBe(1);
     }).toPass({ timeout: 3_000 });
 
-    // Cancel via Escape
+    // Cancel via Escape — non-empty draft prompts confirm; accept to discard
+    page.once("dialog", (dialog) => dialog.accept());
     await textarea.press("Escape");
     await expect(page.locator(".comment-form")).not.toBeVisible();
 


### PR DESCRIPTION
## Summary
- Esc on a non-empty comment form now prompts `Discard comment?` instead of silently throwing away the draft. Empty form → silent close (unchanged).
- Cancel button discards immediately (matches GitHub) — explicit user intent doesn't need a confirm.
- Reported by a user who lost a detailed draft to a reflexive Esc.

## Test plan
- New e2e covering Esc-with-content (accept/dismiss), Esc-empty (no dialog), Cancel-button (no dialog).
- Existing comment / editing / reply-editing / templates / draft-autosave suites green (116/117 — the one failure is a pre-existing dark-theme contrast flake unrelated to this change).
- See also: tomasz-tomczyk/crit#415

🤖 Generated with [Claude Code](https://claude.com/claude-code)