### PR TITLE
docs: update contact emails to crit.md domain

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting vulnerabilities
 
-If you discover a security vulnerability, please email security@crit.live instead of opening a public issue.
+If you discover a security vulnerability, please email security@crit.md instead of opening a public issue.
 
 ## Design decisions
 

--- a/lib/crit_web/controllers/page_html/privacy.html.heex
+++ b/lib/crit_web/controllers/page_html/privacy.html.heex
@@ -57,9 +57,9 @@
         This information is used solely to identify you across sessions and to display your name
         on reviews and comments you create. We do not share it with third parties.
         You can delete your account by emailing <a
-          href="mailto:tom@crit.live"
+          href="mailto:tomasz@crit.md"
           class="crit-link"
-        >tom@crit.live</a>.
+        >tomasz@crit.md</a>.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Anonymous session</h2>
@@ -137,9 +137,9 @@
           href="https://github.com/tomasz-tomczyk/crit"
           class="crit-link"
         >GitHub</a>. For sensitive requests (such as data deletion), email <a
-          href="mailto:tom@crit.live"
+          href="mailto:tomasz@crit.md"
           class="crit-link"
-        >tom@crit.live</a>.
+        >tomasz@crit.md</a>.
       </p>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- security@crit.live → security@crit.md (SECURITY.md)
- tom@crit.live → tomasz@crit.md (privacy page)

Legacy `crit.live` host redirects in `canonical_host.ex` are intentionally preserved.

## Test plan
- [x] No remaining `@crit.live` email references
- See also: tomasz-tomczyk/crit#420

🤖 Generated with [Claude Code](https://claude.com/claude-code)