### PR TITLE
fix: close get-prompt modal on backdrop click

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,8 @@ Use `:req` (`Req`) for HTTP requests. **Avoid** `:httpoison`, `:tesla`, `:httpc`
 - `phx-hook="MyHook"` requires a unique `id` and `phx-update="ignore"` if the hook manages its own DOM
 - Use `push_event/3` server→client, `this.pushEvent` client→server
 - For UI toggles (popovers, dropdowns, mobile drawers, tabs), prefer `Phoenix.LiveView.JS` commands declaratively in the template — `JS.toggle_attribute({"hidden", "hidden"}, to: "#el")`, `JS.toggle_attribute({"aria-expanded", "true", "false"})`, `JS.toggle/1`. Pipe them together for multi-step toggles
-- For behaviors `JS` can't express (click-outside, Escape close, focus traps), use a colocated hook scoped to the element. Hooks have lifecycle (`mounted`/`destroyed`) so listeners clean up on unmount
+- For click-outside-to-close, use `phx-click-away={JS.hide(to: "#id")}` on the inner content element. LiveView only fires the binding when the element is visible, so there's no race with the open click — no hook needed
+- For behaviors `JS` still can't express (Escape close, focus traps, document-level dismiss for popovers anchored to a separate trigger), use a colocated hook scoped to the element. Hooks have lifecycle (`mounted`/`destroyed`) so listeners clean up on unmount
 
 ### LiveView tests
 

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -303,7 +303,7 @@
   </div>
 
   <div id="crit-prompt-panel" class="crit-prompt-overlay" style="display:none">
-    <div class="crit-prompt-dialog">
+    <div class="crit-prompt-dialog" phx-click-away={JS.hide(to: "#crit-prompt-panel")}>
       <%= if @prompt_mode == "full_export" do %>
         <h3 class="crit-prompt-title">Full plan + comments</h3>
         <p class="crit-prompt-description">


### PR DESCRIPTION
## Summary
- Add `phx-click-away={JS.hide(to: "#crit-prompt-panel")}` on the prompt dialog body so clicking the backdrop dismisses the "Get prompt" / "Act on comments" overlay.
- Update `AGENTS.md` to recommend `phx-click-away` over a colocated hook for click-outside-to-close (the binding only fires when the bound element is visible, so there's no race with the open click).

## Review
- [x] Code review: passed
- [x] Parity audit: passed

## Test plan
- [ ] Open Get prompt panel, click on the dimmed backdrop → panel closes
- [ ] Click inside the dialog body → panel stays open
- [ ] Open then immediately re-open → no race with the show animation

See also: tomasz-tomczyk/crit#470 (companion fix for the Finish Review modal in crit/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)