### PR TITLE
style: bump comment input font-size to 14px

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1642,7 +1642,7 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   border-radius: 4px;
   padding: 6px 8px;
   font-family: var(--crit-font-body);
-  font-size: 13px;
+  font-size: 14px;
   resize: vertical;
   box-sizing: border-box;
 }
@@ -1662,7 +1662,7 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   background: var(--crit-editor-bg-elevated);
   color: var(--crit-editor-fg);
   font-family: var(--crit-font-body);
-  font-size: 13px;
+  font-size: 14px;
   box-sizing: border-box;
   cursor: text;
 }
@@ -1693,7 +1693,7 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   background: var(--crit-editor-comment-bg);
   color: var(--crit-editor-fg);
   font-family: var(--crit-font-body);
-  font-size: 13px;
+  font-size: 14px;
   resize: vertical;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- Bumps `.comment-textarea`, `.reply-input`, and expanded `.reply-textarea` from 13px → 14px
- Aligns these with `.comment-body`, `.comment-form textarea`, and `.reply-body`, which were already 14px
- Pure visual; no logic changes

## Test plan
- [ ] Comment edit textarea renders at 14px
- [ ] Reply input (collapsed) renders at 14px
- [ ] Reply textarea (expanded) renders at 14px
- [ ] Cross-repo parity: matched 1:1 with crit/

See also: tomasz-tomczyk/crit#441

🤖 Generated with [Claude Code](https://claude.com/claude-code)