### PR TITLE
style: align textarea line-height with rendered comment bodies

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1782,6 +1782,7 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   padding: 6px 8px;
   font-family: var(--crit-font-body);
   font-size: 14px;
+  line-height: 1.6;
   resize: vertical;
   box-sizing: border-box;
 }
@@ -1802,6 +1803,7 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   color: var(--crit-editor-fg);
   font-family: var(--crit-font-body);
   font-size: 14px;
+  line-height: 1.6;
   box-sizing: border-box;
   cursor: text;
 }
@@ -1833,6 +1835,7 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   color: var(--crit-editor-fg);
   font-family: var(--crit-font-body);
   font-size: 14px;
+  line-height: 1.6;
   resize: vertical;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- Reply, comment, and reply-input textareas had no `line-height`, falling back to browser default (`normal`, ~1.15)
- Rendered `.comment-body` and `.reply-body` use 1.6, so wrapped form text looked visibly tighter than the comments above
- Set `line-height: 1.6` on `.comment-textarea`, `.reply-input`, and `.reply-form.expanded .reply-textarea`

## Review
- [x] Parity audit: matches font-size: 14px / line-height: 1.6 already used on rendered bodies and the new-comment textarea

## Test plan
- [ ] Reply form: type wrapped text, verify spacing matches comment above
- [ ] Edit comment: same check
- [ ] Cross-check with crit/ PR — see also: tomasz-tomczyk/crit#444

🤖 Generated with [Claude Code](https://claude.com/claude-code)