### PR TITLE
feat: add raw file view at /r/:token/raw/*file_path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,10 @@ CI runs the same sequence in `.github/workflows/ci.yml` (Postgres 17 service, El
 - `/dashboard`, `/settings` — `live_session :user`, requires authenticated user
 - `/overview` — `live_session :admin`, selfhost admin only
 
+**Browser controllers (noindex):**
+
+- `GET /r/:token/raw/*file_path` — raw file content (text/plain, noindex)
+
 **API (`/api`, all noindex):**
 
 - `POST /reviews` — create review (from CLI share)

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2541,6 +2541,25 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   border: 1px solid var(--crit-badge-removed-border);
 }
 
+.file-header-raw,
+.crit-header-raw {
+  margin-left: 0.5rem;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--crit-editor-fg-muted);
+  text-decoration: none;
+  border: 1px solid var(--crit-border);
+  border-radius: 0.25rem;
+  background: var(--crit-bg-elevated);
+}
+
+.file-header-raw:hover,
+.crit-header-raw:hover {
+  color: var(--crit-fg-primary);
+  background: var(--crit-row-hover);
+}
+
 /* Viewed checkbox in file header */
 .file-header-viewed {
   display: flex;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2541,25 +2541,6 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   border: 1px solid var(--crit-badge-removed-border);
 }
 
-.file-header-raw,
-.crit-header-raw {
-  margin-left: 0.5rem;
-  padding: 0.125rem 0.5rem;
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--crit-editor-fg-muted);
-  text-decoration: none;
-  border: 1px solid var(--crit-border);
-  border-radius: 0.25rem;
-  background: var(--crit-bg-elevated);
-}
-
-.file-header-raw:hover,
-.crit-header-raw:hover {
-  color: var(--crit-fg-primary);
-  background: var(--crit-row-hover);
-}
-
 /* Viewed checkbox in file header */
 .file-header-viewed {
   display: flex;

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1788,7 +1788,7 @@ function renderFileSection(ctx, file) {
       e.preventDefault()
       return
     }
-    if (e.target.closest('.file-header-raw')) {
+    if (e.target.closest('.crit-round-diff-btn')) {
       // Allow the link to navigate; never call e.preventDefault() here.
       return
     }
@@ -1818,7 +1818,7 @@ function renderFileSection(ctx, file) {
     '<svg class="file-header-icon" viewBox="0 0 16 16" fill="var(--crit-editor-fg-muted)"><path fill-rule="evenodd" d="M3.75 1.5a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V6H9.75A1.75 1.75 0 0 1 8 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25V1.75z"/></svg>' +
     '<span class="file-header-name"><span class="dir">' + escapeHtml(dirPath) + '</span>' + escapeHtml(fileName) + '</span>' +
     (file.orphaned ? '<span class="file-header-badge removed">Removed</span>' : '') +
-    '<a class="file-header-raw" href="' + rawHref + '" target="_blank" rel="noopener" title="View raw">Raw</a>'
+    '<a class="crit-round-diff-btn" href="' + rawHref + '" target="_blank" rel="noopener" title="View raw">Raw</a>'
 
   // File comment button — not for orphaned files (no point adding comments to removed files).
   // Also gated on canComment: when policy disallows new comments, don't create the

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1788,6 +1788,10 @@ function renderFileSection(ctx, file) {
       e.preventDefault()
       return
     }
+    if (e.target.closest('.file-header-raw')) {
+      // Allow the link to navigate; never call e.preventDefault() here.
+      return
+    }
     if (section.open) {
       e.preventDefault()
       if (section.getBoundingClientRect().top < 0) {
@@ -1806,11 +1810,15 @@ function renderFileSection(ctx, file) {
   const fileName = dirParts.pop()
   const dirPath = dirParts.length > 0 ? dirParts.join('/') + '/' : ''
 
+  const rawHref = '/r/' + encodeURIComponent(ctx.reviewToken) + '/raw/' +
+    file.path.split('/').map(encodeURIComponent).join('/')
+
   header.innerHTML =
     '<div class="file-header-chevron"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg></div>' +
     '<svg class="file-header-icon" viewBox="0 0 16 16" fill="var(--crit-editor-fg-muted)"><path fill-rule="evenodd" d="M3.75 1.5a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V6H9.75A1.75 1.75 0 0 1 8 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25V1.75z"/></svg>' +
     '<span class="file-header-name"><span class="dir">' + escapeHtml(dirPath) + '</span>' + escapeHtml(fileName) + '</span>' +
-    (file.orphaned ? '<span class="file-header-badge removed">Removed</span>' : '')
+    (file.orphaned ? '<span class="file-header-badge removed">Removed</span>' : '') +
+    '<a class="file-header-raw" href="' + rawHref + '" target="_blank" rel="noopener" title="View raw">Raw</a>'
 
   // File comment button — not for orphaned files (no point adding comments to removed files).
   // Also gated on canComment: when policy disallows new comments, don't create the

--- a/lib/crit_web/controllers/raw_controller.ex
+++ b/lib/crit_web/controllers/raw_controller.ex
@@ -1,0 +1,31 @@
+defmodule CritWeb.RawController do
+  use CritWeb, :controller
+
+  alias Crit.Reviews
+
+  def show(conn, %{"token" => token, "file_path" => path_segments})
+      when is_list(path_segments) do
+    file_path = Enum.join(path_segments, "/")
+
+    with %{} = review <- Reviews.get_by_token(token),
+         %{content: content} = file <-
+           Enum.find(review.files, fn f -> f.file_path == file_path end),
+         basename when basename != :unsafe <- safe_basename(file.file_path) do
+      conn
+      |> put_resp_content_type("text/plain", "utf-8")
+      |> put_resp_header("content-disposition", ~s(inline; filename="#{basename}"))
+      |> send_resp(200, content)
+    else
+      _ -> conn |> put_status(404) |> text("not found")
+    end
+  end
+
+  # Reject any basename containing characters that would break the
+  # content-disposition header (quote, CR, LF) or are control chars.
+  # In practice the CLI never produces these — this is belt-and-braces.
+  defp safe_basename(path) do
+    base = Path.basename(path)
+
+    if String.match?(base, ~r/[\x00-\x1f"\\]/), do: :unsafe, else: base
+  end
+end

--- a/lib/crit_web/controllers/raw_controller.ex
+++ b/lib/crit_web/controllers/raw_controller.ex
@@ -1,13 +1,14 @@
 defmodule CritWeb.RawController do
   use CritWeb, :controller
 
+  alias Crit.Review
   alias Crit.Reviews
 
   def show(conn, %{"token" => token, "file_path" => path_segments})
       when is_list(path_segments) do
     file_path = Enum.join(path_segments, "/")
 
-    with %{} = review <- Reviews.get_by_token(token),
+    with %Review{} = review <- Reviews.get_by_token(token),
          %{content: content} = file <-
            Enum.find(review.files, fn f -> f.file_path == file_path end),
          basename when basename != :unsafe <- safe_basename(file.file_path) do
@@ -20,12 +21,14 @@ defmodule CritWeb.RawController do
     end
   end
 
-  # Reject any basename containing characters that would break the
-  # content-disposition header (quote, CR, LF) or are control chars.
-  # In practice the CLI never produces these — this is belt-and-braces.
+  # RFC 6266 requires the `filename=` parameter to be ASCII. Reject anything
+  # outside printable ASCII (0x20–0x7e), plus the quote and backslash that
+  # would break the quoted-string in the content-disposition header.
+  # We deliberately do NOT emit a `filename*=UTF-8''…` fallback here —
+  # callers with non-ASCII basenames get a 404, which is acceptable.
   defp safe_basename(path) do
     base = Path.basename(path)
 
-    if String.match?(base, ~r/[\x00-\x1f"\\]/), do: :unsafe, else: base
+    if String.match?(base, ~r/[^\x20-\x7e]|["\\]/), do: :unsafe, else: base
   end
 end

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -130,6 +130,18 @@
             <% end %>
           </div>
         <% end %>
+        <%= if length(@review.files) == 1 do %>
+          <% [only_file | _] = @review.files %>
+          <a
+            class="crit-header-raw"
+            href={"/r/" <> @review.token <> "/raw/" <> (only_file.file_path |> String.split("/") |> Enum.map_join("/", &URI.encode/1))}
+            target="_blank"
+            rel="noopener"
+            title="View raw"
+          >
+            Raw
+          </a>
+        <% end %>
       </div>
       <div class="crit-header-actions-right">
         <span id="viewedCount" class="crit-viewed-count" style="display:none"></span>

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -130,18 +130,6 @@
             <% end %>
           </div>
         <% end %>
-        <%= if length(@review.files) == 1 do %>
-          <% [only_file | _] = @review.files %>
-          <a
-            class="crit-round-diff-btn"
-            href={"/r/" <> @review.token <> "/raw/" <> (only_file.file_path |> String.split("/") |> Enum.map_join("/", &URI.encode/1))}
-            target="_blank"
-            rel="noopener"
-            title="View raw"
-          >
-            Raw
-          </a>
-        <% end %>
       </div>
       <div class="crit-header-actions-right">
         <span id="viewedCount" class="crit-viewed-count" style="display:none"></span>
@@ -513,6 +501,18 @@
                 {CritWeb.ReviewLive.comment_policy_label(@comment_policy)}
               </span>
             <% true -> %>
+          <% end %>
+          <%= if length(@review.files) == 1 do %>
+            <% [only_file | _] = @review.files %>
+            <a
+              class="crit-round-diff-btn"
+              href={"/r/" <> @review.token <> "/raw/" <> (only_file.file_path |> String.split("/") |> Enum.map_join("/", &URI.encode/1))}
+              target="_blank"
+              rel="noopener"
+              title="View raw"
+            >
+              Raw
+            </a>
           <% end %>
           <%= if owner? do %>
             <button

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -133,7 +133,7 @@
         <%= if length(@review.files) == 1 do %>
           <% [only_file | _] = @review.files %>
           <a
-            class="crit-header-raw"
+            class="crit-round-diff-btn"
             href={"/r/" <> @review.token <> "/raw/" <> (only_file.file_path |> String.split("/") |> Enum.map_join("/", &URI.encode/1))}
             target="_blank"
             rel="noopener"

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -80,6 +80,8 @@ defmodule CritWeb.Router do
     post "/auth/cli/authorize", DeviceController, :confirm_authorize
     post "/auth/cli/cancel", DeviceController, :cancel
     get "/auth/cli/success", DeviceController, :success
+
+    get "/r/:token/raw/*file_path", RawController, :show
   end
 
   # Review page — visibility-driven noindex/referrer is set in the layout via

--- a/test/crit_web/controllers/raw_controller_test.exs
+++ b/test/crit_web/controllers/raw_controller_test.exs
@@ -69,5 +69,13 @@ defmodule CritWeb.RawControllerTest do
 
       assert response(conn, 200) == "old"
     end
+
+    test "404s when filename contains non-ASCII characters", %{conn: conn} do
+      review = review_fixture(%{files: [file("héllo.txt", "x")]})
+
+      conn = get(conn, "/r/" <> review.token <> "/raw/" <> "héllo.txt")
+
+      assert response(conn, 404)
+    end
   end
 end

--- a/test/crit_web/controllers/raw_controller_test.exs
+++ b/test/crit_web/controllers/raw_controller_test.exs
@@ -1,0 +1,73 @@
+defmodule CritWeb.RawControllerTest do
+  use CritWeb.ConnCase, async: true
+
+  import Crit.ReviewsFixtures
+
+  defp file(path, content, extra \\ %{}) do
+    Map.merge(%{"path" => path, "content" => content}, extra)
+  end
+
+  describe "GET /r/:token/raw/*file_path" do
+    test "returns the file content as text/plain with utf-8", %{conn: conn} do
+      review = review_fixture(%{files: [file("lib/foo.ex", "defmodule Foo, do: :ok\n")]})
+
+      conn = get(conn, ~p"/r/#{review.token}/raw/lib/foo.ex")
+
+      assert response(conn, 200) == "defmodule Foo, do: :ok\n"
+      assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+    end
+
+    test "sets inline content-disposition with the basename", %{conn: conn} do
+      review = review_fixture(%{files: [file("deep/nested/dir/file.txt", "hi")]})
+
+      conn = get(conn, ~p"/r/#{review.token}/raw/deep/nested/dir/file.txt")
+
+      assert get_resp_header(conn, "content-disposition") ==
+               [~s(inline; filename="file.txt")]
+    end
+
+    test "sets x-robots-tag noindex", %{conn: conn} do
+      review = review_fixture(%{files: [file("a.md", "# hi")]})
+
+      conn = get(conn, ~p"/r/#{review.token}/raw/a.md")
+
+      assert get_resp_header(conn, "x-robots-tag") == ["noindex"]
+    end
+
+    test "supports file paths with multiple slashes (glob)", %{conn: conn} do
+      review =
+        review_fixture(%{
+          files: [file("src/app/components/Button.tsx", "export const x = 1")]
+        })
+
+      conn = get(conn, ~p"/r/#{review.token}/raw/src/app/components/Button.tsx")
+
+      assert response(conn, 200) == "export const x = 1"
+    end
+
+    test "404s when the review token is unknown", %{conn: conn} do
+      conn = get(conn, ~p"/r/does-not-exist/raw/foo.txt")
+
+      assert response(conn, 404)
+    end
+
+    test "404s when the file_path is not in the review", %{conn: conn} do
+      review = review_fixture(%{files: [file("real.txt", "x")]})
+
+      conn = get(conn, ~p"/r/#{review.token}/raw/missing.txt")
+
+      assert response(conn, 404)
+    end
+
+    test "serves removed/orphaned file content (still part of the review)", %{conn: conn} do
+      review =
+        review_fixture(%{
+          files: [file("removed.ex", "old", %{"status" => "removed"})]
+        })
+
+      conn = get(conn, ~p"/r/#{review.token}/raw/removed.ex")
+
+      assert response(conn, 200) == "old"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `GET /r/:token/raw/*file_path` controller serves a single review file as `text/plain; charset=utf-8` with `inline; filename="<basename>"` content-disposition. Inherits `noindex` + `referrer-policy: no-referrer` from the existing `:noindex` pipeline.
- ASCII-only basename hardening (`safe_basename/1`) — non-ASCII / control / quote / backslash → 404. RFC 6266 compliance without `filename*=UTF-8''…` complexity.
- "Raw" link UI: per-file in `.file-header` for multi-file reviews (rendered by `document-renderer.js`), and in the review meta-header `<:actions>` slot next to Delete for single-file reviews. Reuses the existing `.crit-round-diff-btn` style.
- Latest-round only (matches `/r/:token` and `GET /api/reviews/:token/document` semantics). Per-round access deferred.
- crit local CLI intentionally not implemented — file is already on disk locally. Documented in monorepo `CLAUDE.md`.

## Review
- [x] Code review: passed (per-task spec + code-quality reviews, plus standalone intent audit)
- [x] Parity audit: N/A (crit-web-only by design)

## Test plan
- 8 controller tests cover: text/plain content, content-disposition basename, x-robots-tag noindex, multi-slash glob paths, unknown-token 404, missing-file 404, removed-file content served, non-ASCII basename 404.
- `mix precommit` clean (635 tests, 0 failures, sobelow no vulns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)