### PR TITLE
feat: add resolved_round to comments (mirror crit timeline)

### DIFF
--- a/lib/crit/comment.ex
+++ b/lib/crit/comment.ex
@@ -13,6 +13,7 @@ defmodule Crit.Comment do
 
     field :scope, :string, default: "line"
     field :resolved, :boolean, default: false
+    field :resolved_round, :integer
     field :external_id, :string
     belongs_to :review, Crit.Review
     belongs_to :parent, Crit.Comment
@@ -36,6 +37,7 @@ defmodule Crit.Comment do
       :file_path,
       :quote,
       :resolved,
+      :resolved_round,
       :scope,
       :external_id
     ])

--- a/lib/crit/output.ex
+++ b/lib/crit/output.ex
@@ -138,6 +138,7 @@ defmodule Crit.Output do
       author: c.author_display_name,
       review_round: c.review_round,
       resolved: c.resolved,
+      resolved_round: c.resolved_round,
       external_id: c.external_id,
       created_at: DateTime.to_iso8601(c.inserted_at),
       updated_at: DateTime.to_iso8601(c.updated_at),

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -481,6 +481,7 @@ defmodule Crit.Reviews do
         "author_display_name" => resolved_display_name,
         "review_round" => attrs["review_round"] || 1,
         "resolved" => attrs["resolved"] || false,
+        "resolved_round" => attrs["resolved_round"],
         "scope" => scope,
         "external_id" => external_id
       })
@@ -875,12 +876,24 @@ defmodule Crit.Reviews do
            Repo.get_by(Comment, id: comment_id, review_id: review_id) || {:error, :not_found},
          %Review{} = review <- Repo.get(Review, review_id) || {:error, :not_found},
          :ok <- can_resolve_comment?(scope, comment, review) do
-      comment |> Ecto.Changeset.change(resolved: resolved) |> Repo.update()
+      changes = resolve_comment_changes(comment, resolved, review.review_round)
+      comment |> Ecto.Changeset.change(changes) |> Repo.update()
     else
       %Comment{parent_id: parent} when parent != nil -> {:error, :not_found}
       {:error, _} = error -> error
     end
   end
+
+  # Stamp resolved_round on false -> true transition; clear on true -> false.
+  # No-op when already in the target state (preserves prior resolved_round).
+  defp resolve_comment_changes(%Comment{resolved: false}, true, review_round),
+    do: [resolved: true, resolved_round: review_round]
+
+  defp resolve_comment_changes(%Comment{resolved: true}, false, _review_round),
+    do: [resolved: false, resolved_round: nil]
+
+  defp resolve_comment_changes(_comment, resolved, _review_round),
+    do: [resolved: resolved]
 
   defp can_resolve_comment?(%Scope{} = scope, %Comment{} = comment, %Review{} = review) do
     scope_uid = Scope.user_id(scope)
@@ -1017,6 +1030,7 @@ defmodule Crit.Reviews do
       review_round: c.review_round,
       file_path: c.file_path,
       resolved: c.resolved,
+      resolved_round: c.resolved_round,
       external_id: c.external_id,
       created_at: DateTime.to_iso8601(c.inserted_at),
       updated_at: DateTime.to_iso8601(c.updated_at),

--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -313,6 +313,29 @@ defmodule CritWeb.ApiController do
       json(conn, %{user_id: user.id, name: user.name, email: user.email, token: plaintext})
     end
 
+    def seed_resolve(conn, %{"token" => token, "comment_id" => comment_id} = params) do
+      case Reviews.get_by_token(token) do
+        nil ->
+          not_found(conn)
+
+        review ->
+          # Authorize as the review owner if there is one; otherwise use a
+          # visitor scope matching the seed-comment author so resolution is
+          # permitted under the comment-author rule.
+          scope =
+            if review.user_id do
+              Scope.for_user(Crit.Repo.get!(Crit.User, review.user_id))
+            else
+              Scope.for_visitor("integration-test", params["author"] || "WebReviewer")
+            end
+
+          resolved = Map.get(params, "resolved", true)
+
+          {:ok, comment} = Reviews.resolve_comment(scope, comment_id, resolved, review.id)
+          json(conn, Reviews.serialize_comment(comment))
+      end
+    end
+
     def seed_reply(conn, %{"token" => token, "comment_id" => comment_id} = params) do
       case Reviews.get_by_token(token) do
         nil ->

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -153,6 +153,7 @@ defmodule CritWeb.Router do
 
       post "/reviews/:token/seed-comment", ApiController, :seed_comment
       post "/reviews/:token/seed-reply/:comment_id", ApiController, :seed_reply
+      post "/reviews/:token/seed-resolve/:comment_id", ApiController, :seed_resolve
       post "/test/seed-user", ApiController, :seed_user
     end
   end

--- a/priv/repo/migrations/20260505200033_add_resolved_round_to_comments.exs
+++ b/priv/repo/migrations/20260505200033_add_resolved_round_to_comments.exs
@@ -1,0 +1,9 @@
+defmodule Crit.Repo.Migrations.AddResolvedRoundToComments do
+  use Ecto.Migration
+
+  def change do
+    alter table(:comments) do
+      add :resolved_round, :integer
+    end
+  end
+end

--- a/test/crit/reviews_test.exs
+++ b/test/crit/reviews_test.exs
@@ -776,6 +776,29 @@ defmodule Crit.ReviewsTest do
 
       assert updated.resolved == false
     end
+
+    test "stamps resolved_round with the review's current round on resolve", ctx do
+      scope = Scope.for_user(ctx.owner)
+      {:ok, _} = Crit.Repo.update(Ecto.Changeset.change(ctx.review, review_round: 3))
+
+      assert {:ok, updated} =
+               Reviews.resolve_comment(scope, ctx.anon_comment.id, true, ctx.review.id)
+
+      assert updated.resolved == true
+      assert updated.resolved_round == 3
+    end
+
+    test "clears resolved_round on unresolve", ctx do
+      scope = Scope.for_user(ctx.owner)
+      {:ok, _} = Crit.Repo.update(Ecto.Changeset.change(ctx.review, review_round: 2))
+      {:ok, _} = Reviews.resolve_comment(scope, ctx.anon_comment.id, true, ctx.review.id)
+
+      assert {:ok, updated} =
+               Reviews.resolve_comment(scope, ctx.anon_comment.id, false, ctx.review.id)
+
+      assert updated.resolved == false
+      assert updated.resolved_round == nil
+    end
   end
 
   describe "reply CRUD (scope)" do

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -276,6 +276,7 @@ defmodule CritWeb.ApiControllerTest do
             "author_display_name" => "Alice",
             "author_identity" => "alice-123",
             "resolved" => true,
+            "resolved_round" => 2,
             "replies" => [
               %{
                 "body" => "done, added MIT license",
@@ -320,6 +321,7 @@ defmodule CritWeb.ApiControllerTest do
       # First comment: resolved with replies and author (export uses "author" key)
       resolved_comment = Enum.find(comments, &(&1["body"] == "add copyright header"))
       assert resolved_comment["resolved"] == true
+      assert resolved_comment["resolved_round"] == 2
       assert resolved_comment["author"] == "Alice"
       assert resolved_comment["start_line"] == 1
       assert resolved_comment["end_line"] == 1
@@ -338,6 +340,7 @@ defmodule CritWeb.ApiControllerTest do
       # Second comment: unresolved, no replies
       unresolved_comment = Enum.find(comments, &(&1["body"] == "needs error handling"))
       assert unresolved_comment["resolved"] == false
+      assert unresolved_comment["resolved_round"] == nil
       assert unresolved_comment["author"] == "Alice"
       assert unresolved_comment["replies"] == []
     end

--- a/test/crit_web/live/review_live_test.exs
+++ b/test/crit_web/live/review_live_test.exs
@@ -560,6 +560,7 @@ defmodule CritWeb.ReviewLiveTest do
           :review_round,
           :file_path,
           :resolved,
+          :resolved_round,
           :external_id,
           :created_at,
           :updated_at,


### PR DESCRIPTION
## Summary

- Adds `resolved_round` (nullable integer) to the `comments` table to mirror crit's round-faithful timeline data model
- On resolve (`false → true`), stamps the review's current `review_round`; on unresolve (`true → false`), clears to `nil`
- Threads the field through CLI share imports (`replace_comments`, `create_changeset`) and surfaces it in API + export payloads
- `null` semantics: absent = never/currently unresolved; integer = resolved at round N

## Review

- [x] Code review: passed
- [x] Parity audit: matches crit's stamping semantics (`session.go:909`, `comment_cli.go:78`)
- [x] Integration tests: `TestShareSyncResolvedRoundMapping` (crit) + extended `api_controller_test` (crit-web)

## Test plan

- 627 existing tests pass; new `Reviews.resolve_comment/4` tests for stamp/clear; `seed-resolve` test endpoint exercised by crit's share integration suite
- See also: tomasz-tomczyk/crit#467 (consuming integration test)

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)