### PR TITLE
fix: render TOC after content arrives in init handler

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3123,7 +3123,8 @@ function buildToc(tocEl, toggleBtn, items) {
   const listEl = tocEl.querySelector(".crit-toc-list")
   listEl.innerHTML = ""
 
-  if (items.length === 0) {
+  // A single-heading TOC has nothing to navigate to — hide it.
+  if (items.length < 2) {
     toggleBtn.style.display = "none"
     tocEl.classList.add("crit-toc-hidden")
     return
@@ -4410,18 +4411,26 @@ export const DocumentRenderer = {
     ctx.md = md
     ctx.lineBlocks = buildLineBlocks(md, rawContent)
 
-    // Build table of contents
+    // Build table of contents. Content arrives via the "init" event, so on
+    // mount the list is empty; rebuildToc() is called again from init to
+    // populate items, run auto-open, and feed scroll spy.
     const tocEl = document.getElementById("crit-toc")
     const tocToggleBtn = document.getElementById("crit-toc-toggle")
-    const tocItems = extractTocItems(md, rawContent)
-    if (tocEl && tocToggleBtn) {
-      buildToc(tocEl, tocToggleBtn, tocItems)
-      if (tocItems.length > 0) {
+    ctx.tocItems = []
+    ctx.rebuildToc = (rawContentForToc) => {
+      if (!tocEl || !tocToggleBtn) return
+      const items = extractTocItems(md, rawContentForToc)
+      ctx.tocItems = items
+      buildToc(tocEl, tocToggleBtn, items)
+      if (items.length >= 2) {
         const saved = localStorage.getItem("crit-toc")
         if (saved === "open" || (saved === null && window.innerWidth > 1200)) {
           tocEl.classList.remove("crit-toc-hidden")
         }
       }
+    }
+    ctx.rebuildToc(rawContent)
+    if (tocEl && tocToggleBtn) {
       tocToggleBtn.addEventListener("click", () => {
         const isHidden = tocEl.classList.contains("crit-toc-hidden")
         tocEl.classList.toggle("crit-toc-hidden", !isHidden)
@@ -4439,7 +4448,7 @@ export const DocumentRenderer = {
       if (scrollSpyFrame) return
       scrollSpyFrame = requestAnimationFrame(() => {
         scrollSpyFrame = null
-        updateTocActive(tocItems)
+        updateTocActive(ctx.tocItems)
       })
     }
     window.addEventListener("scroll", ctx._scrollHandler, { passive: true })
@@ -4580,12 +4589,10 @@ export const DocumentRenderer = {
         ctx.lineBlocks = isCodeFile(f.path)
           ? buildCodeLineBlocks(f.content, f.path)
           : buildLineBlocks(md, f.content)
-        // Rebuild TOC with actual content (mount ran before content arrived)
-        const tocEl = document.getElementById("crit-toc")
-        const tocToggleBtn = document.getElementById("crit-toc-toggle")
-        if (tocEl && tocToggleBtn) {
-          buildToc(tocEl, tocToggleBtn, extractTocItems(md, f.content))
-        }
+        // Rebuild TOC with actual content (mount ran before content arrived).
+        // ctx.rebuildToc updates the items used by scroll spy and re-runs
+        // the auto-open heuristic now that we know there are headings.
+        ctx.rebuildToc(f.content)
       }
 
       render(ctx)

--- a/e2e/toc.spec.ts
+++ b/e2e/toc.spec.ts
@@ -33,6 +33,57 @@ test.describe("Table of Contents", () => {
 
     await expect(toggle).toBeVisible();
     await expect(panel.locator(".crit-toc-list a")).toHaveCount(2);
+    // On a wide viewport with no saved preference, the panel auto-opens.
+    await expect(panel).not.toHaveClass(/crit-toc-hidden/);
+  });
+
+  test("scroll spy highlights active heading after content arrives", async ({
+    page,
+    request,
+  }) => {
+    // Long doc so that scrolling moves a later heading above the threshold.
+    const blocks = Array.from({ length: 6 }, (_, i) => {
+      const filler = Array.from({ length: 40 }, () => "filler line").join("\n");
+      return `## Heading ${i + 1}\n\n${filler}`;
+    }).join("\n\n");
+    const review = await createReview(request, {
+      files: [{ path: "long.md", content: `# Top\n\n${blocks}\n` }],
+    });
+    token = review.token;
+    deleteToken = review.deleteToken;
+
+    await page.setViewportSize({ width: 1400, height: 900 });
+    await loadReview(page, token);
+
+    const panel = page.locator("#crit-toc");
+    // Wait until headings are populated (init handler ran).
+    await expect(panel.locator(".crit-toc-list a")).toHaveCount(7);
+
+    // Scroll well past the first heading.
+    await page.evaluate(() => window.scrollBy(0, 2000));
+    await expect(panel.locator(".crit-toc-list a.crit-toc-active")).toHaveCount(1);
+  });
+
+  test("toggle button is hidden when document has only one heading", async ({
+    page,
+    request,
+  }) => {
+    const review = await createReview(request, {
+      files: [
+        {
+          path: "one-heading.md",
+          content: "# Only heading\n\nSome body text, no other headings.\n",
+        },
+      ],
+    });
+    token = review.token;
+    deleteToken = review.deleteToken;
+
+    await page.setViewportSize({ width: 1400, height: 900 });
+    await loadReview(page, token);
+
+    await expect(page.locator("#crit-toc-toggle")).toBeHidden();
+    await expect(page.locator("#crit-toc")).toHaveClass(/crit-toc-hidden/);
   });
 
   test("toggle button and panel are hidden when document has no headings", async ({


### PR DESCRIPTION
## Summary

The renderer's mount node has no `data-content` attribute, so `mounted()` ran with an empty `rawContent`. `extractTocItems` returned `[]`, `buildToc` hid the panel, the wide-viewport auto-open block was skipped, and the scroll-spy closure captured an empty list. The `init` handler later rebuilt the visible list but never re-ran auto-open or refreshed scroll-spy items.

Reported on https://crit.md/r/BOldGf1BCDSYla_hpRfbv — wide screen, single 46KB markdown file with 8+ headings, TOC stayed collapsed.

- Expose `ctx.rebuildToc` + `ctx.tocItems` so `init` can repopulate items, re-run the auto-open heuristic, and feed the scroll-spy.
- Hide toggle when fewer than two headings — a one-entry TOC has nothing to navigate.

## Test plan

- 5 Playwright tests in `e2e/toc.spec.ts` (auto-open on wide viewport, scroll-spy active highlight, single-heading hide, no-headings hide, localStorage override)
- `mix precommit`: 555 tests, 0 failures

See also: tomasz-tomczyk/crit#443 (parity change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)