### PR TITLE
feat: comment policy controls (open / logged-in only / disabled)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1243,6 +1243,50 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 }
 .crit-vis-badge > [class*="hero-"] { width: 12px; height: 12px; flex-shrink: 0; opacity: 0.7; }
 
+/* ── Comment policy control ──────────────────────────────────────────── */
+/* Same shape as visibility, deliberately duplicated CSS (per spec).      */
+
+.crit-comment-policy-option {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  padding: 10px 14px;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  font-family: inherit;
+  cursor: pointer;
+  border-radius: 0;
+  transition: background-color 0.12s;
+}
+.crit-comment-policy-option:hover { background: var(--crit-brand-subtle); }
+.crit-comment-policy-option:focus-visible { outline: 2px solid var(--crit-brand); outline-offset: -2px; }
+.crit-comment-policy-option[aria-current="true"] { background: var(--crit-brand-subtle); }
+.crit-comment-policy-option-icon {
+  flex-shrink: 0;
+  width: 24px; height: 24px;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 6px;
+  background: var(--crit-bg-card);
+  border: 1px solid var(--crit-border);
+  color: var(--crit-fg-muted);
+}
+.crit-comment-policy-option-icon > [class*="hero-"] { width: 12px; height: 12px; }
+.crit-comment-policy-option-text { display: flex; flex-direction: column; gap: 2px; }
+.crit-comment-policy-option-title { font-size: 13px; font-weight: 500; color: var(--crit-fg-primary); line-height: 1.3; }
+.crit-comment-policy-option-desc  { font-size: 11px; color: var(--crit-fg-muted); line-height: 1.4; }
+
+.crit-comment-policy-badge {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 6px;
+  font-size: 12px;
+  color: var(--crit-fg-muted);
+  cursor: default;
+  white-space: nowrap;
+  user-select: none;
+  border-radius: 4px;
+}
+.crit-comment-policy-badge > [class*="hero-"] { width: 12px; height: 12px; flex-shrink: 0; opacity: 0.7; }
+
 .crit-diff-mode-toggle {
   display: inline-flex;
   background: var(--crit-editor-bg-elevated);

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1333,7 +1333,9 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 .crit-no-comments .comment-form-wrapper,
 .crit-no-comments .comment-form,
 .crit-no-comments .reply-form,
-.crit-no-comments .file-comment-form {
+.crit-no-comments .file-comment-form,
+.crit-no-comments .file-comment-btn,
+.crit-no-comments .review-conversation-add-more {
   display: none !important;
 }
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1287,6 +1287,44 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 }
 .crit-comment-policy-badge > [class*="hero-"] { width: 12px; height: 12px; flex-shrink: 0; opacity: 0.7; }
 
+/* ── Sign-in banner (logged_in_only + anonymous viewers) ─────────────── */
+
+.crit-signin-banner {
+  position: sticky;
+  top: var(--crit-header-height, 0px);
+  z-index: 99;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 24px;
+  background: var(--crit-bg-card);
+  border-bottom: 1px solid var(--crit-border);
+}
+.crit-signin-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px 3px 7px;
+  background: var(--crit-brand-bg);
+  border: 1px solid var(--crit-border);
+  border-radius: 100px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--crit-brand);
+  flex-shrink: 0;
+}
+.crit-signin-banner-text {
+  font-size: 13px;
+  color: var(--crit-fg-primary);
+}
+.crit-signin-banner-link {
+  margin-left: auto;
+  font-size: 0.875rem;
+  color: var(--crit-brand);
+  text-decoration: underline;
+}
+
 .crit-diff-mode-toggle {
   display: inline-flex;
   background: var(--crit-editor-bg-elevated);

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1107,8 +1107,11 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 
 .crit-vis { position: relative; display: inline-flex; align-items: center; }
 
-/* Trigger (Owner + Unlisted): muted, lights up on hover/open */
-.crit-vis-trigger {
+/* Generic popover-menu shell — used by visibility, comment_policy, etc. */
+.crit-popover-menu { position: relative; display: inline-flex; align-items: center; }
+
+/* Trigger (ghost button, lights up on hover/open) */
+.crit-popover-menu-trigger {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -1124,19 +1127,19 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   white-space: nowrap;
   transition: background-color 0.12s, color 0.12s;
 }
-.crit-vis-trigger:hover,
-.crit-vis-trigger[aria-expanded="true"] {
+.crit-popover-menu-trigger:hover,
+.crit-popover-menu-trigger[aria-expanded="true"] {
   background: var(--crit-editor-bg-elevated);
   color: var(--crit-fg-primary);
 }
-.crit-vis-trigger > [class*="hero-"] {
+.crit-popover-menu-trigger > [class*="hero-"] {
   width: 12px; height: 12px; opacity: 0.7;
 }
-.crit-vis-trigger:hover > [class*="hero-"],
-.crit-vis-trigger[aria-expanded="true"] > [class*="hero-"] { opacity: 1; }
+.crit-popover-menu-trigger:hover > [class*="hero-"],
+.crit-popover-menu-trigger[aria-expanded="true"] > [class*="hero-"] { opacity: 1; }
 
-/* Popover */
-.crit-vis-popover {
+/* Panel — closed by default; open via data-open="true" */
+.crit-popover-menu-panel {
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
@@ -1147,11 +1150,12 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   border-radius: 8px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28), 0 2px 6px rgba(0, 0, 0, 0.16);
   overflow: hidden;
+  display: none;
 }
-[data-theme="light"] .crit-vis-popover {
+.crit-popover-menu-panel[data-open="true"] { display: block; }
+[data-theme="light"] .crit-popover-menu-panel {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.10), 0 2px 6px rgba(0, 0, 0, 0.06);
 }
-.crit-vis-popover[hidden] { display: none; }
 
 /* Current state row — informational */
 .crit-vis-current {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1327,11 +1327,13 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 
 /* Hide all comment-creation affordances when policy disallows new comments. */
 /* Existing comments + their resolve/edit/delete controls render unchanged.  */
-html.crit-no-comments .line-add,
-html.crit-no-comments .comment-form-wrapper,
-html.crit-no-comments .comment-form,
-html.crit-no-comments .reply-form,
-html.crit-no-comments .file-comment-form {
+/* Class is server-rendered on .crit-page (review_live.html.heex) so it's    */
+/* always in sync with @can_comment? — no reliance on JS push_event delivery.*/
+.crit-no-comments .line-add,
+.crit-no-comments .comment-form-wrapper,
+.crit-no-comments .comment-form,
+.crit-no-comments .reply-form,
+.crit-no-comments .file-comment-form {
   display: none !important;
 }
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1325,6 +1325,16 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   text-decoration: underline;
 }
 
+/* Hide all comment-creation affordances when policy disallows new comments. */
+/* Existing comments + their resolve/edit/delete controls render unchanged.  */
+html.crit-no-comments .line-add,
+html.crit-no-comments .comment-form-wrapper,
+html.crit-no-comments .comment-form,
+html.crit-no-comments .reply-form,
+html.crit-no-comments .file-comment-form {
+  display: none !important;
+}
+
 .crit-diff-mode-toggle {
   display: inline-flex;
   background: var(--crit-editor-bg-elevated);

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1590,11 +1590,13 @@ function renderRoundDiffBlock(ctx, block, diffClass, file, commentable, blockInd
     commentGutter.dataset.startLine = block.startLine
     commentGutter.dataset.endLine = block.endLine
     commentGutter.dataset.filePath = file.path
-    const lineAdd = document.createElement('span')
-    lineAdd.className = 'line-add'
-    lineAdd.textContent = '+'
-    commentGutter.appendChild(lineAdd)
-    commentGutter.addEventListener('mousedown', (e) => handleGutterMouseDown(e, ctx))
+    if (ctx.canComment !== false) {
+      const lineAdd = document.createElement('span')
+      lineAdd.className = 'line-add'
+      lineAdd.textContent = '+'
+      commentGutter.appendChild(lineAdd)
+      commentGutter.addEventListener('mousedown', (e) => handleGutterMouseDown(e, ctx))
+    }
     lineBlockEl.appendChild(commentGutter)
   } else {
     const roGutter = document.createElement('div')
@@ -2160,14 +2162,18 @@ function renderBlock(ctx, block, index, commentsMap, commentedLineSet, filePath)
 
   const commentGutter = document.createElement("div")
   commentGutter.className = "line-comment-gutter"
-  const lineAdd = document.createElement("span")
-  lineAdd.className = "line-add"
-  lineAdd.textContent = "+"
-  commentGutter.appendChild(lineAdd)
+  if (ctx.canComment !== false) {
+    const lineAdd = document.createElement("span")
+    lineAdd.className = "line-add"
+    lineAdd.textContent = "+"
+    commentGutter.appendChild(lineAdd)
+  }
 
   gutter.appendChild(lineNum)
   gutter.appendChild(commentGutter)
-  gutter.addEventListener("mousedown", (e) => handleGutterMouseDown(e, ctx))
+  if (ctx.canComment !== false) {
+    gutter.addEventListener("mousedown", (e) => handleGutterMouseDown(e, ctx))
+  }
 
   // Content
   const content = document.createElement("div")
@@ -4563,8 +4569,18 @@ export const DocumentRenderer = {
     }
 
     ctx.handleEvent("policy_changed", ({ can_comment }) => {
-      ctx.canComment = can_comment !== false
+      const next = can_comment !== false
+      const changed = ctx.canComment !== next
+      ctx.canComment = next
       refreshCommentAffordances()
+      // Re-render so gutter "+" affordances and any open new-comment forms are
+      // rebuilt under the new policy. CSS alone (html.crit-no-comments) can't
+      // cover the case where the user is actively hovering a gutter or has a
+      // composer open — only a fresh render guarantees the DOM matches state.
+      if (changed && ctx.md) {
+        ctx.activeForms = ctx.activeForms.filter((f) => f.editingId)
+        render(ctx)
+      }
     })
 
     ctx.handleEvent("init", ({ comments, display_name, files, can_comment }) => {

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3855,6 +3855,16 @@ function renderReviewConversation(ctx) {
   const reviewForm = ctx.activeForms.find(f => f.scope === 'review')
   const reviewComments = ctx.comments.filter(c => c.scope === 'review')
 
+  // When commenting is disallowed AND there are no existing review-level
+  // comments, the section has nothing to read and no affordance to offer —
+  // hide it entirely instead of rendering an empty header. If a comment
+  // exists, keep the section visible (users can still read/resolve threads;
+  // the "Add comment" button stays gated by canComment below).
+  if (ctx.canComment === false && reviewComments.length === 0 && !reviewForm) {
+    section.hidden = true
+    return
+  }
+
   const collapsed = isReviewConversationCollapsed() && !reviewForm
   section.classList.toggle('collapsed', collapsed)
 

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -4558,9 +4558,20 @@ export const DocumentRenderer = {
     // Show loading until server sends init
     ctx.el.innerHTML = '<div class="crit-loading">Loading comments…</div>'
 
-    ctx.handleEvent("init", ({ comments, display_name, files }) => {
+    function refreshCommentAffordances() {
+      document.documentElement.classList.toggle("crit-no-comments", ctx.canComment === false)
+    }
+
+    ctx.handleEvent("policy_changed", ({ can_comment }) => {
+      ctx.canComment = can_comment !== false
+      refreshCommentAffordances()
+    })
+
+    ctx.handleEvent("init", ({ comments, display_name, files, can_comment }) => {
       ctx.displayName = display_name || null
       ctx.comments = comments
+      ctx.canComment = can_comment !== false
+      refreshCommentAffordances()
 
       if (files && files.length > 1) {
         ctx.multiFile = true

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1812,8 +1812,10 @@ function renderFileSection(ctx, file) {
     '<span class="file-header-name"><span class="dir">' + escapeHtml(dirPath) + '</span>' + escapeHtml(fileName) + '</span>' +
     (file.orphaned ? '<span class="file-header-badge removed">Removed</span>' : '')
 
-  // File comment button — not for orphaned files (no point adding comments to removed files)
-  if (!file.orphaned) {
+  // File comment button — not for orphaned files (no point adding comments to removed files).
+  // Also gated on canComment: when policy disallows new comments, don't create the
+  // affordance or its click handler.
+  if (!file.orphaned && ctx.canComment !== false) {
     const fileCommentBtn = document.createElement('button')
     fileCommentBtn.className = 'file-comment-btn'
     fileCommentBtn.title = 'Add file comment'
@@ -2531,8 +2533,11 @@ function createCommentElement(comment, ctx) {
     card.appendChild(renderReplyList(comment, ctx))
   }
 
-  // Inline reply input (GitHub-style: compact, expands on focus)
-  card.appendChild(createReplyInput(comment.id, ctx))
+  // Inline reply input (GitHub-style: compact, expands on focus).
+  // A reply is a new comment, so respect comment policy.
+  if (ctx.canComment !== false) {
+    card.appendChild(createReplyInput(comment.id, ctx))
+  }
 
   wrapper.appendChild(card)
   return wrapper
@@ -3102,8 +3107,10 @@ function createResolvedElement(comment, ctx) {
     card.appendChild(renderReplyList(comment, ctx))
   }
 
-  // Reply input
-  card.appendChild(createReplyInput(comment.id, ctx))
+  // Reply input — gated on comment policy (a reply is a new comment).
+  if (ctx.canComment !== false) {
+    card.appendChild(createReplyInput(comment.id, ctx))
+  }
 
   wrapper.appendChild(card)
   return wrapper
@@ -3904,9 +3911,13 @@ function renderReviewConversation(ctx) {
   }
 
   // Footer: compose form (when active) or ghost "Add comment" button.
+  // Gate on canComment so the affordance physically isn't created when the
+  // policy disallows new comments — the click handler triggers a re-render
+  // that visibly removes the button (jankiness). CSS .crit-no-comments
+  // hiding is defense in depth; skipping creation is the source of truth.
   if (reviewForm && !reviewForm.editingId) {
     body.appendChild(renderCommentFormUI(ctx, reviewForm))
-  } else {
+  } else if (ctx.canComment !== false) {
     const addMore = document.createElement('button')
     addMore.className = 'review-conversation-add-more'
     if (reviewComments.length === 0) addMore.classList.add('review-conversation-empty')
@@ -3944,10 +3955,13 @@ function createReviewConversationCard(ctx, comment) {
   }
   // Render existing replies + a reply input — review-level threads support replies
   // exactly like line-anchored ones (parity with crit local).
+  // Reply input gated on comment policy (a reply is a new comment).
   if (comment.replies && comment.replies.length > 0) {
     card.appendChild(renderReplyList(comment, ctx))
   }
-  card.appendChild(createReplyInput(comment.id, ctx))
+  if (ctx.canComment !== false) {
+    card.appendChild(createReplyInput(comment.id, ctx))
+  }
   return wrapper
 }
 

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -4564,19 +4564,16 @@ export const DocumentRenderer = {
     // Show loading until server sends init
     ctx.el.innerHTML = '<div class="crit-loading">Loading comments…</div>'
 
-    function refreshCommentAffordances() {
-      document.documentElement.classList.toggle("crit-no-comments", ctx.canComment === false)
-    }
-
+    // Comment-affordance class (`.crit-no-comments`) is server-rendered on
+    // the `.crit-page` wrapper (see review_live.html.heex), so the visual
+    // suppression is always in sync with @can_comment? — no JS toggle, no
+    // reliance on push_event delivery. The hook still receives policy_changed
+    // so it can drop any open new-comment composers and re-render the document
+    // (closing forms that CSS alone can't unwind for an actively-typing user).
     ctx.handleEvent("policy_changed", ({ can_comment }) => {
       const next = can_comment !== false
       const changed = ctx.canComment !== next
       ctx.canComment = next
-      refreshCommentAffordances()
-      // Re-render so gutter "+" affordances and any open new-comment forms are
-      // rebuilt under the new policy. CSS alone (html.crit-no-comments) can't
-      // cover the case where the user is actively hovering a gutter or has a
-      // composer open — only a fresh render guarantees the DOM matches state.
       if (changed && ctx.md) {
         ctx.activeForms = ctx.activeForms.filter((f) => f.editingId)
         render(ctx)
@@ -4587,7 +4584,6 @@ export const DocumentRenderer = {
       ctx.displayName = display_name || null
       ctx.comments = comments
       ctx.canComment = can_comment !== false
-      refreshCommentAffordances()
 
       if (files && files.length > 1) {
         ctx.multiFile = true

--- a/e2e/comment-policy.spec.ts
+++ b/e2e/comment-policy.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test";
+import { createReview, deleteReview, loadReview } from "./helpers";
+
+const BASE_URL = `http://localhost:${process.env.CRIT_WEB_TEST_PORT || "4003"}`;
+
+/**
+ * Set comment_policy via the API. We can't fully simulate owner-driven UI
+ * toggling without a logged-in browser session (no E2E auth helper exists),
+ * so we drive the policy change through the seeded admin path instead and
+ * verify the viewer-side effects in the browser.
+ *
+ * Anonymous PUT silently ignores comment_policy, so we use the dev-only
+ * seed pattern: create the review with an authenticated bearer token, then
+ * PUT with that bearer to set the policy.
+ */
+async function seedUserAndToken(request) {
+  const res = await request.post(`${BASE_URL}/api/seed-user`, {
+    data: { name: "CP Owner" },
+  });
+  expect(res.status()).toBe(200);
+  return res.json();
+}
+
+async function setCommentPolicyAsOwner(
+  request,
+  token: string,
+  deleteToken: string,
+  bearer: string,
+  policy: "open" | "logged_in_only" | "disallowed"
+) {
+  const res = await request.put(`${BASE_URL}/api/reviews/${token}`, {
+    headers: { Authorization: `Bearer ${bearer}` },
+    data: {
+      delete_token: deleteToken,
+      files: [{ path: "a.md", content: "# hi\n" }],
+      comments: [],
+      review_round: 1,
+      comment_policy: policy,
+    },
+  });
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  expect(body.comment_policy).toBe(policy);
+}
+
+test.describe("comment policy", () => {
+  test("logged_in_only — anon viewer sees the sign-in banner and no add-comment button", async ({
+    browser,
+    request,
+  }) => {
+    const { token: bearer } = await seedUserAndToken(request);
+
+    // Create review as the authenticated owner so the bearer scope owns it.
+    const createRes = await request.post(`${BASE_URL}/api/reviews`, {
+      headers: { Authorization: `Bearer ${bearer}` },
+      data: {
+        files: [{ path: "a.md", content: "# hi\n" }],
+        comments: [],
+      },
+    });
+    expect(createRes.status()).toBe(201);
+    const { url, delete_token: deleteToken } = await createRes.json();
+    const token = (url as string).split("/r/")[1];
+
+    await setCommentPolicyAsOwner(request, token, deleteToken, bearer, "logged_in_only");
+
+    // Anonymous browser viewer.
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await loadReview(page, token);
+
+    await expect(page.locator('[data-test="signin-banner"]')).toBeVisible();
+    await expect(page.locator('[data-test="signin-banner"]')).toContainText("Sign-in required");
+
+    // Hidden via crit-no-comments root class.
+    await expect(page.locator("html.crit-no-comments")).toHaveCount(1);
+
+    await deleteReview(request, deleteToken);
+  });
+
+  test("disallowed — header carries the signal, no body banner, comment affordances hidden", async ({
+    browser,
+    request,
+  }) => {
+    const { token: bearer } = await seedUserAndToken(request);
+
+    const createRes = await request.post(`${BASE_URL}/api/reviews`, {
+      headers: { Authorization: `Bearer ${bearer}` },
+      data: { files: [{ path: "a.md", content: "# hi\n" }], comments: [] },
+    });
+    const { url, delete_token: deleteToken } = await createRes.json();
+    const token = (url as string).split("/r/")[1];
+
+    await setCommentPolicyAsOwner(request, token, deleteToken, bearer, "disallowed");
+
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await loadReview(page, token);
+
+    await expect(page.locator('[data-test="signin-banner"]')).toBeHidden();
+    await expect(page.locator('[data-test="comment-policy-badge"]')).toContainText("Disabled");
+    await expect(page.locator("html.crit-no-comments")).toHaveCount(1);
+
+    await deleteReview(request, deleteToken);
+  });
+
+  test("open — no banner, no badge for anon viewer", async ({ request, page }) => {
+    const { token: deleteToken, ...rest } = await createReview(request);
+    await loadReview(page, rest.token);
+
+    await expect(page.locator('[data-test="signin-banner"]')).toBeHidden();
+    await expect(page.locator('[data-test="comment-policy-badge"]')).toHaveCount(0);
+    await expect(page.locator("html.crit-no-comments")).toHaveCount(0);
+
+    await deleteReview(request, rest.deleteToken);
+  });
+});

--- a/e2e/comment-policy.spec.ts
+++ b/e2e/comment-policy.spec.ts
@@ -14,7 +14,7 @@ const BASE_URL = `http://localhost:${process.env.CRIT_WEB_TEST_PORT || "4003"}`;
  * PUT with that bearer to set the policy.
  */
 async function seedUserAndToken(request) {
-  const res = await request.post(`${BASE_URL}/api/seed-user`, {
+  const res = await request.post(`${BASE_URL}/api/test/seed-user`, {
     data: { name: "CP Owner" },
   });
   expect(res.status()).toBe(200);
@@ -105,13 +105,13 @@ test.describe("comment policy", () => {
   });
 
   test("open — no banner, no badge for anon viewer", async ({ request, page }) => {
-    const { token: deleteToken, ...rest } = await createReview(request);
-    await loadReview(page, rest.token);
+    const { token, deleteToken } = await createReview(request);
+    await loadReview(page, token);
 
     await expect(page.locator('[data-test="signin-banner"]')).toBeHidden();
     await expect(page.locator('[data-test="comment-policy-badge"]')).toHaveCount(0);
     await expect(page.locator("html.crit-no-comments")).toHaveCount(0);
 
-    await deleteReview(request, rest.deleteToken);
+    await deleteReview(request, deleteToken);
   });
 });

--- a/e2e/comment-policy.spec.ts
+++ b/e2e/comment-policy.spec.ts
@@ -72,8 +72,8 @@ test.describe("comment policy", () => {
     await expect(page.locator('[data-test="signin-banner"]')).toBeVisible();
     await expect(page.locator('[data-test="signin-banner"]')).toContainText("Sign-in required");
 
-    // Hidden via crit-no-comments root class.
-    await expect(page.locator("html.crit-no-comments")).toHaveCount(1);
+    // Hidden via server-rendered .crit-page.crit-no-comments class.
+    await expect(page.locator(".crit-page.crit-no-comments")).toHaveCount(1);
 
     await deleteReview(request, deleteToken);
   });
@@ -99,7 +99,7 @@ test.describe("comment policy", () => {
 
     await expect(page.locator('[data-test="signin-banner"]')).toBeHidden();
     await expect(page.locator('[data-test="comment-policy-badge"]')).toContainText("Disabled");
-    await expect(page.locator("html.crit-no-comments")).toHaveCount(1);
+    await expect(page.locator(".crit-page.crit-no-comments")).toHaveCount(1);
 
     await deleteReview(request, deleteToken);
   });
@@ -110,7 +110,7 @@ test.describe("comment policy", () => {
 
     await expect(page.locator('[data-test="signin-banner"]')).toBeHidden();
     await expect(page.locator('[data-test="comment-policy-badge"]')).toHaveCount(0);
-    await expect(page.locator("html.crit-no-comments")).toHaveCount(0);
+    await expect(page.locator(".crit-page.crit-no-comments")).toHaveCount(0);
 
     await deleteReview(request, deleteToken);
   });

--- a/lib/crit/output.ex
+++ b/lib/crit/output.ex
@@ -113,6 +113,7 @@ defmodule Crit.Output do
     %{
       review_round: review.review_round,
       visibility: review.visibility,
+      comment_policy: review.comment_policy,
       share_url: base_url <> "/r/#{review.token}",
       delete_token: review.delete_token,
       updated_at: DateTime.to_iso8601(review.updated_at),

--- a/lib/crit/review.ex
+++ b/lib/crit/review.ex
@@ -9,6 +9,10 @@ defmodule Crit.Review do
     field :cli_args, {:array, :string}, default: []
     field :visibility, Ecto.Enum, values: [:unlisted, :public], default: :unlisted
 
+    field :comment_policy, Ecto.Enum,
+      values: [:open, :logged_in_only, :disallowed],
+      default: :open
+
     belongs_to :user, Crit.User, type: :binary_id
 
     has_many :comments, Crit.Comment
@@ -41,8 +45,9 @@ defmodule Crit.Review do
   """
   def update_changeset(review, attrs) do
     review
-    |> cast(attrs, [:review_round, :cli_args])
+    |> cast(attrs, [:review_round, :cli_args, :comment_policy])
     |> validate_cli_args()
+    |> validate_inclusion(:comment_policy, [:open, :logged_in_only, :disallowed])
   end
 
   @doc "Changeset for owner-driven visibility updates."

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -900,34 +900,47 @@ defmodule Crit.Reviews do
   Same attribution rules as `create_comment/4`.
   """
   def create_reply(%Scope{} = scope, comment_id, attrs, review_id) do
+    query =
+      from c in Comment,
+        where: c.id == ^comment_id and c.review_id == ^review_id,
+        join: r in Review,
+        on: r.id == c.review_id,
+        select: {c, r}
+
+    case Repo.one(query) do
+      nil ->
+        {:error, :not_found}
+
+      {%Comment{parent_id: parent}, _r} when parent != nil ->
+        {:error, :not_found}
+
+      {parent, review} ->
+        with :ok <- check_comment_policy(scope, review) do
+          do_create_reply(scope, parent, attrs)
+        end
+    end
+  end
+
+  defp do_create_reply(%Scope{} = scope, %Comment{} = parent, attrs) do
     user_id = Scope.user_id(scope)
     identity = scope.identity
     display_name = scope.display_name
 
-    case Repo.get_by(Comment, id: comment_id, review_id: review_id) do
-      nil ->
-        {:error, :not_found}
+    %Comment{}
+    |> Comment.reply_changeset(attrs)
+    |> Ecto.Changeset.put_change(:parent_id, parent.id)
+    |> Ecto.Changeset.put_change(:review_id, parent.review_id)
+    |> Ecto.Changeset.put_change(:author_identity, if(user_id, do: nil, else: identity))
+    |> Ecto.Changeset.put_change(:user_id, user_id)
+    |> Ecto.Changeset.put_change(:author_display_name, display_name)
+    |> Repo.insert()
+    |> case do
+      {:ok, reply} ->
+        Statistics.increment_comment()
+        {:ok, Repo.preload(reply, :user)}
 
-      %Comment{parent_id: parent} when parent != nil ->
-        {:error, :not_found}
-
-      parent ->
-        %Comment{}
-        |> Comment.reply_changeset(attrs)
-        |> Ecto.Changeset.put_change(:parent_id, comment_id)
-        |> Ecto.Changeset.put_change(:review_id, parent.review_id)
-        |> Ecto.Changeset.put_change(:author_identity, if(user_id, do: nil, else: identity))
-        |> Ecto.Changeset.put_change(:user_id, user_id)
-        |> Ecto.Changeset.put_change(:author_display_name, display_name)
-        |> Repo.insert()
-        |> case do
-          {:ok, reply} ->
-            Statistics.increment_comment()
-            {:ok, Repo.preload(reply, :user)}
-
-          other ->
-            other
-        end
+      other ->
+        other
     end
   end
 

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -74,7 +74,13 @@ defmodule Crit.Reviews do
   Opts:
     * `:file_path` — file path the comment is anchored to
   """
-  def create_comment(%Scope{} = scope, %Review{id: review_id}, attrs, opts \\ []) do
+  def create_comment(%Scope{} = scope, %Review{} = review, attrs, opts \\ []) do
+    with :ok <- check_comment_policy(scope, review) do
+      do_create_comment(scope, review, attrs, opts)
+    end
+  end
+
+  defp do_create_comment(%Scope{} = scope, %Review{id: review_id}, attrs, opts) do
     user_id = Scope.user_id(scope)
     identity = scope.identity
     display_name = scope.display_name
@@ -95,6 +101,14 @@ defmodule Crit.Reviews do
       _ -> :ok
     end)
   end
+
+  defp check_comment_policy(_scope, %Review{comment_policy: :disallowed}),
+    do: {:error, :comments_disallowed}
+
+  defp check_comment_policy(%Scope{user: nil}, %Review{comment_policy: :logged_in_only}),
+    do: {:error, :comments_require_login}
+
+  defp check_comment_policy(_scope, _review), do: :ok
 
   @doc """
   Update a comment's body if the caller's scope owns it.

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -174,6 +174,11 @@ defmodule Crit.Reviews do
   Owner-scoped update of arbitrary whitelisted attrs. The whitelist is the
   `cast` list in `Review.update_changeset/2` — unknown keys are silently dropped.
 
+  Intentionally generic: this is the forward seam for owner-writable review
+  fields. Adding a new writable column means extending `Review.update_changeset/2`'s
+  cast list — no new context function required. Callers (LiveView events, API
+  controllers) pass an attrs map straight through.
+
   Returns `{:ok, review}`, `{:error, :not_found}`, `{:error, :unauthorized}`,
   or `{:error, %Ecto.Changeset{}}`.
   """
@@ -192,13 +197,16 @@ defmodule Crit.Reviews do
 
   # Broadcast cross-tab policy changes only when the value actually changed.
   # Same topic ("review:#{token}") that ReviewLive subscribes to in mount/3.
+  # Uses broadcast_from(self(), ...) so the originating LV (which already
+  # applied the change in handle_event) doesn't run a redundant handle_info.
   defp maybe_broadcast_policy_changed(%Review{comment_policy: old}, %Review{comment_policy: new})
        when old == new,
        do: :ok
 
   defp maybe_broadcast_policy_changed(_old, %Review{} = updated) do
-    Phoenix.PubSub.broadcast(
+    Phoenix.PubSub.broadcast_from(
       Crit.PubSub,
+      self(),
       "review:#{updated.token}",
       {:policy_changed, updated.id, %{comment_policy: updated.comment_policy}}
     )

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -156,6 +156,40 @@ defmodule Crit.Reviews do
   defp ensure_unlisted(%Review{visibility: :unlisted}), do: :ok
   defp ensure_unlisted(%Review{visibility: :public}), do: {:error, :already_public}
 
+  @doc """
+  Owner-scoped update of arbitrary whitelisted attrs. The whitelist is the
+  `cast` list in `Review.update_changeset/2` — unknown keys are silently dropped.
+
+  Returns `{:ok, review}`, `{:error, :not_found}`, `{:error, :unauthorized}`,
+  or `{:error, %Ecto.Changeset{}}`.
+  """
+  def update_review(%Scope{} = scope, review_id, attrs) when is_map(attrs) do
+    with {:ok, review} <- fetch_review_for_owner(scope, review_id),
+         {:ok, updated} <-
+           review
+           |> Review.update_changeset(attrs)
+           |> Repo.update() do
+      maybe_broadcast_policy_changed(review, updated)
+      {:ok, updated}
+    end
+  end
+
+  def update_review(_scope, _id, _attrs), do: {:error, :unauthorized}
+
+  # Broadcast cross-tab policy changes only when the value actually changed.
+  # Same topic ("review:#{token}") that ReviewLive subscribes to in mount/3.
+  defp maybe_broadcast_policy_changed(%Review{comment_policy: old}, %Review{comment_policy: new})
+       when old == new,
+       do: :ok
+
+  defp maybe_broadcast_policy_changed(_old, %Review{} = updated) do
+    Phoenix.PubSub.broadcast(
+      Crit.PubSub,
+      "review:#{updated.token}",
+      {:policy_changed, updated.id, %{comment_policy: updated.comment_policy}}
+    )
+  end
+
   defp fetch_review_for_owner(%Scope{} = scope, review_id) do
     with {:ok, uuid} <- Ecto.UUID.cast(review_id),
          %Review{} = review <- Repo.get(Review, uuid),

--- a/lib/crit_web/components/popover_menu.ex
+++ b/lib/crit_web/components/popover_menu.ex
@@ -13,6 +13,23 @@ defmodule CritWeb.Components.PopoverMenu do
   use Phoenix.Component
   alias Phoenix.LiveView.JS
 
+  @doc """
+  Returns a `JS` chain that closes the popover panel with the given `id`.
+
+  Chain this onto an option button's `phx-click` so selecting an option
+  both fires the server event and dismisses the menu:
+
+      phx-click={
+        PopoverMenu.close_js("comment-policy-menu")
+        |> JS.push("update_comment_policy", value: %{policy: "open"})
+      }
+  """
+  def close_js(id, %JS{} = js \\ %JS{}) when is_binary(id) do
+    js
+    |> JS.set_attribute({"data-open", "false"}, to: "##{id}-panel")
+    |> JS.set_attribute({"aria-expanded", "false"}, to: "##{id}-trigger")
+  end
+
   attr :id, :string, required: true
   attr :open?, :boolean, default: false
   attr :placement, :atom, default: :below, values: [:below]

--- a/lib/crit_web/components/popover_menu.ex
+++ b/lib/crit_web/components/popover_menu.ex
@@ -1,0 +1,62 @@
+defmodule CritWeb.Components.PopoverMenu do
+  @moduledoc """
+  Generic popover-menu shell: ghost trigger button + click-away-dismissible
+  panel, with ARIA wiring (`role="dialog"`, `aria-haspopup`,
+  `aria-controls`, `aria-expanded`) and `data-test` hooks.
+
+  Owns no policy: each call site composes its own trigger label and panel
+  contents (status row, option rows, badge, etc.) inline. See
+  `lib/crit_web/live/review_live.html.heex` for the visibility and
+  comment_policy callers.
+  """
+
+  use Phoenix.Component
+  alias Phoenix.LiveView.JS
+
+  attr :id, :string, required: true
+  attr :open?, :boolean, default: false
+  attr :placement, :atom, default: :below, values: [:below]
+  attr :test_prefix, :string, required: true
+  attr :panel_label, :string, default: "Menu"
+
+  slot :trigger, required: true
+  slot :inner_block, required: true
+
+  def popover_menu(assigns) do
+    ~H"""
+    <div
+      class="crit-popover-menu"
+      data-test={"#{@test_prefix}-menu"}
+      phx-click-away={
+        JS.set_attribute({"data-open", "false"}, to: "##{@id}-panel")
+        |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id}-trigger")
+      }
+    >
+      <button
+        type="button"
+        id={"#{@id}-trigger"}
+        class="crit-popover-menu-trigger"
+        aria-haspopup="dialog"
+        aria-expanded={to_string(@open?)}
+        aria-controls={"#{@id}-panel"}
+        phx-click={
+          JS.toggle_attribute({"data-open", "true", "false"}, to: "##{@id}-panel")
+          |> JS.toggle_attribute({"aria-expanded", "true", "false"}, to: "##{@id}-trigger")
+        }
+      >
+        {render_slot(@trigger)}
+      </button>
+      <div
+        id={"#{@id}-panel"}
+        class="crit-popover-menu-panel"
+        role="dialog"
+        aria-label={@panel_label}
+        data-open={to_string(@open?)}
+        data-test={"#{@test_prefix}-panel"}
+      >
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -29,8 +29,16 @@ defmodule CritWeb.ApiController do
                cli_args: cli_args
              ) do
           {:ok, review} ->
+            review = maybe_update_comment_policy(scope, review, params)
             url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
-            conn |> put_status(201) |> json(%{url: url, delete_token: review.delete_token})
+
+            conn
+            |> put_status(201)
+            |> json(%{
+              url: url,
+              delete_token: review.delete_token,
+              comment_policy: review.comment_policy
+            })
 
           {:error, :total_size_exceeded} ->
             conn |> put_status(422) |> json(%{error: "Total file size exceeds 10 MB limit"})
@@ -70,8 +78,16 @@ defmodule CritWeb.ApiController do
                cli_args: cli_args
              ) do
           {:ok, review} ->
+            review = maybe_update_comment_policy(scope, review, params)
             url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
-            conn |> put_status(201) |> json(%{url: url, delete_token: review.delete_token})
+
+            conn
+            |> put_status(201)
+            |> json(%{
+              url: url,
+              delete_token: review.delete_token,
+              comment_policy: review.comment_policy
+            })
 
           {:error, :total_size_exceeded} ->
             conn |> put_status(422) |> json(%{error: "Total file size exceeds 10 MB limit"})
@@ -98,7 +114,11 @@ defmodule CritWeb.ApiController do
             %{path: f.file_path, content: f.content, status: f.status}
           end)
 
-        json(conn, %{files: files, visibility: review.visibility})
+        json(conn, %{
+          files: files,
+          visibility: review.visibility,
+          comment_policy: review.comment_policy
+        })
     end
   end
 
@@ -121,7 +141,8 @@ defmodule CritWeb.ApiController do
         # greppable for callers piping the export into automation. Signals
         # whether the source review is `:unlisted` (URL-only) or `:public`.
         md =
-          "<!-- crit-visibility: #{review.visibility} -->\n" <>
+          "<!-- crit-comment-policy: #{review.comment_policy} -->\n" <>
+            "<!-- crit-visibility: #{review.visibility} -->\n" <>
             Output.generate_multi_file_review_md(files, comments)
 
         conn
@@ -178,12 +199,26 @@ defmodule CritWeb.ApiController do
 
     case Reviews.upsert_review(scope, token, delete_token, payload) do
       {:ok, :updated, review} ->
+        review = maybe_update_comment_policy(scope, review, params)
         url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
-        json(conn, %{url: url, review_round: review.review_round, changed: true})
+
+        json(conn, %{
+          url: url,
+          review_round: review.review_round,
+          changed: true,
+          comment_policy: review.comment_policy
+        })
 
       {:ok, :no_changes, review} ->
+        review = maybe_update_comment_policy(scope, review, params)
         url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
-        json(conn, %{url: url, review_round: review.review_round, changed: false})
+
+        json(conn, %{
+          url: url,
+          review_round: review.review_round,
+          changed: false,
+          comment_policy: review.comment_policy
+        })
 
       {:error, :not_found} ->
         not_found(conn)
@@ -192,6 +227,22 @@ defmodule CritWeb.ApiController do
         conn |> put_status(401) |> json(%{error: "unauthorized"})
     end
   end
+
+  defp maybe_update_comment_policy(scope, review, %{"comment_policy" => raw}) when is_binary(raw) do
+    with {:ok, policy} <- parse_comment_policy(raw),
+         {:ok, updated} <- Reviews.update_review(scope, review.id, %{comment_policy: policy}) do
+      updated
+    else
+      _ -> review
+    end
+  end
+
+  defp maybe_update_comment_policy(_scope, review, _params), do: review
+
+  defp parse_comment_policy("open"), do: {:ok, :open}
+  defp parse_comment_policy("logged_in_only"), do: {:ok, :logged_in_only}
+  defp parse_comment_policy("disallowed"), do: {:ok, :disallowed}
+  defp parse_comment_policy(_), do: :error
 
   def delete_review(conn, %{"delete_token" => delete_token})
       when is_binary(delete_token) and delete_token != "" do

--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -228,7 +228,8 @@ defmodule CritWeb.ApiController do
     end
   end
 
-  defp maybe_update_comment_policy(scope, review, %{"comment_policy" => raw}) when is_binary(raw) do
+  defp maybe_update_comment_policy(scope, review, %{"comment_policy" => raw})
+       when is_binary(raw) do
     with {:ok, policy} <- parse_comment_policy(raw),
          {:ok, updated} <- Reviews.update_review(scope, review.id, %{comment_policy: policy}) do
       updated

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -2,6 +2,7 @@ defmodule CritWeb.ReviewLive do
   use CritWeb, :live_view
 
   alias Crit.Accounts.Scope
+  alias Crit.Review
   alias Crit.Reviews
 
   # Auth is gated by the router's :require_review_scope on_mount hook
@@ -112,7 +113,10 @@ defmodule CritWeb.ReviewLive do
          |> assign(:noindex, not public?)
          |> assign(:og_type, "article")
          |> assign(:canonical_url, canonical_url)
-         |> assign(:owner?, owner?), layout: {CritWeb.Layouts, :review}}
+         |> assign(:owner?, owner?)
+         |> assign(:comment_policy, review.comment_policy)
+         |> assign(:can_comment?, can_comment?(scope, review))
+         |> assign(:current_path, ~p"/r/#{review.token}"), layout: {CritWeb.Layouts, :review}}
     end
   end
 
@@ -140,6 +144,36 @@ defmodule CritWeb.ReviewLive do
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Could not make the review public.")}
+    end
+  end
+
+  def handle_event("update_comment_policy", %{"policy" => raw}, socket) do
+    scope = socket.assigns.current_scope
+    review = socket.assigns.review
+
+    with {:ok, policy} <- parse_comment_policy(raw),
+         {:ok, updated} <- Reviews.update_review(scope, review.id, %{comment_policy: policy}) do
+      merged = Map.merge(review, Map.take(updated, [:comment_policy]))
+
+      {:noreply,
+       socket
+       |> assign(:review, merged)
+       |> assign(:comment_policy, updated.comment_policy)
+       |> assign(:can_comment?, can_comment?(scope, updated))
+       |> push_event("policy_changed", %{can_comment: can_comment?(scope, updated)})
+       |> put_flash(:info, flash_for_policy(updated.comment_policy))}
+    else
+      :error ->
+        {:noreply, put_flash(socket, :error, "Invalid comment policy.")}
+
+      {:error, :unauthorized} ->
+        {:noreply, put_flash(socket, :error, "Not allowed.")}
+
+      {:error, :not_found} ->
+        {:noreply, put_flash(socket, :error, "Review not found.")}
+
+      {:error, %Ecto.Changeset{}} ->
+        {:noreply, put_flash(socket, :error, "Could not update the comment policy.")}
     end
   end
 
@@ -434,6 +468,25 @@ defmodule CritWeb.ReviewLive do
     {:noreply, push_event(socket, "display_name_changed", payload)}
   end
 
+  @impl true
+  def handle_info({:policy_changed, review_id, %{comment_policy: new_policy}}, socket) do
+    review = socket.assigns.review
+
+    if review.id == review_id do
+      scope = socket.assigns.current_scope
+      merged = Map.merge(review, %{comment_policy: new_policy})
+
+      {:noreply,
+       socket
+       |> assign(:review, merged)
+       |> assign(:comment_policy, new_policy)
+       |> assign(:can_comment?, can_comment?(scope, merged))
+       |> push_event("policy_changed", %{can_comment: can_comment?(scope, merged)})}
+    else
+      {:noreply, socket}
+    end
+  end
+
   defp broadcast_from_review(socket, message) do
     token = socket.assigns.review.token
     Phoenix.PubSub.broadcast_from(@pubsub, self(), "review:#{token}", message)
@@ -496,4 +549,32 @@ defmodule CritWeb.ReviewLive do
 
   defp display_filename(%{files: [first | _]}), do: first.file_path
   defp display_filename(_), do: "Review"
+
+  defp can_comment?(_scope, %Review{comment_policy: :disallowed}), do: false
+  defp can_comment?(%Scope{user: nil}, %Review{comment_policy: :logged_in_only}), do: false
+  defp can_comment?(_scope, _review), do: true
+
+  defp parse_comment_policy("open"), do: {:ok, :open}
+  defp parse_comment_policy("logged_in_only"), do: {:ok, :logged_in_only}
+  defp parse_comment_policy("disallowed"), do: {:ok, :disallowed}
+  defp parse_comment_policy(_), do: :error
+
+  defp flash_for_policy(:open), do: "Comments are now open to everyone."
+  defp flash_for_policy(:logged_in_only), do: "Only signed-in users can comment now."
+  defp flash_for_policy(:disallowed), do: "New comments are turned off for this review."
+
+  @doc false
+  def comment_policy_icon(:open), do: "hero-chat-bubble-left-right"
+  def comment_policy_icon(:logged_in_only), do: "hero-user"
+  def comment_policy_icon(:disallowed), do: "hero-no-symbol"
+
+  @doc false
+  def comment_policy_label(:open), do: "Open"
+  def comment_policy_label(:logged_in_only), do: "Login required"
+  def comment_policy_label(:disallowed), do: "Disabled"
+
+  @doc false
+  def comment_policy_description(:open), do: "Anyone can comment, signed in or not."
+  def comment_policy_description(:logged_in_only), do: "Only signed-in users can comment."
+  def comment_policy_description(:disallowed), do: "Nobody can post new comments."
 end

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -470,6 +470,9 @@ defmodule CritWeb.ReviewLive do
   end
 
   @impl true
+  # Cross-tab observer path: no flash and no :owner? recompute — the actor lives
+  # in another tab/session, so this socket is just mirroring state, not reacting
+  # to its own user's action. Don't mirror the handle_event flash here.
   def handle_info({:policy_changed, review_id, %{comment_policy: new_policy}}, socket) do
     review = socket.assigns.review
 

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -53,7 +53,8 @@ defmodule CritWeb.ReviewLive do
             push_event(socket, "init", %{
               comments: serialize_comments(comments),
               display_name: display_name,
-              files: files_data
+              files: files_data,
+              can_comment: can_comment?(scope, review)
             })
           else
             socket

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -454,7 +454,10 @@
                 panel_label="Comment policy"
               >
                 <:trigger>
-                  <.icon name={CritWeb.ReviewLive.comment_policy_icon(@comment_policy)} class="size-3" />
+                  <.icon
+                    name={CritWeb.ReviewLive.comment_policy_icon(@comment_policy)}
+                    class="size-3"
+                  />
                   <span>{CritWeb.ReviewLive.comment_policy_label(@comment_policy)}</span>
                   <.icon name="hero-chevron-down" class="size-3" />
                 </:trigger>
@@ -488,7 +491,10 @@
                 title={"Comments: " <> CritWeb.ReviewLive.comment_policy_label(@comment_policy)}
                 aria-label={"Comments: " <> CritWeb.ReviewLive.comment_policy_label(@comment_policy)}
               >
-                <.icon name={CritWeb.ReviewLive.comment_policy_icon(@comment_policy)} class="size-3" />
+                <.icon
+                  name={CritWeb.ReviewLive.comment_policy_icon(@comment_policy)}
+                  class="size-3"
+                />
                 {CritWeb.ReviewLive.comment_policy_label(@comment_policy)}
               </span>
             <% true -> %>

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -528,7 +528,17 @@
       </a>
     </div>
   <% end %>
-  <div id="crit-main-layout" class="crit-main-layout">
+  <%!--
+    `phx-update="ignore"` on the main layout: every child node here
+    (review-conversation cards, file-tree contents, the JS-appended
+    comments panel) is rendered and mutated by document-renderer.js.
+    Without ignore, any LV diff (e.g. updating @comment_policy) would
+    morphdom-patch this subtree back to its empty template, wiping the
+    existing review-level comments, file tree, and comments panel.
+    The only dynamic Elixir lives inside `#document-renderer`, which is
+    itself phx-update="ignore" and reads its own data-* attrs via the hook.
+  --%>
+  <div id="crit-main-layout" class="crit-main-layout" phx-update="ignore">
     <div id="fileTreePanel" class="tree-panel" style="display:none">
       <div id="treeConversationSection" class="tree-section--conversation"></div>
       <div class="tree-header">

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -1,4 +1,4 @@
-<div class="crit-page">
+<div class={["crit-page", not @can_comment? && "crit-no-comments"]}>
   <div class="crit-header">
     <div class="crit-header-bar">
       <div class="crit-header-left">

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -398,7 +398,10 @@
                 <div class="crit-vis-divider"></div>
                 <button
                   type="button"
-                  phx-click="make_public"
+                  phx-click={
+                    CritWeb.Components.PopoverMenu.close_js("visibility-menu")
+                    |> Phoenix.LiveView.JS.push("make_public")
+                  }
                   data-test="make-public"
                   data-confirm="Make this review public? Search engines will be able to index and cache it. You can delete the review later, but you can't un-expose a URL that's already been crawled."
                   class="crit-vis-promote"
@@ -454,17 +457,17 @@
                 panel_label="Comment policy"
               >
                 <:trigger>
-                  <.icon
-                    name={CritWeb.ReviewLive.comment_policy_icon(@comment_policy)}
-                    class="size-3"
-                  />
+                  <.icon name="hero-chat-bubble-left-right" class="size-3" />
                   <span>{CritWeb.ReviewLive.comment_policy_label(@comment_policy)}</span>
                   <.icon name="hero-chevron-down" class="size-3" />
                 </:trigger>
                 <%= for option <- [:open, :logged_in_only, :disallowed] do %>
                   <button
                     type="button"
-                    phx-click="update_comment_policy"
+                    phx-click={
+                      CritWeb.Components.PopoverMenu.close_js("comment-policy-menu")
+                      |> Phoenix.LiveView.JS.push("update_comment_policy")
+                    }
                     phx-value-policy={option}
                     data-test={"comment-policy-set-#{option}"}
                     class="crit-comment-policy-option"

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -508,6 +508,20 @@
       </CritWeb.Components.ReviewListingHeader.review_listing_header>
     </div>
   </div>
+  <%= if @comment_policy == :logged_in_only and not @can_comment? do %>
+    <div class="crit-signin-banner" role="status" aria-live="polite" data-test="signin-banner">
+      <div class="crit-signin-pill">
+        <.icon name="hero-user" class="size-3" />
+        <span>Sign-in required</span>
+      </div>
+      <span class="crit-signin-banner-text">
+        Only signed-in users can comment on this review.
+      </span>
+      <a href={~p"/auth/login?return_to=#{@current_path}"} class="crit-signin-banner-link">
+        Sign in
+      </a>
+    </div>
+  <% end %>
   <div id="crit-main-layout" class="crit-main-layout">
     <div id="fileTreePanel" class="tree-panel" style="display:none">
       <div id="treeConversationSection" class="tree-section--conversation"></div>

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -446,6 +446,53 @@
                 <.icon name="hero-eye-slash" class="size-3" /> Unlisted
               </span>
           <% end %>
+          <%= cond do %>
+            <% @owner? -> %>
+              <CritWeb.Components.PopoverMenu.popover_menu
+                id="comment-policy-menu"
+                test_prefix="comment-policy"
+                panel_label="Comment policy"
+              >
+                <:trigger>
+                  <.icon name={CritWeb.ReviewLive.comment_policy_icon(@comment_policy)} class="size-3" />
+                  <span>{CritWeb.ReviewLive.comment_policy_label(@comment_policy)}</span>
+                  <.icon name="hero-chevron-down" class="size-3" />
+                </:trigger>
+                <%= for option <- [:open, :logged_in_only, :disallowed] do %>
+                  <button
+                    type="button"
+                    phx-click="update_comment_policy"
+                    phx-value-policy={option}
+                    data-test={"comment-policy-set-#{option}"}
+                    class="crit-comment-policy-option"
+                    aria-current={@comment_policy == option}
+                  >
+                    <div class="crit-comment-policy-option-icon">
+                      <.icon name={CritWeb.ReviewLive.comment_policy_icon(option)} class="size-3" />
+                    </div>
+                    <div class="crit-comment-policy-option-text">
+                      <span class="crit-comment-policy-option-title">
+                        {CritWeb.ReviewLive.comment_policy_label(option)}
+                      </span>
+                      <span class="crit-comment-policy-option-desc">
+                        {CritWeb.ReviewLive.comment_policy_description(option)}
+                      </span>
+                    </div>
+                  </button>
+                <% end %>
+              </CritWeb.Components.PopoverMenu.popover_menu>
+            <% @comment_policy != :open -> %>
+              <span
+                class="crit-comment-policy-badge"
+                data-test="comment-policy-badge"
+                title={"Comments: " <> CritWeb.ReviewLive.comment_policy_label(@comment_policy)}
+                aria-label={"Comments: " <> CritWeb.ReviewLive.comment_policy_label(@comment_policy)}
+              >
+                <.icon name={CritWeb.ReviewLive.comment_policy_icon(@comment_policy)} class="size-3" />
+                {CritWeb.ReviewLive.comment_policy_label(@comment_policy)}
+              </span>
+            <% true -> %>
+          <% end %>
           <%= if owner? do %>
             <button
               phx-click="delete_review"

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -375,81 +375,49 @@
         <:actions>
           <%= cond do %>
             <% owner? and @review.visibility == :unlisted -> %>
-              <div
-                class="crit-vis"
-                id="visibility-control"
-                data-test="visibility-menu"
-                phx-click-away={
-                  Phoenix.LiveView.JS.set_attribute({"hidden", "hidden"},
-                    to: "#visibility-popover"
-                  )
-                  |> Phoenix.LiveView.JS.set_attribute({"aria-expanded", "false"},
-                    to: "#visibility-trigger"
-                  )
-                }
+              <CritWeb.Components.PopoverMenu.popover_menu
+                id="visibility-menu"
+                test_prefix="visibility"
+                panel_label="Visibility settings"
               >
-                <button
-                  type="button"
-                  id="visibility-trigger"
-                  class="crit-vis-trigger"
-                  aria-haspopup="dialog"
-                  aria-expanded="false"
-                  aria-controls="visibility-popover"
-                  title="Unlisted — only people with the URL can see this review."
-                  phx-click={
-                    Phoenix.LiveView.JS.toggle_attribute({"hidden", "hidden"},
-                      to: "#visibility-popover"
-                    )
-                    |> Phoenix.LiveView.JS.toggle_attribute({"aria-expanded", "true", "false"},
-                      to: "#visibility-trigger"
-                    )
-                  }
-                >
+                <:trigger>
                   <.icon name="hero-eye-slash" class="size-3" />
                   <span>Unlisted</span>
-                </button>
-                <div
-                  id="visibility-popover"
-                  class="crit-vis-popover"
-                  role="dialog"
-                  aria-label="Visibility settings"
-                  hidden
-                >
-                  <div class="crit-vis-current">
-                    <div class="crit-vis-current-icon">
-                      <.icon name="hero-eye-slash" class="size-3" />
-                    </div>
-                    <div class="crit-vis-current-text">
-                      <span class="crit-vis-current-label">Unlisted</span>
-                      <span class="crit-vis-current-desc">
-                        Only people with the URL can see this
-                      </span>
-                    </div>
+                </:trigger>
+                <div class="crit-vis-current">
+                  <div class="crit-vis-current-icon">
+                    <.icon name="hero-eye-slash" class="size-3" />
                   </div>
-                  <div class="crit-vis-divider"></div>
-                  <button
-                    type="button"
-                    phx-click="make_public"
-                    data-test="make-public"
-                    data-confirm="Make this review public? Search engines will be able to index and cache it. You can delete the review later, but you can't un-expose a URL that's already been crawled."
-                    class="crit-vis-promote"
-                  >
-                    <div class="crit-vis-promote-icon">
-                      <.icon name="hero-globe-alt" class="size-3" />
-                    </div>
-                    <div class="crit-vis-promote-text">
-                      <span class="crit-vis-promote-title">Make public</span>
-                      <span class="crit-vis-promote-desc">
-                        Anyone can find and view it. Indexed by search engines.
-                      </span>
-                    </div>
-                  </button>
-                  <div class="crit-vis-notice">
-                    <.icon name="hero-information-circle" class="size-3" />
-                    Making a review public can't be undone.
+                  <div class="crit-vis-current-text">
+                    <span class="crit-vis-current-label">Unlisted</span>
+                    <span class="crit-vis-current-desc">
+                      Only people with the URL can see this
+                    </span>
                   </div>
                 </div>
-              </div>
+                <div class="crit-vis-divider"></div>
+                <button
+                  type="button"
+                  phx-click="make_public"
+                  data-test="make-public"
+                  data-confirm="Make this review public? Search engines will be able to index and cache it. You can delete the review later, but you can't un-expose a URL that's already been crawled."
+                  class="crit-vis-promote"
+                >
+                  <div class="crit-vis-promote-icon">
+                    <.icon name="hero-globe-alt" class="size-3" />
+                  </div>
+                  <div class="crit-vis-promote-text">
+                    <span class="crit-vis-promote-title">Make public</span>
+                    <span class="crit-vis-promote-desc">
+                      Anyone can find and view it. Indexed by search engines.
+                    </span>
+                  </div>
+                </button>
+                <div class="crit-vis-notice">
+                  <.icon name="hero-information-circle" class="size-3" />
+                  Making a review public can't be undone.
+                </div>
+              </CritWeb.Components.PopoverMenu.popover_menu>
             <% @review.visibility == :public and owner? -> %>
               <span
                 class="crit-vis-status"

--- a/priv/repo/migrations/20260504000001_add_comment_policy_to_reviews.exs
+++ b/priv/repo/migrations/20260504000001_add_comment_policy_to_reviews.exs
@@ -1,0 +1,9 @@
+defmodule Crit.Repo.Migrations.AddCommentPolicyToReviews do
+  use Ecto.Migration
+
+  def change do
+    alter table(:reviews) do
+      add :comment_policy, :string, null: false, default: "open"
+    end
+  end
+end

--- a/test/crit/output_test.exs
+++ b/test/crit/output_test.exs
@@ -238,10 +238,17 @@ defmodule Crit.OutputTest do
       %{
         review_round: 1,
         visibility: :unlisted,
+        comment_policy: :open,
         token: "test-token",
         delete_token: "del-token",
         updated_at: ~U[2026-01-01 00:00:00Z]
       }
+    end
+
+    test "includes comment_policy" do
+      review = %{fake_review() | comment_policy: :logged_in_only}
+      result = Output.multi_file_comments_json(review, [], [], @base_url)
+      assert result.comment_policy == :logged_in_only
     end
 
     test "groups comments by file path" do

--- a/test/crit/review_test.exs
+++ b/test/crit/review_test.exs
@@ -38,6 +38,29 @@ defmodule Crit.ReviewTest do
     end
   end
 
+  describe "update_changeset/2" do
+    test "default comment_policy is :open" do
+      {:ok, review} =
+        %Review{}
+        |> Review.create_changeset(%{})
+        |> Crit.Repo.insert()
+
+      assert review.comment_policy == :open
+    end
+
+    test "update_changeset/2 accepts valid comment_policy values" do
+      review = %Review{comment_policy: :open}
+      assert Review.update_changeset(review, %{comment_policy: :open}).valid?
+      assert Review.update_changeset(review, %{comment_policy: :logged_in_only}).valid?
+      assert Review.update_changeset(review, %{comment_policy: :disallowed}).valid?
+    end
+
+    test "update_changeset/2 rejects unknown comment_policy values" do
+      review = %Review{comment_policy: :open}
+      refute Review.update_changeset(review, %{comment_policy: :secret}).valid?
+    end
+  end
+
   describe "visibility" do
     test "default visibility is :unlisted" do
       {:ok, review} =

--- a/test/crit/reviews_comment_policy_test.exs
+++ b/test/crit/reviews_comment_policy_test.exs
@@ -45,7 +45,9 @@ defmodule Crit.ReviewsCommentPolicyTest do
       review = create_review_for(owner)
 
       assert {:error, :unauthorized} =
-               Reviews.update_review(Scope.for_user(other), review.id, %{comment_policy: :disallowed})
+               Reviews.update_review(Scope.for_user(other), review.id, %{
+                 comment_policy: :disallowed
+               })
     end
 
     test "anonymous scope cannot change comment_policy" do
@@ -53,7 +55,9 @@ defmodule Crit.ReviewsCommentPolicyTest do
       review = create_review_for(owner)
 
       assert {:error, :unauthorized} =
-               Reviews.update_review(Scope.for_visitor("ident"), review.id, %{comment_policy: :disallowed})
+               Reviews.update_review(Scope.for_visitor("ident"), review.id, %{
+                 comment_policy: :disallowed
+               })
     end
 
     test "anonymous-owned review cannot have comment_policy changed by an authed visitor" do
@@ -70,21 +74,27 @@ defmodule Crit.ReviewsCommentPolicyTest do
       assert review.user_id == nil
 
       assert {:error, :unauthorized} =
-               Reviews.update_review(Scope.for_user(other), review.id, %{comment_policy: :disallowed})
+               Reviews.update_review(Scope.for_user(other), review.id, %{
+                 comment_policy: :disallowed
+               })
     end
 
     test "missing review returns :not_found" do
       user = owner_user_fixture()
 
       assert {:error, :not_found} =
-               Reviews.update_review(Scope.for_user(user), Ecto.UUID.generate(), %{comment_policy: :disallowed})
+               Reviews.update_review(Scope.for_user(user), Ecto.UUID.generate(), %{
+                 comment_policy: :disallowed
+               })
     end
 
     test "non-UUID review_id returns :not_found instead of raising" do
       user = owner_user_fixture()
 
       assert {:error, :not_found} =
-               Reviews.update_review(Scope.for_user(user), "not-a-uuid", %{comment_policy: :disallowed})
+               Reviews.update_review(Scope.for_user(user), "not-a-uuid", %{
+                 comment_policy: :disallowed
+               })
     end
 
     test "invalid policy atom returns a changeset error" do
@@ -100,7 +110,10 @@ defmodule Crit.ReviewsCommentPolicyTest do
       review = create_review_for(user)
 
       assert {:ok, updated} =
-               Reviews.update_review(Scope.for_user(user), review.id, %{comment_policy: :disallowed, evil: 1})
+               Reviews.update_review(Scope.for_user(user), review.id, %{
+                 comment_policy: :disallowed,
+                 evil: 1
+               })
 
       assert updated.comment_policy == :disallowed
     end
@@ -162,8 +175,13 @@ defmodule Crit.ReviewsCommentPolicyTest do
       open_r = create_review_for(user)
       login_r = create_review_for(user)
       closed_r = create_review_for(user)
-      {:ok, _} = Reviews.update_review(Scope.for_user(user), login_r.id, %{comment_policy: :logged_in_only})
-      {:ok, _} = Reviews.update_review(Scope.for_user(user), closed_r.id, %{comment_policy: :disallowed})
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(user), login_r.id, %{comment_policy: :logged_in_only})
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(user), closed_r.id, %{comment_policy: :disallowed})
+
       login_r = Reviews.get_by_token(login_r.token)
       closed_r = Reviews.get_by_token(closed_r.token)
       attrs = %{"start_line" => 1, "end_line" => 1, "body" => "hi"}
@@ -204,8 +222,13 @@ defmodule Crit.ReviewsCommentPolicyTest do
       open_r = create_review_for(user)
       login_r = create_review_for(user)
       closed_r = create_review_for(user)
-      {:ok, _} = Reviews.update_review(Scope.for_user(user), login_r.id, %{comment_policy: :logged_in_only})
-      {:ok, _} = Reviews.update_review(Scope.for_user(user), closed_r.id, %{comment_policy: :disallowed})
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(user), login_r.id, %{comment_policy: :logged_in_only})
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(user), closed_r.id, %{comment_policy: :disallowed})
+
       login_r = Reviews.get_by_token(login_r.token)
       closed_r = Reviews.get_by_token(closed_r.token)
       anon = Scope.for_visitor("anon", "Anon")

--- a/test/crit/reviews_comment_policy_test.exs
+++ b/test/crit/reviews_comment_policy_test.exs
@@ -248,6 +248,33 @@ defmodule Crit.ReviewsCommentPolicyTest do
     end
   end
 
+  describe "upsert_review/4 with restrictive comment_policy" do
+    test "bulk replace path still works regardless of policy" do
+      owner = owner_user_fixture()
+      review = create_review_for(owner)
+      scope = Scope.for_user(owner)
+      {:ok, _} = Reviews.update_review(scope, review.id, %{comment_policy: :disallowed})
+
+      payload = %{
+        "files" => [%{"path" => "a.md", "content" => "hello"}],
+        "comments" => [
+          %{
+            "start_line" => 1,
+            "end_line" => 1,
+            "body" => "from cli upload",
+            "scope" => "line",
+            "external_id" => "cli_1"
+          }
+        ]
+      }
+
+      assert {:ok, _outcome, _updated} =
+               Reviews.upsert_review(scope, review.token, review.delete_token, payload)
+
+      assert [%{body: "from cli upload"}] = Reviews.list_comments(review.id)
+    end
+  end
+
   defp insert_top_level_comment!(%Crit.Review{} = review) do
     Crit.Repo.insert!(%Crit.Comment{
       review_id: review.id,

--- a/test/crit/reviews_comment_policy_test.exs
+++ b/test/crit/reviews_comment_policy_test.exs
@@ -1,0 +1,158 @@
+defmodule Crit.ReviewsCommentPolicyTest do
+  use Crit.DataCase, async: true
+
+  alias Crit.Accounts.Scope
+  alias Crit.Reviews
+
+  defp owner_user_fixture do
+    {:ok, user} =
+      Crit.Accounts.find_or_create_from_oauth("github", %{
+        "sub" => "cp-#{System.unique_integer([:positive])}",
+        "email" => "cp-#{System.unique_integer([:positive])}@example.com",
+        "name" => "CP Owner"
+      })
+
+    user
+  end
+
+  defp create_review_for(user) do
+    {:ok, review} =
+      Reviews.create_review(
+        Scope.for_user(user),
+        [%{"path" => "a.md", "content" => "x"}],
+        0,
+        []
+      )
+
+    review
+  end
+
+  describe "update_review/3 — comment_policy" do
+    test "owner can change comment_policy through every value" do
+      user = owner_user_fixture()
+      scope = Scope.for_user(user)
+      review = create_review_for(user)
+
+      for policy <- [:logged_in_only, :disallowed, :open] do
+        assert {:ok, updated} = Reviews.update_review(scope, review.id, %{comment_policy: policy})
+        assert updated.comment_policy == policy
+      end
+    end
+
+    test "non-owner authenticated user cannot change comment_policy" do
+      owner = owner_user_fixture()
+      other = owner_user_fixture()
+      review = create_review_for(owner)
+
+      assert {:error, :unauthorized} =
+               Reviews.update_review(Scope.for_user(other), review.id, %{comment_policy: :disallowed})
+    end
+
+    test "anonymous scope cannot change comment_policy" do
+      owner = owner_user_fixture()
+      review = create_review_for(owner)
+
+      assert {:error, :unauthorized} =
+               Reviews.update_review(Scope.for_visitor("ident"), review.id, %{comment_policy: :disallowed})
+    end
+
+    test "anonymous-owned review cannot have comment_policy changed by an authed visitor" do
+      other = owner_user_fixture()
+
+      {:ok, review} =
+        Reviews.create_review(
+          Scope.for_visitor("anon-#{System.unique_integer([:positive])}"),
+          [%{"path" => "a.md", "content" => "x"}],
+          0,
+          []
+        )
+
+      assert review.user_id == nil
+
+      assert {:error, :unauthorized} =
+               Reviews.update_review(Scope.for_user(other), review.id, %{comment_policy: :disallowed})
+    end
+
+    test "missing review returns :not_found" do
+      user = owner_user_fixture()
+
+      assert {:error, :not_found} =
+               Reviews.update_review(Scope.for_user(user), Ecto.UUID.generate(), %{comment_policy: :disallowed})
+    end
+
+    test "non-UUID review_id returns :not_found instead of raising" do
+      user = owner_user_fixture()
+
+      assert {:error, :not_found} =
+               Reviews.update_review(Scope.for_user(user), "not-a-uuid", %{comment_policy: :disallowed})
+    end
+
+    test "invalid policy atom returns a changeset error" do
+      user = owner_user_fixture()
+      review = create_review_for(user)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Reviews.update_review(Scope.for_user(user), review.id, %{comment_policy: :bogus})
+    end
+
+    test "unknown attrs keys are silently dropped by the changeset cast list" do
+      user = owner_user_fixture()
+      review = create_review_for(user)
+
+      assert {:ok, updated} =
+               Reviews.update_review(Scope.for_user(user), review.id, %{comment_policy: :disallowed, evil: 1})
+
+      assert updated.comment_policy == :disallowed
+    end
+
+    test "setting comment_policy to its current value is a no-op success" do
+      user = owner_user_fixture()
+      scope = Scope.for_user(user)
+      review = create_review_for(user)
+      assert review.comment_policy == :open
+
+      assert {:ok, updated} = Reviews.update_review(scope, review.id, %{comment_policy: :open})
+      assert updated.comment_policy == :open
+    end
+
+    test "string-keyed attrs work too (API-style payloads)" do
+      user = owner_user_fixture()
+      scope = Scope.for_user(user)
+      review = create_review_for(user)
+
+      assert {:ok, updated} =
+               Reviews.update_review(scope, review.id, %{"comment_policy" => "logged_in_only"})
+
+      assert updated.comment_policy == :logged_in_only
+    end
+
+    test "broadcasts {:policy_changed, ...} on a real comment_policy change" do
+      user = owner_user_fixture()
+      scope = Scope.for_user(user)
+      review = create_review_for(user)
+      assert review.comment_policy == :open
+
+      Phoenix.PubSub.subscribe(Crit.PubSub, "review:#{review.token}")
+
+      assert {:ok, _updated} =
+               Reviews.update_review(scope, review.id, %{comment_policy: :disallowed})
+
+      assert_receive {:policy_changed, review_id, %{comment_policy: :disallowed}}
+      assert review_id == review.id
+    end
+
+    test "does NOT broadcast {:policy_changed, ...} when comment_policy is unchanged" do
+      user = owner_user_fixture()
+      scope = Scope.for_user(user)
+      review = create_review_for(user)
+      assert review.comment_policy == :open
+
+      Phoenix.PubSub.subscribe(Crit.PubSub, "review:#{review.token}")
+
+      assert {:ok, _updated} =
+               Reviews.update_review(scope, review.id, %{comment_policy: :open})
+
+      refute_receive {:policy_changed, _, _}, 100
+    end
+  end
+end

--- a/test/crit/reviews_comment_policy_test.exs
+++ b/test/crit/reviews_comment_policy_test.exs
@@ -155,4 +155,46 @@ defmodule Crit.ReviewsCommentPolicyTest do
       refute_receive {:policy_changed, _, _}, 100
     end
   end
+
+  describe "create_comment/4 — comment_policy gate" do
+    setup do
+      user = owner_user_fixture()
+      open_r = create_review_for(user)
+      login_r = create_review_for(user)
+      closed_r = create_review_for(user)
+      {:ok, _} = Reviews.update_review(Scope.for_user(user), login_r.id, %{comment_policy: :logged_in_only})
+      {:ok, _} = Reviews.update_review(Scope.for_user(user), closed_r.id, %{comment_policy: :disallowed})
+      login_r = Reviews.get_by_token(login_r.token)
+      closed_r = Reviews.get_by_token(closed_r.token)
+      attrs = %{"start_line" => 1, "end_line" => 1, "body" => "hi"}
+      %{user: user, open_r: open_r, login_r: login_r, closed_r: closed_r, attrs: attrs}
+    end
+
+    test "open: anonymous allowed", %{open_r: r, attrs: a} do
+      scope = Scope.for_visitor("anon", "Anon")
+      assert {:ok, _} = Reviews.create_comment(scope, r, a)
+    end
+
+    test "open: authenticated allowed", %{user: u, open_r: r, attrs: a} do
+      assert {:ok, _} = Reviews.create_comment(Scope.for_user(u), r, a)
+    end
+
+    test "logged_in_only: anonymous rejected", %{login_r: r, attrs: a} do
+      scope = Scope.for_visitor("anon", "Anon")
+      assert {:error, :comments_require_login} = Reviews.create_comment(scope, r, a)
+    end
+
+    test "logged_in_only: authenticated allowed", %{user: u, login_r: r, attrs: a} do
+      assert {:ok, _} = Reviews.create_comment(Scope.for_user(u), r, a)
+    end
+
+    test "disallowed: anonymous rejected", %{closed_r: r, attrs: a} do
+      scope = Scope.for_visitor("anon", "Anon")
+      assert {:error, :comments_disallowed} = Reviews.create_comment(scope, r, a)
+    end
+
+    test "disallowed: authenticated rejected", %{user: u, closed_r: r, attrs: a} do
+      assert {:error, :comments_disallowed} = Reviews.create_comment(Scope.for_user(u), r, a)
+    end
+  end
 end

--- a/test/crit/reviews_comment_policy_test.exs
+++ b/test/crit/reviews_comment_policy_test.exs
@@ -27,6 +27,32 @@ defmodule Crit.ReviewsCommentPolicyTest do
     review
   end
 
+  # Subscribe to the review topic from a separate process and forward all
+  # messages back to the test pid. Needed because Reviews.update_review/3
+  # uses broadcast_from(self(), ...) and would skip a same-process subscriber.
+  defp subscribe_from_other_process(token) do
+    test_pid = self()
+
+    {:ok, _pid} =
+      Task.start_link(fn ->
+        Phoenix.PubSub.subscribe(Crit.PubSub, "review:#{token}")
+        forward_loop(test_pid)
+      end)
+
+    # Give the Task a tick to register the subscription before the caller
+    # triggers the broadcast.
+    Process.sleep(20)
+    :ok
+  end
+
+  defp forward_loop(test_pid) do
+    receive do
+      msg ->
+        send(test_pid, msg)
+        forward_loop(test_pid)
+    end
+  end
+
   describe "update_review/3 — comment_policy" do
     test "owner can change comment_policy through every value" do
       user = owner_user_fixture()
@@ -145,7 +171,11 @@ defmodule Crit.ReviewsCommentPolicyTest do
       review = create_review_for(user)
       assert review.comment_policy == :open
 
-      Phoenix.PubSub.subscribe(Crit.PubSub, "review:#{review.token}")
+      # Subscribe from a separate process so broadcast_from(self(), ...) in
+      # update_review (which excludes the *caller* of update_review) still
+      # delivers to this subscriber. Mirrors the production topology where
+      # the originating LV calls update_review and other-tab LVs subscribe.
+      subscribe_from_other_process(review.token)
 
       assert {:ok, _updated} =
                Reviews.update_review(scope, review.id, %{comment_policy: :disallowed})
@@ -160,7 +190,7 @@ defmodule Crit.ReviewsCommentPolicyTest do
       review = create_review_for(user)
       assert review.comment_policy == :open
 
-      Phoenix.PubSub.subscribe(Crit.PubSub, "review:#{review.token}")
+      subscribe_from_other_process(review.token)
 
       assert {:ok, _updated} =
                Reviews.update_review(scope, review.id, %{comment_policy: :open})

--- a/test/crit/reviews_comment_policy_test.exs
+++ b/test/crit/reviews_comment_policy_test.exs
@@ -197,4 +197,64 @@ defmodule Crit.ReviewsCommentPolicyTest do
       assert {:error, :comments_disallowed} = Reviews.create_comment(Scope.for_user(u), r, a)
     end
   end
+
+  describe "create_reply/4 — comment_policy gate" do
+    setup do
+      user = owner_user_fixture()
+      open_r = create_review_for(user)
+      login_r = create_review_for(user)
+      closed_r = create_review_for(user)
+      {:ok, _} = Reviews.update_review(Scope.for_user(user), login_r.id, %{comment_policy: :logged_in_only})
+      {:ok, _} = Reviews.update_review(Scope.for_user(user), closed_r.id, %{comment_policy: :disallowed})
+      login_r = Reviews.get_by_token(login_r.token)
+      closed_r = Reviews.get_by_token(closed_r.token)
+      anon = Scope.for_visitor("anon", "Anon")
+
+      open_parent = insert_top_level_comment!(open_r)
+      login_parent = insert_top_level_comment!(login_r)
+      closed_parent = insert_top_level_comment!(closed_r)
+
+      %{
+        user: user,
+        anon: anon,
+        open: {open_r, open_parent},
+        login: {login_r, login_parent},
+        closed: {closed_r, closed_parent}
+      }
+    end
+
+    test "open: anonymous allowed", %{anon: anon, open: {r, p}} do
+      assert {:ok, _} = Reviews.create_reply(anon, p.id, %{"body" => "r"}, r.id)
+    end
+
+    test "logged_in_only: anonymous rejected", %{anon: anon, login: {r, p}} do
+      assert {:error, :comments_require_login} =
+               Reviews.create_reply(anon, p.id, %{"body" => "r"}, r.id)
+    end
+
+    test "logged_in_only: authenticated allowed", %{user: u, login: {r, p}} do
+      assert {:ok, _} =
+               Reviews.create_reply(Scope.for_user(u), p.id, %{"body" => "r"}, r.id)
+    end
+
+    test "disallowed: anonymous rejected", %{anon: anon, closed: {r, p}} do
+      assert {:error, :comments_disallowed} =
+               Reviews.create_reply(anon, p.id, %{"body" => "r"}, r.id)
+    end
+
+    test "disallowed: authenticated rejected", %{user: u, closed: {r, p}} do
+      assert {:error, :comments_disallowed} =
+               Reviews.create_reply(Scope.for_user(u), p.id, %{"body" => "r"}, r.id)
+    end
+  end
+
+  defp insert_top_level_comment!(%Crit.Review{} = review) do
+    Crit.Repo.insert!(%Crit.Comment{
+      review_id: review.id,
+      start_line: 1,
+      end_line: 1,
+      body: "seed",
+      scope: "line"
+    })
+  end
 end

--- a/test/crit_web/components/popover_menu_test.exs
+++ b/test/crit_web/components/popover_menu_test.exs
@@ -1,0 +1,57 @@
+defmodule CritWeb.Components.PopoverMenuTest do
+  use CritWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+  import Phoenix.Component
+
+  import CritWeb.Components.PopoverMenu
+
+  test "renders trigger button and panel with shared shell wiring" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.popover_menu id="visibility-menu" test_prefix="visibility">
+        <:trigger>
+          <span>Trigger label</span>
+        </:trigger>
+        <span class="option-row">option content</span>
+      </.popover_menu>
+      """)
+
+    assert html =~ ~s(data-test="visibility-menu")
+    assert html =~ ~s(id="visibility-menu-trigger")
+    assert html =~ ~s(id="visibility-menu-panel")
+    assert html =~ ~s(role="dialog")
+    assert html =~ ~s(aria-haspopup="dialog")
+    assert html =~ ~s(aria-controls="visibility-menu-panel")
+    assert html =~ "Trigger label"
+    assert html =~ "option content"
+  end
+
+  test "panel is closed by default (no data-open=true) and trigger has aria-expanded=false" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.popover_menu id="m" test_prefix="m"><:trigger>t</:trigger>x</.popover_menu>
+      """)
+
+    assert html =~ ~s(aria-expanded="false")
+    refute html =~ ~s(data-open="true")
+  end
+
+  test "test_prefix namespaces the data-test attributes" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <.popover_menu id="comment-policy-menu" test_prefix="comment-policy">
+        <:trigger>x</:trigger>
+        body
+      </.popover_menu>
+      """)
+
+    assert html =~ ~s(data-test="comment-policy-menu")
+    refute html =~ "visibility-menu"
+  end
+end

--- a/test/crit_web/components/popover_menu_test.exs
+++ b/test/crit_web/components/popover_menu_test.exs
@@ -40,6 +40,17 @@ defmodule CritWeb.Components.PopoverMenuTest do
     refute html =~ ~s(data-open="true")
   end
 
+  test "close_js/1 returns a JS chain that closes the panel and resets aria-expanded" do
+    js = CritWeb.Components.PopoverMenu.close_js("comment-policy-menu")
+    encoded = Phoenix.HTML.Safe.to_iodata(js) |> IO.iodata_to_binary()
+
+    assert encoded =~ "set_attr"
+    assert encoded =~ "comment-policy-menu-panel"
+    assert encoded =~ "data-open"
+    assert encoded =~ "comment-policy-menu-trigger"
+    assert encoded =~ "aria-expanded"
+  end
+
   test "test_prefix namespaces the data-test attributes" do
     assigns = %{}
 

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -180,7 +180,7 @@ defmodule CritWeb.ApiControllerTest do
       review = create_review()
       conn = get(conn, ~p"/api/export/#{review.token}/review")
       body = response(conn, 200)
-      assert body =~ ~r/\A<!-- crit-visibility: unlisted -->/
+      assert body =~ ~r/<!-- crit-visibility: unlisted -->/
       assert get_resp_header(conn, "x-robots-tag") == ["noindex"]
     end
 
@@ -203,7 +203,7 @@ defmodule CritWeb.ApiControllerTest do
       {:ok, _} = Reviews.make_public(Scope.for_user(user), review.id)
 
       conn = get(conn, ~p"/api/export/#{review.token}/review")
-      assert response(conn, 200) =~ ~r/\A<!-- crit-visibility: public -->/
+      assert response(conn, 200) =~ ~r/<!-- crit-visibility: public -->/
     end
 
     test "returns 404 for unknown token", %{conn: conn} do
@@ -709,6 +709,128 @@ defmodule CritWeb.ApiControllerTest do
         })
 
       assert conn.status == 404
+    end
+  end
+
+  describe "comment_policy via API" do
+    defp owner_with_token do
+      {:ok, user} =
+        Crit.Accounts.find_or_create_from_oauth("github", %{
+          "sub" => "api-cp-#{System.unique_integer([:positive])}",
+          "email" => "api-cp-#{System.unique_integer([:positive])}@example.com",
+          "name" => "API CP"
+        })
+
+      {:ok, {plaintext, _record}} = Crit.Accounts.create_token(user, "test")
+      {user, plaintext}
+    end
+
+    test "document endpoint echoes comment_policy (defaults to open)", %{conn: conn} do
+      review = create_review()
+      conn = get(conn, ~p"/api/reviews/#{review.token}/document")
+      assert json_response(conn, 200)["comment_policy"] == "open"
+    end
+
+    test "document endpoint reflects updated comment_policy", %{conn: conn} do
+      {user, _token} = owner_with_token()
+
+      {:ok, review} =
+        Reviews.create_review(
+          Scope.for_user(user),
+          [%{"path" => "p.md", "content" => "x"}],
+          0,
+          []
+        )
+
+      {:ok, _} = Reviews.update_review(Scope.for_user(user), review.id, %{comment_policy: :disallowed})
+
+      conn = get(conn, ~p"/api/reviews/#{review.token}/document")
+      assert json_response(conn, 200)["comment_policy"] == "disallowed"
+    end
+
+    test "export endpoint prefixes the markdown with a comment-policy marker", %{conn: conn} do
+      review = create_review()
+      conn = get(conn, ~p"/api/export/#{review.token}/review")
+      body = response(conn, 200)
+      assert body =~ ~r/<!-- crit-comment-policy: open -->/
+    end
+
+    test "owner can set comment_policy when updating a review via PUT", %{conn: conn} do
+      {user, plaintext} = owner_with_token()
+
+      {:ok, review} =
+        Reviews.create_review(
+          Scope.for_user(user),
+          [%{"path" => "p.md", "content" => "x"}],
+          1,
+          []
+        )
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer " <> plaintext)
+        |> put_req_header("content-type", "application/json")
+        |> put("/api/reviews/#{review.token}", %{
+          delete_token: review.delete_token,
+          files: [%{path: "p.md", content: "y"}],
+          comments: [],
+          review_round: 1,
+          comment_policy: "logged_in_only"
+        })
+
+      assert json_response(conn, 200)["comment_policy"] == "logged_in_only"
+      assert Reviews.get_by_token(review.token).comment_policy == :logged_in_only
+    end
+
+    test "non-owner cannot set comment_policy via PUT (field silently ignored)", %{conn: conn} do
+      review = create_review()
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put("/api/reviews/#{review.token}", %{
+          delete_token: review.delete_token,
+          files: [%{path: "test.md", content: "y"}],
+          comments: [],
+          review_round: 0,
+          comment_policy: "disallowed"
+        })
+
+      assert conn.status == 200
+      assert Reviews.get_by_token(review.token).comment_policy == :open
+    end
+
+    test "owner can set comment_policy on POST /api/reviews", %{conn: conn} do
+      {_user, plaintext} = owner_with_token()
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer " <> plaintext)
+        |> post(~p"/api/reviews", %{
+          files: [%{path: "a.md", content: "x"}],
+          comments: [],
+          comment_policy: "logged_in_only"
+        })
+
+      body = json_response(conn, 201)
+      assert body["comment_policy"] == "logged_in_only"
+
+      token = body["url"] |> String.split("/r/") |> List.last()
+      assert Reviews.get_by_token(token).comment_policy == :logged_in_only
+    end
+
+    test "anonymous POST /api/reviews silently ignores comment_policy", %{conn: conn} do
+      conn =
+        post(conn, ~p"/api/reviews", %{
+          files: [%{path: "a.md", content: "x"}],
+          comments: [],
+          comment_policy: "disallowed"
+        })
+
+      body = json_response(conn, 201)
+      assert body["comment_policy"] == "open"
+      token = body["url"] |> String.split("/r/") |> List.last()
+      assert Reviews.get_by_token(token).comment_policy == :open
     end
   end
 

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -742,7 +742,8 @@ defmodule CritWeb.ApiControllerTest do
           []
         )
 
-      {:ok, _} = Reviews.update_review(Scope.for_user(user), review.id, %{comment_policy: :disallowed})
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(user), review.id, %{comment_policy: :disallowed})
 
       conn = get(conn, ~p"/api/reviews/#{review.token}/document")
       assert json_response(conn, 200)["comment_policy"] == "disallowed"

--- a/test/crit_web/live/review_live_comment_policy_test.exs
+++ b/test/crit_web/live/review_live_comment_policy_test.exs
@@ -228,4 +228,77 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
       assert render(view) == before
     end
   end
+
+  # The review-conversation, file tree, and comments panel are all populated by
+  # document-renderer.js (a phx-hook) inside `#crit-main-layout`. Only
+  # `#document-renderer` reads dynamic Elixir attrs and is itself
+  # phx-update="ignore" — the rest of the subtree must also be marked ignored,
+  # otherwise any LV diff (e.g. flipping comment_policy) would morphdom-patch
+  # the JS-rendered children back to the empty template and existing comments
+  # would visually disappear. Regression for the bug where switching policy
+  # wiped the review-level comments section.
+  describe "JS-rendered comment surfaces survive LV patches" do
+    test "main layout is phx-update=\"ignore\" so renderer-managed children persist",
+         %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      assert has_element?(view, "#crit-main-layout[phx-update=\"ignore\"]")
+      assert has_element?(view, "#reviewConversation")
+      assert has_element?(view, "#document-renderer[phx-update=\"ignore\"]")
+    end
+
+    test "owner flipping policy to :disallowed does not remove existing comments", %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+      _review_comment = comment_fixture(review, %{"scope" => "review", "body" => "review-level"})
+      _line_comment = comment_fixture(review, %{"scope" => "line", "body" => "line-level"})
+
+      conn = log_in(conn, owner)
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+      view |> element("[data-test=comment-policy-set-disallowed]") |> render_click()
+
+      # JS-rendered comment surfaces stay structurally present.
+      assert has_element?(view, "#crit-main-layout[phx-update=\"ignore\"]")
+      assert has_element?(view, "#reviewConversation")
+
+      # Existing comments are not destroyed by a policy flip.
+      assert length(Reviews.list_comments(review.id)) == 2
+    end
+
+    test "anonymous viewer of :logged_in_only review still sees existing comments",
+         %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+      _review_comment = comment_fixture(review, %{"scope" => "review", "body" => "review-level"})
+      _line_comment = comment_fixture(review, %{"scope" => "line", "body" => "line-level"})
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+      assert has_element?(view, "#crit-main-layout[phx-update=\"ignore\"]")
+      assert has_element?(view, "#reviewConversation")
+      assert length(Reviews.list_comments(review.id)) == 2
+    end
+
+    test "anonymous viewer of :disallowed review still sees existing comments", %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+      _review_comment = comment_fixture(review, %{"scope" => "review", "body" => "review-level"})
+      _line_comment = comment_fixture(review, %{"scope" => "line", "body" => "line-level"})
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+      assert has_element?(view, "#crit-main-layout[phx-update=\"ignore\"]")
+      assert has_element?(view, "#reviewConversation")
+      assert length(Reviews.list_comments(review.id)) == 2
+    end
+  end
 end

--- a/test/crit_web/live/review_live_comment_policy_test.exs
+++ b/test/crit_web/live/review_live_comment_policy_test.exs
@@ -1,0 +1,128 @@
+defmodule CritWeb.ReviewLiveCommentPolicyTest do
+  use CritWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+  import Crit.ReviewsFixtures
+
+  alias Crit.Accounts.Scope
+  alias Crit.Reviews
+
+  defp owner_fixture do
+    {:ok, user} =
+      Crit.Accounts.find_or_create_from_oauth("github", %{
+        "sub" => "cp-#{System.unique_integer([:positive])}",
+        "email" => "cp-#{System.unique_integer([:positive])}@example.com",
+        "name" => "Owner"
+      })
+
+    user
+  end
+
+  defp log_in(conn, user), do: init_test_session(conn, %{user_id: user.id})
+
+  test "owner sees the comment-policy popover trigger", %{conn: conn} do
+    user = owner_fixture()
+    review = review_fixture(user_id: user.id)
+    conn = log_in(conn, user)
+
+    {:ok, view, html} = live(conn, ~p"/r/#{review.token}")
+    assert has_element?(view, "[data-test=comment-policy-menu]")
+    assert has_element?(view, "#comment-policy-menu-panel[role=dialog]")
+    assert has_element?(view, "#comment-policy-menu-trigger[aria-controls=comment-policy-menu-panel]")
+    assert has_element?(view, "[data-test=comment-policy-set-disallowed]")
+    assert html =~ "Open"
+  end
+
+  test "owner can switch to :logged_in_only and the page re-renders without losing preloads",
+       %{conn: conn} do
+    user = owner_fixture()
+    review = review_fixture(user_id: user.id)
+    conn = log_in(conn, user)
+    file_path = hd(review.files).file_path
+
+    {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+    rendered = view |> element("[data-test=comment-policy-set-logged_in_only]") |> render_click()
+
+    assert Reviews.get_by_token(review.token).comment_policy == :logged_in_only
+    assert rendered =~ "signed-in users can comment"
+    assert rendered =~ file_path
+  end
+
+  test "non-owner authenticated user sees no menu, no badge on :open", %{conn: conn} do
+    owner = owner_fixture()
+    other = owner_fixture()
+    review = review_fixture(user_id: owner.id)
+    conn = log_in(conn, other)
+
+    {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+    refute has_element?(view, "[data-test=comment-policy-menu]")
+    refute has_element?(view, "[data-test=comment-policy-badge]")
+  end
+
+  test "non-owner sees a muted badge when policy is :disallowed", %{conn: conn} do
+    owner = owner_fixture()
+    other = owner_fixture()
+    review = review_fixture(user_id: owner.id)
+    {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+    conn = log_in(conn, other)
+
+    {:ok, view, html} = live(conn, ~p"/r/#{review.token}")
+    refute has_element?(view, "[data-test=comment-policy-menu]")
+    assert has_element?(view, "[data-test=comment-policy-badge]")
+    assert html =~ "Disabled"
+  end
+
+  test "anonymous viewer sees no menu", %{conn: conn} do
+    owner = owner_fixture()
+    review = review_fixture(user_id: owner.id)
+
+    {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+    refute has_element?(view, "[data-test=comment-policy-menu]")
+  end
+
+  describe "cross-tab :policy_changed broadcast" do
+    test "anonymous viewer's open tab updates when owner flips policy elsewhere", %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+
+      {:ok, view, html} = live(conn, ~p"/r/#{review.token}")
+      refute html =~ "Sign in to comment"
+
+      {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+
+      _ = render(view)
+      rendered = render(view)
+
+      assert rendered =~ "Login required" or has_element?(view, "[data-test=comment-policy-badge]")
+      refute rendered =~ "Only signed-in users can comment now."
+    end
+
+    test "owner's other tab updates without flash when same owner flips policy in tab A",
+         %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+      conn = log_in(conn, owner)
+
+      {:ok, view_b, _html} = live(conn, ~p"/r/#{review.token}")
+
+      {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+
+      _ = render(view_b)
+      rendered = render(view_b)
+
+      assert rendered =~ "Disabled"
+      refute rendered =~ "turned off for this review"
+    end
+
+    test "no-op update (same policy) does not push a stale render or flash", %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      before = render(view)
+
+      {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :open})
+
+      _ = render(view)
+      assert render(view) == before
+    end
+  end
+end

--- a/test/crit_web/live/review_live_comment_policy_test.exs
+++ b/test/crit_web/live/review_live_comment_policy_test.exs
@@ -27,7 +27,12 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
     {:ok, view, html} = live(conn, ~p"/r/#{review.token}")
     assert has_element?(view, "[data-test=comment-policy-menu]")
     assert has_element?(view, "#comment-policy-menu-panel[role=dialog]")
-    assert has_element?(view, "#comment-policy-menu-trigger[aria-controls=comment-policy-menu-panel]")
+
+    assert has_element?(
+             view,
+             "#comment-policy-menu-trigger[aria-controls=comment-policy-menu-panel]"
+           )
+
     assert has_element?(view, "[data-test=comment-policy-set-disallowed]")
     assert html =~ "Open"
   end
@@ -62,7 +67,10 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
     owner = owner_fixture()
     other = owner_fixture()
     review = review_fixture(user_id: owner.id)
-    {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+
+    {:ok, _} =
+      Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+
     conn = log_in(conn, other)
 
     {:ok, view, html} = live(conn, ~p"/r/#{review.token}")
@@ -82,7 +90,9 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
   test "anonymous viewer in :logged_in_only mode sees the sign-in banner", %{conn: conn} do
     owner = owner_fixture()
     review = review_fixture(user_id: owner.id)
-    {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+
+    {:ok, _} =
+      Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
 
     {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
     assert has_element?(view, ".crit-signin-banner")
@@ -92,7 +102,10 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
   test "authenticated viewer in :logged_in_only mode does NOT see the banner", %{conn: conn} do
     owner = owner_fixture()
     review = review_fixture(user_id: owner.id)
-    {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+
+    {:ok, _} =
+      Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+
     conn = log_in(conn, owner_fixture())
 
     {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
@@ -103,7 +116,9 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
        %{conn: conn} do
     owner = owner_fixture()
     review = review_fixture(user_id: owner.id)
-    {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+
+    {:ok, _} =
+      Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
 
     {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
     refute has_element?(view, ".crit-signin-banner")
@@ -124,12 +139,15 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
       {:ok, view, html} = live(conn, ~p"/r/#{review.token}")
       refute html =~ "Sign in to comment"
 
-      {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
 
       _ = render(view)
       rendered = render(view)
 
-      assert rendered =~ "Login required" or has_element?(view, "[data-test=comment-policy-badge]")
+      assert rendered =~ "Login required" or
+               has_element?(view, "[data-test=comment-policy-badge]")
+
       refute rendered =~ "Only signed-in users can comment now."
     end
 
@@ -141,7 +159,8 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
 
       {:ok, view_b, _html} = live(conn, ~p"/r/#{review.token}")
 
-      {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
 
       _ = render(view_b)
       rendered = render(view_b)
@@ -154,7 +173,10 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
       owner = owner_fixture()
       review = review_fixture(user_id: owner.id)
       conn = log_in(conn, owner)
-      {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+
       {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
 
       view
@@ -172,7 +194,9 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
          %{conn: conn} do
       owner = owner_fixture()
       review = review_fixture(user_id: owner.id)
-      {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
 
       parent =
         Crit.Repo.insert!(%Crit.Comment{

--- a/test/crit_web/live/review_live_comment_policy_test.exs
+++ b/test/crit_web/live/review_live_comment_policy_test.exs
@@ -79,6 +79,43 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
     refute has_element?(view, "[data-test=comment-policy-menu]")
   end
 
+  test "anonymous viewer in :logged_in_only mode sees the sign-in banner", %{conn: conn} do
+    owner = owner_fixture()
+    review = review_fixture(user_id: owner.id)
+    {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+
+    {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+    assert has_element?(view, ".crit-signin-banner")
+    assert has_element?(view, ".crit-signin-banner a", "Sign in")
+  end
+
+  test "authenticated viewer in :logged_in_only mode does NOT see the banner", %{conn: conn} do
+    owner = owner_fixture()
+    review = review_fixture(user_id: owner.id)
+    {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+    conn = log_in(conn, owner_fixture())
+
+    {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+    refute has_element?(view, ".crit-signin-banner")
+  end
+
+  test ":disallowed does NOT show a body banner (header pill carries the signal)",
+       %{conn: conn} do
+    owner = owner_fixture()
+    review = review_fixture(user_id: owner.id)
+    {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+
+    {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+    refute has_element?(view, ".crit-signin-banner")
+  end
+
+  test ":open never shows the banner", %{conn: conn} do
+    owner = owner_fixture()
+    review = review_fixture(user_id: owner.id)
+    {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+    refute has_element?(view, ".crit-signin-banner")
+  end
+
   describe "cross-tab :policy_changed broadcast" do
     test "anonymous viewer's open tab updates when owner flips policy elsewhere", %{conn: conn} do
       owner = owner_fixture()

--- a/test/crit_web/live/review_live_comment_policy_test.exs
+++ b/test/crit_web/live/review_live_comment_policy_test.exs
@@ -301,4 +301,84 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
       assert length(Reviews.list_comments(review.id)) == 2
     end
   end
+
+  # The CSS class `.crit-no-comments` on `.crit-page` hides the gutter "+" and
+  # any new-comment composers (CSS in app.css). It MUST be rendered server-side
+  # from @can_comment? — earlier iterations toggled it from JS in response to a
+  # `policy_changed` push_event, which raced with morphdom and left a stale "+"
+  # visible on the gutter when an owner flipped policy to :disallowed. The
+  # class is the only thing keeping a viewer from clicking "+" on a disallowed
+  # review (the create gates in Reviews still reject the write, but the UI
+  # would visually invite the action).
+  describe "server-rendered .crit-no-comments class" do
+    test ":open viewer (anonymous) does NOT get crit-no-comments", %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      refute has_element?(view, ".crit-page.crit-no-comments")
+    end
+
+    test ":disallowed viewer (anonymous) gets crit-no-comments", %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      assert has_element?(view, ".crit-page.crit-no-comments")
+    end
+
+    test ":disallowed owner gets crit-no-comments (creation gated for everyone)",
+         %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+
+      conn = log_in(conn, owner)
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      assert has_element?(view, ".crit-page.crit-no-comments")
+    end
+
+    test ":logged_in_only anonymous viewer gets crit-no-comments", %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      assert has_element?(view, ".crit-page.crit-no-comments")
+    end
+
+    test ":logged_in_only authed viewer does NOT get crit-no-comments", %{conn: conn} do
+      owner = owner_fixture()
+      other = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+
+      {:ok, _} =
+        Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+
+      conn = log_in(conn, other)
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      refute has_element?(view, ".crit-page.crit-no-comments")
+    end
+
+    test "owner flipping :open → :disallowed adds the class without a reload",
+         %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+      conn = log_in(conn, owner)
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      refute has_element?(view, ".crit-page.crit-no-comments")
+
+      view |> element("[data-test=comment-policy-set-disallowed]") |> render_click()
+
+      assert has_element?(view, ".crit-page.crit-no-comments")
+    end
+  end
 end

--- a/test/crit_web/live/review_live_comment_policy_test.exs
+++ b/test/crit_web/live/review_live_comment_policy_test.exs
@@ -37,6 +37,38 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
     assert html =~ "Open"
   end
 
+  test "trigger icon is a chat bubble regardless of selected policy", %{conn: conn} do
+    user = owner_fixture()
+    review = review_fixture(user_id: user.id)
+
+    {:ok, _} =
+      Reviews.update_review(Scope.for_user(user), review.id, %{comment_policy: :disallowed})
+
+    conn = log_in(conn, user)
+    {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+    trigger_html =
+      view |> element("#comment-policy-menu-trigger") |> render()
+
+    assert trigger_html =~ "hero-chat-bubble-left-right"
+    refute trigger_html =~ "hero-no-symbol"
+  end
+
+  test "selecting a policy option chains a close action onto the click", %{conn: conn} do
+    user = owner_fixture()
+    review = review_fixture(user_id: user.id)
+    conn = log_in(conn, user)
+
+    {:ok, _view, html} = live(conn, ~p"/r/#{review.token}")
+
+    assert html =~ "comment-policy-menu-panel"
+    assert html =~ "data-open"
+    # The option button's phx-click is a JS chain that includes a set_attribute
+    # closing the panel. Asserting the encoded JS contains the panel id is
+    # enough to verify the close-on-select wiring.
+    assert html =~ ~r/phx-click="\[\[.*comment-policy-menu-panel/s
+  end
+
   test "owner can switch to :logged_in_only and the page re-renders without losing preloads",
        %{conn: conn} do
     user = owner_fixture()

--- a/test/crit_web/live/review_live_comment_policy_test.exs
+++ b/test/crit_web/live/review_live_comment_policy_test.exs
@@ -381,4 +381,47 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
       assert has_element?(view, ".crit-page.crit-no-comments")
     end
   end
+
+  # The original .crit-no-comments rule covered .line-add (gutter "+") and the
+  # comment-form selectors but missed two affordances that physically remain
+  # in the DOM and reroute through the JS render on click:
+  #
+  #   - .review-conversation-add-more (review-level "Add comment" button)
+  #   - .file-comment-btn             (per-file "Add file comment" header icon)
+  #
+  # When a viewer clicked either on a :disallowed review, the click handler
+  # fired and the renderer rebuilt the surface, making the button disappear
+  # — visually janky and an invitation to perform an action the server will
+  # reject. JS now skips creating these when ctx.canComment === false; the
+  # CSS rule below is defense in depth so the affordance is hidden even if
+  # the JS gate ever regresses.
+  describe ".crit-no-comments CSS covers all add-comment affordances" do
+    @app_css_path "assets/css/app.css"
+
+    setup do
+      {:ok, css: File.read!(@app_css_path)}
+    end
+
+    test "rule hides the line gutter +", %{css: css} do
+      assert css =~ ".crit-no-comments .line-add"
+    end
+
+    test "rule hides the review-level Add comment button", %{css: css} do
+      assert css =~ ".crit-no-comments .review-conversation-add-more"
+    end
+
+    test "rule hides the per-file Add file comment button", %{css: css} do
+      assert css =~ ".crit-no-comments .file-comment-btn"
+    end
+
+    test "rule hides reply-form (a reply is a new comment)", %{css: css} do
+      assert css =~ ".crit-no-comments .reply-form"
+    end
+
+    test "rule hides the line/file/review composer wrappers", %{css: css} do
+      assert css =~ ".crit-no-comments .comment-form-wrapper"
+      assert css =~ ".crit-no-comments .comment-form"
+      assert css =~ ".crit-no-comments .file-comment-form"
+    end
+  end
 end

--- a/test/crit_web/live/review_live_comment_policy_test.exs
+++ b/test/crit_web/live/review_live_comment_policy_test.exs
@@ -150,6 +150,48 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
       refute rendered =~ "turned off for this review"
     end
 
+    test "add_comment is rejected when comment_policy is :disallowed", %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+      conn = log_in(conn, owner)
+      {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :disallowed})
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+      view
+      |> render_hook("add_comment", %{
+        "body" => "nope",
+        "start_line" => 1,
+        "end_line" => 1,
+        "scope" => "line"
+      })
+
+      assert Reviews.list_comments(review.id) == []
+    end
+
+    test "add_reply is rejected when comment_policy is :logged_in_only and viewer is anonymous",
+         %{conn: conn} do
+      owner = owner_fixture()
+      review = review_fixture(user_id: owner.id)
+      {:ok, _} = Reviews.update_review(Scope.for_user(owner), review.id, %{comment_policy: :logged_in_only})
+
+      parent =
+        Crit.Repo.insert!(%Crit.Comment{
+          review_id: review.id,
+          start_line: 1,
+          end_line: 1,
+          body: "p",
+          scope: "line"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+      view
+      |> render_hook("add_reply", %{"comment_id" => parent.id, "body" => "no"})
+
+      assert [seen] = Reviews.list_comments(review.id)
+      assert seen.id == parent.id
+    end
+
     test "no-op update (same policy) does not push a stale render or flash", %{conn: conn} do
       owner = owner_fixture()
       review = review_fixture(user_id: owner.id)

--- a/test/crit_web/live/review_live_visibility_test.exs
+++ b/test/crit_web/live/review_live_visibility_test.exs
@@ -29,8 +29,8 @@ defmodule CritWeb.ReviewLiveVisibilityTest do
     {:ok, view, html} = live(conn, ~p"/r/#{review.token}")
     assert html =~ "Unlisted"
     assert has_element?(view, "[data-test=visibility-menu]")
-    assert has_element?(view, "#visibility-popover[role=dialog]")
-    assert has_element?(view, "#visibility-trigger[aria-controls=visibility-popover]")
+    assert has_element?(view, "#visibility-menu-panel[role=dialog]")
+    assert has_element?(view, "#visibility-menu-trigger[aria-controls=visibility-menu-panel]")
     assert has_element?(view, "[data-test=make-public][data-confirm]")
     # Copy-pin: a future "soften" of this warning should be a deliberate decision.
     assert html =~ "can&#39;t be undone"


### PR DESCRIPTION
## Summary
- Adds three-state comment policy per review (`:open`, `:logged_in_only`, `:disallowed`) — owner-only toggle via popover next to existing visibility control.
- Extracts shared `PopoverMenu` primitive from PR #169's visibility popover (visibility now uses the same primitive).
- Server-side gates on `create_comment` / `create_reply`; API echoes `comment_policy` and honors it on owner write paths.
- Cross-tab sync via PubSub `policy_changed` broadcast (uses `broadcast_from` to avoid self-deliver).
- Sign-in CTA banner for `:logged_in_only` viewers; affordances physically removed (not just hidden) when commenting is disabled to prevent click-handler races.
- Empty review-conversation section auto-hides when commenting is disabled and no comments exist.

## Review
- [x] Code review: passed (full elixir-expert + frontend-expert pass, intent audit clean, parity 98%)
- [x] Parity audit: hosted-only feature; crit/ correctly unaffected

## Test plan
- 625 tests, 0 failures (\`DB_PORT=5433 mix precommit\`)
- E2E spec covers viewer-side effects (banner, badge, hidden affordances)
- Manual: tested in browser through multiple iterations including cross-tab flips and edge-case clicks on the gutter while toggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)