### PR TITLE
feat: add custom 404 page

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,7 +17,7 @@ config :crit, CritWeb.Endpoint,
   adapter: Bandit.PhoenixAdapter,
   render_errors: [
     formats: [html: CritWeb.ErrorHTML, json: CritWeb.ErrorJSON],
-    layout: false
+    layout: {CritWeb.Layouts, :root}
   ],
   pubsub_server: Crit.PubSub,
   live_view: [signing_salt: "WyzCaSCk"]

--- a/e2e/review-page.spec.ts
+++ b/e2e/review-page.spec.ts
@@ -52,10 +52,12 @@ test.describe("Review Page — Loading", () => {
     ).toContainText("Get prompt");
   });
 
-  test("returns 404 flash for invalid token", async ({ page }) => {
-    await page.goto("/r/nonexistent-token-12345");
-    // Should redirect to home with flash error
-    await expect(page).toHaveURL("/");
+  test("renders 404 page for invalid token", async ({ page }) => {
+    const response = await page.goto("/r/nonexistent-token-12345");
+    expect(response?.status()).toBe(404);
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      "not found"
+    );
   });
 });
 

--- a/lib/crit_web/controllers/error_html.ex
+++ b/lib/crit_web/controllers/error_html.ex
@@ -6,18 +6,11 @@ defmodule CritWeb.ErrorHTML do
   """
   use CritWeb, :html
 
-  # If you want to customize your error pages,
-  # uncomment the embed_templates/1 call below
-  # and add pages to the error directory:
-  #
-  #   * lib/crit_web/controllers/error_html/404.html.heex
-  #   * lib/crit_web/controllers/error_html/500.html.heex
-  #
-  # embed_templates "error_html/*"
+  embed_templates "error_html/*"
 
-  # The default is to render a plain text page based on
-  # the template name. For example, "404.html" becomes
-  # "Not Found".
+  # Fallback for any template without a dedicated .heex file (e.g. 500).
+  # Phoenix.Controller.status_message_from_template/1 returns the standard
+  # text like "Internal Server Error".
   def render(template, _assigns) do
     Phoenix.Controller.status_message_from_template(template)
   end

--- a/lib/crit_web/controllers/error_html/404.html.heex
+++ b/lib/crit_web/controllers/error_html/404.html.heex
@@ -1,0 +1,163 @@
+<Layouts.flash_group flash={assigns[:flash] || %{}} />
+
+<div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
+  <Layouts.site_header current_scope={assigns[:current_scope]} />
+
+  <main class="flex-1 relative">
+    <div class="max-w-7xl mx-auto px-10 py-24 max-sm:px-4 max-sm:py-14 w-full grid grid-cols-1 md:grid-cols-[1.1fr_0.9fr] gap-20 max-md:gap-12 items-center">
+      <div class="max-w-xl">
+        <h1 class="text-7xl font-extrabold leading-none tracking-tight mb-7 max-lg:text-6xl max-sm:text-5xl">
+          This page was <span class="block text-(--crit-brand)">not found.</span>
+        </h1>
+        <p class="text-xl max-sm:text-base leading-relaxed text-(--crit-fg-secondary) mb-10">
+          We looked everywhere &mdash; under the desk, behind the server rack, in the git stash &mdash;
+          and the page you're after just isn't here. It might have moved, or the link might have a typo in it.
+        </p>
+
+        <div class="flex gap-3 flex-wrap mb-10 max-sm:grid max-sm:grid-cols-2">
+          <a
+            href={~p"/"}
+            class="inline-flex items-center justify-center px-7 py-3 bg-(--crit-brand-cta) text-(--crit-fg-on-brand) rounded-lg text-sm font-bold no-underline hover:bg-(--crit-brand-cta-hover) transition-all"
+          >
+            Back to home
+          </a>
+          <a
+            href={~p"/getting-started"}
+            class="inline-flex items-center justify-center px-7 py-3 border border-(--crit-border) text-(--crit-fg-secondary) rounded-lg text-sm font-semibold no-underline hover:border-(--crit-fg-muted) hover:text-(--crit-fg-primary) transition-all"
+          >
+            Get started
+          </a>
+        </div>
+
+        <nav aria-label="Quick links" class="border-t border-(--crit-border) pt-6">
+          <div class="text-xs font-semibold uppercase tracking-widest text-(--crit-fg-muted) mb-2.5">
+            Or try one of these
+          </div>
+          <a
+            :for={
+              {href, label, meta} <- [
+                {~p"/features", "Features", "What crit does"},
+                {~p"/integrations", "Integrations", "Editors & AI tools"},
+                {~p"/changelog", "Changelog", "What's new"}
+              ]
+            }
+            href={href}
+            class="group/ql flex items-center justify-between py-3 border-b border-(--crit-border) text-(--crit-fg-primary) text-base no-underline transition-[padding] duration-200 hover:pl-1.5"
+          >
+            <span>{label}</span>
+            <span class="flex items-center gap-3">
+              <span class="text-sm text-(--crit-fg-muted)">{meta}</span>
+              <span
+                aria-hidden="true"
+                class="text-(--crit-fg-muted) transition-transform duration-200 group-hover/ql:translate-x-1 group-hover/ql:text-(--crit-brand)"
+              >
+                &rarr;
+              </span>
+            </span>
+          </a>
+          <a
+            href="https://github.com/tomasz-tomczyk/crit"
+            class="group/ql flex items-center justify-between py-3 border-b border-(--crit-border) text-(--crit-fg-primary) text-base no-underline transition-[padding] duration-200 hover:pl-1.5"
+          >
+            <span class="flex items-center gap-2">
+              <svg viewBox="0 0 16 16" class="size-4 fill-current" aria-hidden="true">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+              </svg>
+              <span>GitHub</span>
+            </span>
+            <span class="flex items-center gap-3">
+              <span class="text-sm text-(--crit-fg-muted)">Source code</span>
+              <span
+                aria-hidden="true"
+                class="text-(--crit-fg-muted) transition-transform duration-200 group-hover/ql:translate-x-1 group-hover/ql:text-(--crit-brand)"
+              >
+                &rarr;
+              </span>
+            </span>
+          </a>
+        </nav>
+      </div>
+
+      <div class="relative w-full max-w-[380px] aspect-square ml-auto max-md:mx-auto select-none crit-404-stage">
+        <svg
+          viewBox="0 0 400 400"
+          role="img"
+          aria-hidden="true"
+          preserveAspectRatio="xMidYMid meet"
+          class="w-full h-full block"
+        >
+          <%!-- faint echo, parallel-ish trajectory --%>
+          <path
+            d="M 108 280 C 200 232, 300 152, 440 76"
+            fill="none"
+            stroke="var(--crit-border-strong)"
+            stroke-width="1"
+            stroke-linecap="butt"
+            opacity="0.45"
+          />
+
+          <%!-- main hairline; draws on load via stroke-dashoffset animation --%>
+          <path
+            class="crit-404-line"
+            d="M 108 244 C 200 196, 300 116, 440 40"
+            fill="none"
+            stroke="var(--crit-fg-secondary)"
+            stroke-width="1.2"
+            stroke-linecap="butt"
+          />
+
+          <%!-- endpoint dot --%>
+          <circle class="crit-404-endpoint" cx="108" cy="244" r="5" fill="var(--crit-brand)" />
+
+          <%!-- monospace labels --%>
+          <text
+            class="crit-404-label"
+            x="120"
+            y="278"
+            font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="32"
+            font-weight="500"
+            letter-spacing="-0.01em"
+            fill="var(--crit-fg-primary)"
+          >
+            404
+          </text>
+          <text
+            class="crit-404-label"
+            x="121"
+            y="298"
+            font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+            font-size="14"
+            letter-spacing="0.06em"
+            fill="var(--crit-fg-muted)"
+          >
+            NOT FOUND
+          </text>
+        </svg>
+      </div>
+    </div>
+  </main>
+</div>
+
+<style>
+  .crit-404-line {
+    stroke-dasharray: 600;
+    stroke-dashoffset: 600;
+    animation: crit-404-draw 1.2s ease forwards;
+  }
+  .crit-404-endpoint {
+    opacity: 0;
+    animation: crit-404-pop 0.4s ease 1.0s forwards;
+  }
+  .crit-404-label {
+    opacity: 0;
+    animation: crit-404-fade 0.4s ease 1.1s forwards;
+  }
+  @keyframes crit-404-draw { to { stroke-dashoffset: 0; } }
+  @keyframes crit-404-pop  { to { opacity: 1; } }
+  @keyframes crit-404-fade { to { opacity: 1; } }
+  @media (prefers-reduced-motion: reduce) {
+    .crit-404-line { animation: none; stroke-dashoffset: 0; }
+    .crit-404-endpoint, .crit-404-label { animation: none; opacity: 1; }
+  }
+</style>

--- a/lib/crit_web/exceptions.ex
+++ b/lib/crit_web/exceptions.ex
@@ -1,0 +1,8 @@
+defmodule CritWeb.NotFoundError do
+  @moduledoc """
+  Raised to render the 404 page. Phoenix's `render_errors` config
+  (see `config/config.exs`) catches exceptions whose `plug_status`
+  is 404 and renders `CritWeb.ErrorHTML` with template `"404"`.
+  """
+  defexception message: "not found", plug_status: 404
+end

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -21,10 +21,7 @@ defmodule CritWeb.ReviewLive do
   defp mount_review(token, socket, %Scope{} = scope, auth_required) do
     case Reviews.get_by_token(token) do
       nil ->
-        {:ok,
-         socket
-         |> put_flash(:error, "Review not found.")
-         |> redirect(to: ~p"/"), layout: {CritWeb.Layouts, :review}}
+        raise CritWeb.NotFoundError
 
       review ->
         demo? = review.token == Application.get_env(:crit, :demo_review_token)

--- a/test/crit_web/controllers/error_html_test.exs
+++ b/test/crit_web/controllers/error_html_test.exs
@@ -4,8 +4,13 @@ defmodule CritWeb.ErrorHTMLTest do
   # Bring render_to_string/4 for testing custom views
   import Phoenix.Template, only: [render_to_string: 4]
 
-  test "renders 404.html" do
-    assert render_to_string(CritWeb.ErrorHTML, "404", "html", []) == "Not Found"
+  test "renders 404.html with headline and recovery links" do
+    html = render_to_string(CritWeb.ErrorHTML, "404", "html", current_scope: nil, flash: %{})
+
+    assert html =~ "This page was"
+    assert html =~ "not found"
+    assert html =~ "Back to home"
+    assert html =~ "Get started"
   end
 
   test "renders 500.html" do

--- a/test/crit_web/controllers/page_controller_test.exs
+++ b/test/crit_web/controllers/page_controller_test.exs
@@ -68,7 +68,9 @@ defmodule CritWeb.PageControllerTest do
 
     test "returns 404 for an unknown tool", %{conn: conn} do
       conn = get(conn, ~p"/integrations/does-not-exist")
-      assert response(conn, 404) =~ "Not Found"
+      body = response(conn, 404)
+      assert body =~ "This page was"
+      assert body =~ "not found"
     end
   end
 end

--- a/test/crit_web/live/review_live_test.exs
+++ b/test/crit_web/live/review_live_test.exs
@@ -24,8 +24,8 @@ defmodule CritWeb.ReviewLiveTest do
       assert html =~ hd(review.files).file_path
     end
 
-    test "redirects to home for invalid token", %{conn: conn} do
-      assert {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/r/nonexistent-token")
+    test "renders 404 for invalid token", %{conn: conn} do
+      assert_error_sent 404, fn -> live(conn, ~p"/r/nonexistent-token") end
     end
 
     test "sets page title to first file path", %{conn: conn, review: review} do


### PR DESCRIPTION
## Summary
- Replaces Phoenix's plaintext "Not Found" with a styled 404 page that matches the marketing site (site header, brand-blue accent, line-graphic illustration).
- `render_errors` now uses the root layout so the 404 inherits head + footer chrome.
- New `CritWeb.NotFoundError` (`plug_status: 404`) lets LiveView raise a clean 404; `ReviewLive` uses it for unknown tokens instead of redirecting to `/` with a flash.

## Test plan
- [x] `mix precommit` (516 tests, 0 failures)
- [x] Manually verified `/features/anything` and `/integrations/anything` render the new template in dev
- [ ] Verify `/r/<bad-token>` renders the 404 in prod (dev shows the debugger first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)