### PR TITLE
refactor: narrow review_round_snapshot status enum to actual values

### DIFF
--- a/lib/crit/review_round_snapshot.ex
+++ b/lib/crit/review_round_snapshot.ex
@@ -8,7 +8,7 @@ defmodule Crit.ReviewRoundSnapshot do
     field :position, :integer, default: 0
 
     field :status, Ecto.Enum,
-      values: [:added, :modified, :deleted, :renamed, :removed],
+      values: [:modified, :removed],
       default: :modified
 
     belongs_to :review, Crit.Review

--- a/priv/repo/migrations/20260505201901_normalize_review_round_snapshot_status.exs
+++ b/priv/repo/migrations/20260505201901_normalize_review_round_snapshot_status.exs
@@ -1,0 +1,19 @@
+defmodule Crit.Repo.Migrations.NormalizeReviewRoundSnapshotStatus do
+  use Ecto.Migration
+
+  # The schema enum is being narrowed from
+  # [:added, :modified, :deleted, :renamed, :removed] to [:modified, :removed].
+  # Files-mode share (the only producer) only ever emits "modified" or "removed",
+  # so this is a defensive backfill — any rogue values get folded to "modified".
+  def up do
+    execute("""
+    UPDATE review_round_snapshots
+       SET status = 'modified'
+     WHERE status NOT IN ('modified', 'removed')
+    """)
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -66,7 +66,7 @@ if Mix.env() in [:dev, :test] do
           file_path: snap.file_path,
           content: snap.content,
           position: snap[:position] || 0,
-          status: snap[:status] || :added,
+          status: snap[:status] || :modified,
           inserted_at: attrs[:inserted_at_naive] || now_naive
         })
       end
@@ -561,7 +561,7 @@ if Mix.env() in [:dev, :test] do
                   return list(self.data.keys())
           """),
         position: 0,
-        status: :added
+        status: :modified
       },
       # Round 1 — revised with dataclass, error handling, strict mode
       %{


### PR DESCRIPTION
## Summary
- Narrow `ReviewRoundSnapshot.status` enum from `[:added, :modified, :deleted, :renamed, :removed]` to `[:modified, :removed]`
- Only `:modified` and `:removed` are ever produced by crit's files-mode share path; the others were dead schema
- Add defensive backfill migration normalising any non-canonical values to `"modified"`
- Update seeds to use `:modified` instead of `:added`

## Review
- [x] Code review: passed (inline self-review)
- [x] Parity audit: N/A (backend schema only)

## Test plan
- [x] `mix precommit` — 627/627 tests pass
- [x] crit `make e2e-share` against this worktree — 23/23 share integration tests pass, including `TestShareSyncOrphanedFile` (exercises `:removed` path end-to-end)

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)