### PR TITLE
fix(security): gate raw file endpoint behind selfhosted OAuth

### DIFF
--- a/lib/crit_web/controllers/raw_controller.ex
+++ b/lib/crit_web/controllers/raw_controller.ex
@@ -4,6 +4,8 @@ defmodule CritWeb.RawController do
   alias Crit.Review
   alias Crit.Reviews
 
+  plug :require_review_scope
+
   def show(conn, %{"token" => token, "file_path" => path_segments})
       when is_list(path_segments) do
     file_path = Enum.join(path_segments, "/")
@@ -20,6 +22,32 @@ defmodule CritWeb.RawController do
       _ -> conn |> put_status(404) |> text("not found")
     end
   end
+
+  # Mirrors `CritWeb.UserAuth.on_mount(:require_review_scope, ...)` for the
+  # plain-controller raw endpoint. On selfhosted+OAuth instances, anonymous
+  # visitors must hit the OAuth login flow with `return_to` set to the raw URL
+  # so the LiveView gate's protection isn't bypassed by the raw endpoint.
+  defp require_review_scope(conn, _opts) do
+    cond do
+      conn.assigns.current_scope.user ->
+        conn
+
+      Crit.Config.selfhosted_oauth?() ->
+        return_to = conn.request_path <> maybe_query(conn.query_string)
+
+        conn
+        |> Phoenix.Controller.redirect(
+          to: "/auth/login?return_to=#{URI.encode_www_form(return_to)}"
+        )
+        |> halt()
+
+      true ->
+        conn
+    end
+  end
+
+  defp maybe_query(""), do: ""
+  defp maybe_query(qs), do: "?" <> qs
 
   # RFC 6266 requires the `filename=` parameter to be ASCII. Reject anything
   # outside printable ASCII (0x20–0x7e), plus the quote and backslash that

--- a/test/crit_web/controllers/raw_controller_test.exs
+++ b/test/crit_web/controllers/raw_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule CritWeb.RawControllerTest do
-  use CritWeb.ConnCase, async: true
+  use CritWeb.ConnCase, async: false
 
   import Crit.ReviewsFixtures
 
@@ -76,6 +76,88 @@ defmodule CritWeb.RawControllerTest do
       conn = get(conn, "/r/" <> review.token <> "/raw/" <> "héllo.txt")
 
       assert response(conn, 404)
+    end
+  end
+
+  describe "auth gate for selfhosted with OAuth" do
+    setup do
+      original_selfhosted = Application.get_env(:crit, :selfhosted)
+      original_oauth = Application.get_env(:crit, :oauth_provider)
+
+      Application.put_env(:crit, :selfhosted, true)
+      Application.put_env(:crit, :oauth_provider, :github)
+
+      on_exit(fn ->
+        if is_nil(original_selfhosted),
+          do: Application.delete_env(:crit, :selfhosted),
+          else: Application.put_env(:crit, :selfhosted, original_selfhosted)
+
+        if is_nil(original_oauth),
+          do: Application.delete_env(:crit, :oauth_provider),
+          else: Application.put_env(:crit, :oauth_provider, original_oauth)
+      end)
+
+      :ok
+    end
+
+    test "redirects unauthenticated visitor to /auth/login with return_to", %{conn: conn} do
+      review = review_fixture(%{files: [file("lib/foo.ex", "secret")]})
+
+      conn = get(conn, ~p"/r/#{review.token}/raw/lib/foo.ex")
+
+      assert redirected_to(conn) =~ "/auth/login"
+      assert redirected_to(conn) =~ "return_to="
+      assert redirected_to(conn) =~ URI.encode_www_form("/r/#{review.token}/raw/lib/foo.ex")
+      # Body must not include the file content.
+      refute response(conn, 302) =~ "secret"
+    end
+
+    test "serves file content when an authenticated user is in the session", %{conn: conn} do
+      review = review_fixture(%{files: [file("lib/foo.ex", "defmodule Foo, do: :ok\n")]})
+
+      {:ok, user} =
+        Crit.Accounts.find_or_create_from_oauth("github", %{
+          "sub" => "raw_uid_#{System.unique_integer()}",
+          "email" => "raw@example.com",
+          "name" => "Raw User"
+        })
+
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{user_id: user.id})
+        |> get(~p"/r/#{review.token}/raw/lib/foo.ex")
+
+      assert response(conn, 200) == "defmodule Foo, do: :ok\n"
+    end
+  end
+
+  describe "without selfhosted+OAuth (public/hosted mode)" do
+    setup do
+      original_selfhosted = Application.get_env(:crit, :selfhosted)
+      original_oauth = Application.get_env(:crit, :oauth_provider)
+
+      Application.put_env(:crit, :selfhosted, false)
+      Application.delete_env(:crit, :oauth_provider)
+
+      on_exit(fn ->
+        if is_nil(original_selfhosted),
+          do: Application.delete_env(:crit, :selfhosted),
+          else: Application.put_env(:crit, :selfhosted, original_selfhosted)
+
+        if is_nil(original_oauth),
+          do: Application.delete_env(:crit, :oauth_provider),
+          else: Application.put_env(:crit, :oauth_provider, original_oauth)
+      end)
+
+      :ok
+    end
+
+    test "raw URL is reachable without auth", %{conn: conn} do
+      review = review_fixture(%{files: [file("lib/foo.ex", "defmodule Foo, do: :ok\n")]})
+
+      conn = get(conn, ~p"/r/#{review.token}/raw/lib/foo.ex")
+
+      assert response(conn, 200) == "defmodule Foo, do: :ok\n"
     end
   end
 end


### PR DESCRIPTION
## Summary
- `/r/:token/raw/*file_path` was reachable unauthenticated on selfhosted+OAuth instances, while `/r/:token` (LiveView) is gated. Same review surface, asymmetric gate — fixes that.
- Adds `plug :require_review_scope` mirroring `UserAuth.on_mount(:require_review_scope, ...)` semantics: redirects to `/auth/login?return_to=<raw url>` when `Crit.Config.selfhosted_oauth?()` and no user.
- Hosted/non-selfhost behavior unchanged (raw stays open, matches the URL-equals-knowledge model).

Surfaced by `/release-audit` against `v0.6.0..main`.

## Test plan
- [x] `mix test test/crit_web/controllers/raw_controller_test.exs` — 11/11
- [x] `mix test` (full suite) — 638/638 pre-nit, re-running locally
- [ ] CI green
- [ ] Manual: spin up selfhosted+OAuth dev instance, hit `/r/<token>/raw/file` unauth → expect redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)