### PR TITLE
feat: resizable sidebars + draggable comments panel

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2784,6 +2784,44 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 }
 
 
+/* ===== Sidebar Resize Handles ===== */
+/* Thin draggable strip on the inner edge of each sidebar. Default transparent;
+   the brand-color line on hover/drag is the only visual affordance. Sticky so
+   it tracks the viewport vertically while pages scroll. */
+.sidebar-resize-handle {
+  flex: 0 0 4px;
+  align-self: stretch;
+  cursor: col-resize;
+  position: sticky;
+  top: var(--crit-header-height, 53px);
+  height: calc(100vh - var(--crit-header-height, 53px));
+  z-index: 86;
+  background: transparent;
+  transition: background 0.15s ease;
+}
+.sidebar-resize-handle:hover,
+.sidebar-resize-handle:focus-visible,
+.sidebar-resize-handle.dragging {
+  background: var(--crit-brand);
+  outline: none;
+}
+/* Hide the comments-panel resizer when its panel is hidden. */
+.crit-main-layout:has(#commentsPanel.comments-panel-hidden) #commentsPanelResizer,
+.crit-main-layout:has(.comments-panel:not(.comments-panel-open)) #commentsPanelResizer {
+  display: none;
+}
+/* Hide the file-tree resizer when the panel is hidden (single-file mode). */
+.crit-main-layout:has(#fileTreePanel[style*="display:none"]) #fileTreeResizer,
+.crit-main-layout:has(#fileTreePanel[style*="display: none"]) #fileTreeResizer {
+  display: none;
+}
+/* Suppress text selection and force resize cursor while dragging. */
+body.sidebar-resizing,
+body.sidebar-resizing * {
+  user-select: none !important;
+  cursor: col-resize !important;
+}
+
 /* ===== Responsive ===== */
 @media (max-width: 900px) {
   #document-renderer { padding-left: 8px; padding-right: 8px; }
@@ -2796,6 +2834,7 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   .line-content.code-line { white-space: pre-wrap; overflow-wrap: anywhere; }
   .crit-toc, #crit-toc-toggle { display: none !important; }
   .tree-panel { display: none !important; }
+  .sidebar-resize-handle { display: none !important; }
 
   /* Two-row header on mobile */
   .crit-header {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2806,7 +2806,6 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   outline: none;
 }
 /* Hide the comments-panel resizer when its panel is hidden. */
-.crit-main-layout:has(#commentsPanel.comments-panel-hidden) #commentsPanelResizer,
 .crit-main-layout:has(.comments-panel:not(.comments-panel-open)) #commentsPanelResizer {
   display: none;
 }

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -2754,6 +2754,88 @@ function cancelComment(formObj, ctx) {
   render(ctx)
 }
 
+// ===== Sidebar Resize =====
+// File-tree and comments-panel widths are user-resizable via drag handles.
+// Persisted in localStorage (crit-web is served from a stable origin, unlike
+// the local CLI which uses a random port). Only a minimum is enforced —
+// no upper bound; ultrawide users may legitimately want very wide sidebars.
+const SIDEBAR_RESIZE = [
+  { handleId: 'fileTreeResizer',     targetId: 'fileTreePanel',  storageKey: 'crit-file-tree-width',     min: 180, edge: 'right', step: 16 },
+  { handleId: 'commentsPanelResizer', targetId: 'commentsPanel', storageKey: 'crit-comments-panel-width', min: 300, edge: 'left',  step: 16 },
+]
+
+function initSidebarWidths() {
+  SIDEBAR_RESIZE.forEach(function(cfg) {
+    const target = document.getElementById(cfg.targetId)
+    if (!target) return
+    const raw = localStorage.getItem(cfg.storageKey)
+    const saved = raw == null ? NaN : parseInt(raw, 10)
+    if (Number.isFinite(saved) && saved >= cfg.min) {
+      target.style.width = saved + 'px'
+    }
+    const handle = document.getElementById(cfg.handleId)
+    if (handle && !handle.dataset.resizeWired) {
+      attachSidebarResizeHandle(handle, target, cfg)
+      handle.dataset.resizeWired = '1'
+    }
+  })
+}
+
+function attachSidebarResizeHandle(handle, target, cfg) {
+  // Pointer events + setPointerCapture: the handle keeps receiving move/up
+  // events even if the pointer leaves the window, devtools opens, or the
+  // user alt-tabs. Avoids the "stuck dragging" leak that document-level
+  // mousemove listeners suffer from.
+  handle.addEventListener('pointerdown', function(e) {
+    if (e.button !== 0) return
+    e.preventDefault()
+    handle.setPointerCapture(e.pointerId)
+    const startX = e.clientX
+    const startWidth = target.getBoundingClientRect().width
+    // For a left-edge handle (comments panel), dragging right shrinks the panel.
+    const dir = cfg.edge === 'left' ? -1 : 1
+    handle.classList.add('dragging')
+    document.body.classList.add('sidebar-resizing')
+    let lastWidth = startWidth
+
+    function onMove(ev) {
+      const delta = (ev.clientX - startX) * dir
+      const w = Math.max(cfg.min, startWidth + delta)
+      target.style.width = w + 'px'
+      lastWidth = w
+    }
+    function onEnd() {
+      handle.removeEventListener('pointermove', onMove)
+      handle.removeEventListener('pointerup', onEnd)
+      handle.removeEventListener('pointercancel', onEnd)
+      handle.classList.remove('dragging')
+      document.body.classList.remove('sidebar-resizing')
+      try {
+        localStorage.setItem(cfg.storageKey, String(Math.round(lastWidth)))
+      } catch { /* storage unavailable; ignore */ }
+    }
+    handle.addEventListener('pointermove', onMove)
+    handle.addEventListener('pointerup', onEnd)
+    handle.addEventListener('pointercancel', onEnd)
+  })
+
+  // Keyboard resize for a11y: ArrowLeft / ArrowRight nudges by `step` px.
+  // For left-edge handles the direction flips so ArrowRight always shrinks
+  // the controlled panel — matching pointer drag semantics.
+  handle.addEventListener('keydown', function(e) {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+    e.preventDefault()
+    const dir = cfg.edge === 'left' ? -1 : 1
+    const sign = e.key === 'ArrowRight' ? 1 : -1
+    const current = target.getBoundingClientRect().width
+    const w = Math.max(cfg.min, current + sign * dir * cfg.step)
+    target.style.width = w + 'px'
+    try {
+      localStorage.setItem(cfg.storageKey, String(Math.round(w)))
+    } catch { /* storage unavailable; ignore */ }
+  })
+}
+
 function insertSuggestion(textarea, formObj, ctx) {
   let lines
   if (formObj.quote) {
@@ -4576,8 +4658,20 @@ export const DocumentRenderer = {
       toggleExpandAllComments(ctx)
     })
     const mainLayout = document.getElementById('crit-main-layout')
+    // Inject the comments-panel resize handle as a sibling immediately before
+    // the panel — drag the handle to widen/narrow the panel.
+    const commentsResizer = document.createElement('div')
+    commentsResizer.id = 'commentsPanelResizer'
+    commentsResizer.className = 'sidebar-resize-handle'
+    commentsResizer.setAttribute('role', 'separator')
+    commentsResizer.setAttribute('tabindex', '0')
+    commentsResizer.setAttribute('aria-orientation', 'vertical')
+    commentsResizer.setAttribute('aria-label', 'Resize comments panel')
+    mainLayout.appendChild(commentsResizer)
     mainLayout.appendChild(commentsPanel)
     ctx._commentsPanel = commentsPanel
+    ctx._commentsPanelResizer = commentsResizer
+    initSidebarWidths()
     }
 
     // Wire comment count as panel toggle. The button uses phx-click with
@@ -5037,6 +5131,10 @@ export const DocumentRenderer = {
     if (this._commentsPanel) {
       this._commentsPanel.remove()
       this._commentsPanel = null
+    }
+    if (this._commentsPanelResizer) {
+      this._commentsPanelResizer.remove()
+      this._commentsPanelResizer = null
     }
   },
 }

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -4581,6 +4581,7 @@ export const DocumentRenderer = {
       // Already created in this hook instance — nothing to do.
     } else {
     const commentsPanel = document.createElement('div')
+    commentsPanel.id = 'commentsPanel'
     commentsPanel.className = 'comments-panel'
     commentsPanel.innerHTML = `
       <div class="comments-panel-header">

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -550,6 +550,15 @@
       </div>
       <div id="fileTreeBody" class="tree-body"></div>
     </div>
+    <div
+      id="fileTreeResizer"
+      class="sidebar-resize-handle"
+      role="separator"
+      tabindex="0"
+      aria-orientation="vertical"
+      aria-label="Resize file tree"
+    >
+    </div>
 
     <div class="crit-main-content">
       <div id="reviewConversation" class="review-conversation" hidden></div>


### PR DESCRIPTION
## Summary

Closes #164 — ports the resizable file-tree and comments-panel sidebars from crit/ to the hosted review surface.

- Drag the thin handle on the inner edge of either sidebar to resize. Widths persist via `localStorage` (`crit-file-tree-width`, `crit-comments-panel-width`) since crit-web is served from a stable origin.
- Handles use `role="separator"` with `tabindex="0"` and ArrowLeft/ArrowRight keyboard support (16px steps, clamped to min 180 file-tree / 300 comments). No upper bound.
- Hide handle when its panel is hidden; mobile breakpoint hides both.

P1 (Esc-confirm on non-empty comment draft) was already implemented at HEAD via `confirmDiscardIfDirty` — no code change needed.

Companion: tomasz-tomczyk/crit#469 (sibling a11y change for keyboard-accessible handles in the local CLI).

## Review

- [x] Code review: passed (1 drift fixed: focus-visible style ported to crit/, dead selector removed)
- [x] Parity audit: in sync with crit/

## Test plan

- [x] mix compile clean
- [x] mix format clean
- [x] Manual drag verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)