### PR TITLE
fix: frontend audit cleanup (resize leak, a11y, styling regime)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -559,35 +559,6 @@
   vertical-align: baseline;
 }
 
-/* ===== Platform Stats ===== */
-.stat-item {
-  opacity: 0;
-  transform: translateY(12px);
-  transition: opacity 0.6s ease, transform 0.6s ease;
-}
-.stat-item.revealed {
-  opacity: 1;
-  transform: translateY(0);
-}
-.stat-divider {
-  opacity: 0;
-  transition: opacity 0.8s ease 0.3s;
-}
-.stat-divider.revealed {
-  opacity: 1;
-}
-
-/* ===== Features Section ===== */
-.feature-card {
-  opacity: 0;
-  transform: translateY(16px);
-  transition: opacity 0.5s ease, transform 0.5s ease;
-}
-.feature-card.revealed {
-  opacity: 1;
-  transform: translateY(0);
-}
-
 .crit-kbd {
   display: inline-flex;
   align-items: center;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -274,14 +274,16 @@ if (ytFacade) {
   ytFacade.addEventListener("keydown", e => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); activate() }})
 }
 
-// Home page: testimonials scroll-triggered reveal
+// Home page: testimonials scroll-triggered reveal.
+// Cards start at opacity-0/translate-y-4 (Tailwind) and the data-revealed
+// attribute swaps in opacity-100/translate-y-0 via Tailwind data-[revealed]:* variants.
 const testimonialsGrid = document.getElementById("testimonials-grid")
 if (testimonialsGrid) {
   const observer = new IntersectionObserver((entries) => {
     entries.forEach(entry => {
       if (entry.isIntersecting) {
-        testimonialsGrid.querySelectorAll(".feature-card").forEach((card, i) => {
-          setTimeout(() => card.classList.add("revealed"), i * 150)
+        testimonialsGrid.querySelectorAll("[data-reveal]").forEach((card, i) => {
+          setTimeout(() => card.setAttribute("data-revealed", ""), i * 150)
         })
         observer.unobserve(entry.target)
       }
@@ -318,21 +320,12 @@ if (platformStats) {
   const statsObserver = new IntersectionObserver((entries) => {
     entries.forEach(entry => {
       if (entry.isIntersecting) {
-        // Staggered reveal
-        platformStats.querySelectorAll(".stat-item, .stat-divider").forEach((el, i) => {
-          setTimeout(() => el.classList.add("revealed"), i * 100)
+        platformStats.querySelectorAll("[data-count-to]").forEach(el => {
+          countUp(el, parseInt(el.dataset.countTo, 10), formatWithCommas)
         })
-
-        // Count-up after first item reveals
-        setTimeout(() => {
-          platformStats.querySelectorAll("[data-count-to]").forEach(el => {
-            countUp(el, parseInt(el.dataset.countTo, 10), formatWithCommas)
-          })
-          platformStats.querySelectorAll("[data-count-bytes]").forEach(el => {
-            countUp(el, parseInt(el.dataset.countBytes, 10), formatBytes)
-          })
-        }, 150)
-
+        platformStats.querySelectorAll("[data-count-bytes]").forEach(el => {
+          countUp(el, parseInt(el.dataset.countBytes, 10), formatBytes)
+        })
         statsObserver.unobserve(entry.target)
       }
     })

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1354,7 +1354,12 @@ function renderMultiFile(ctx) {
     }
   }
   updateHeaderHeight()
-  // Store reference so destroyed() can clean it up
+  // renderMultiFile runs on every render(ctx) — remove any prior handler
+  // before re-binding so listeners don't accumulate across re-renders.
+  // destroyed() removes the latest one stored on ctx._resizeHandler.
+  if (ctx._resizeHandler) {
+    window.removeEventListener('resize', ctx._resizeHandler)
+  }
   ctx._resizeHandler = updateHeaderHeight
   window.addEventListener('resize', updateHeaderHeight)
 
@@ -4664,9 +4669,6 @@ export const DocumentRenderer = {
     commentsResizer.setAttribute('tabindex', '0')
     commentsResizer.setAttribute('aria-orientation', 'vertical')
     commentsResizer.setAttribute('aria-label', 'Resize comments panel')
-    commentsResizer.setAttribute('aria-valuenow', '50')
-    commentsResizer.setAttribute('aria-valuemin', '0')
-    commentsResizer.setAttribute('aria-valuemax', '100')
     mainLayout.appendChild(commentsResizer)
     mainLayout.appendChild(commentsPanel)
     ctx._commentsPanel = commentsPanel

--- a/lib/crit_web/components/popover_menu.ex
+++ b/lib/crit_web/components/popover_menu.ex
@@ -70,6 +70,8 @@ defmodule CritWeb.Components.PopoverMenu do
         aria-label={@panel_label}
         data-open={to_string(@open?)}
         data-test={"#{@test_prefix}-panel"}
+        phx-window-keydown={close_js(@id)}
+        phx-key="escape"
       >
         {render_slot(@inner_block)}
       </div>

--- a/lib/crit_web/controllers/error_html/404.html.heex
+++ b/lib/crit_web/controllers/error_html/404.html.heex
@@ -81,7 +81,6 @@
       <div class="relative w-full max-w-[380px] aspect-square ml-auto max-md:mx-auto select-none crit-404-stage">
         <svg
           viewBox="0 0 400 400"
-          role="img"
           aria-hidden="true"
           preserveAspectRatio="xMidYMid meet"
           class="w-full h-full block"

--- a/lib/crit_web/controllers/page_html/home.html.heex
+++ b/lib/crit_web/controllers/page_html/home.html.heex
@@ -349,7 +349,8 @@
     <div class="grid grid-cols-2 gap-8 max-sm:grid-cols-1 max-sm:gap-6" id="testimonials-grid">
       <div
         :for={testimonial <- @testimonials}
-        class="feature-card"
+        data-reveal
+        class="opacity-0 translate-y-4 transition-[opacity,transform] duration-500 ease-out data-[revealed]:opacity-100 data-[revealed]:translate-y-0"
       >
         <p class="text-lg font-semibold leading-snug text-(--crit-fg-primary) mb-4">
           {testimonial.highlight}

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -303,9 +303,21 @@
   </div>
 
   <div id="crit-prompt-panel" class="crit-prompt-overlay" style="display:none">
-    <div class="crit-prompt-dialog" phx-click-away={JS.hide(to: "#crit-prompt-panel")}>
+    <%!-- Focus trap is out of scope; Escape and click-away are wired here.
+         phx-window-keydown fires regardless of element visibility, but
+         JS.hide on an already-hidden panel is a no-op, so leaving the
+         binding always-on is safe. --%>
+    <div
+      class="crit-prompt-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="crit-prompt-title"
+      phx-click-away={JS.hide(to: "#crit-prompt-panel")}
+      phx-window-keydown={JS.hide(to: "#crit-prompt-panel")}
+      phx-key="escape"
+    >
       <%= if @prompt_mode == "full_export" do %>
-        <h3 class="crit-prompt-title">Full plan + comments</h3>
+        <h3 id="crit-prompt-title" class="crit-prompt-title">Full plan + comments</h3>
         <p class="crit-prompt-description">
           Paste this prompt into your agent to implement the full plan with comments.
         </p>
@@ -320,7 +332,7 @@
           </button>
         </div>
       <% else %>
-        <h3 class="crit-prompt-title">Act on comments</h3>
+        <h3 id="crit-prompt-title" class="crit-prompt-title">Act on comments</h3>
         <p class="crit-prompt-description">
           Paste this prompt into your agent to address the review comments.
         </p>
@@ -569,9 +581,6 @@
       tabindex="0"
       aria-orientation="vertical"
       aria-label="Resize file tree"
-      aria-valuenow="50"
-      aria-valuemin="0"
-      aria-valuemax="100"
     >
     </div>
 


### PR DESCRIPTION
## Summary
Audit-driven cleanup from `/release-audit` against `v0.6.0..main`. Six findings:

- **P0** — `document-renderer.js`: `renderMultiFile()` leaked a `window` resize listener on every render. Now removes the previous handler before re-binding.
- **P1** — Resize separators had hardcoded `aria-valuenow="50"` never updated during resize. Dropped the value triplet (min is in pixels, no max — fabricating a percentage is worse than omitting); `role="separator"` + `aria-orientation` + `aria-label` + `tabindex` remain.
- **P1** — 404 SVG had conflicting `role="img"` + `aria-hidden="true"`. Removed `role="img"`.
- **P1** — Marketing CSS classes (`.stat-item`, `.stat-divider`, `.feature-card`) violated the "non-review pages = Tailwind only" rule. Removed from `app.css`; replaced `.feature-card` in `home.html.heex` with Tailwind utilities + `data-reveal`/`data-[revealed]:*` variants. IntersectionObserver in `app.js` now targets `[data-reveal]` and toggles a `data-revealed` attribute.
- **P2** — `#crit-prompt-panel` modal a11y: added `role="dialog"`, `aria-modal`, `aria-labelledby`, and Escape-to-close.
- **P2** — `PopoverMenu` Escape-to-close via `phx-window-keydown`.

## Test plan
- [x] `mix compile --warnings-as-errors`
- [ ] CI green
- [ ] Manual: open a multi-file review, resize repeatedly, observe no listener accumulation in DevTools
- [ ] Manual: keyboard-nudge sidebar separators with screen reader on, verify SR no longer announces stale "50%"
- [ ] Manual: open get-prompt modal, press Escape, confirm close
- [ ] Manual: open a popover menu, press Escape, confirm close
- [ ] Manual: scroll homepage feature cards, verify reveal animation still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)