### PR TITLE
fix: use chat icon on disabled/login-required comment policy badge

### DIFF
--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -506,10 +506,7 @@
                 title={"Comments: " <> CritWeb.ReviewLive.comment_policy_label(@comment_policy)}
                 aria-label={"Comments: " <> CritWeb.ReviewLive.comment_policy_label(@comment_policy)}
               >
-                <.icon
-                  name={CritWeb.ReviewLive.comment_policy_icon(@comment_policy)}
-                  class="size-3"
-                />
+                <.icon name="hero-chat-bubble-left-right" class="size-3" />
                 {CritWeb.ReviewLive.comment_policy_label(@comment_policy)}
               </span>
             <% true -> %>

--- a/test/crit_web/live/review_live_comment_policy_test.exs
+++ b/test/crit_web/live/review_live_comment_policy_test.exs
@@ -109,6 +109,10 @@ defmodule CritWeb.ReviewLiveCommentPolicyTest do
     refute has_element?(view, "[data-test=comment-policy-menu]")
     assert has_element?(view, "[data-test=comment-policy-badge]")
     assert html =~ "Disabled"
+
+    badge_html = view |> element("[data-test=comment-policy-badge]") |> render()
+    assert badge_html =~ "hero-chat-bubble-left-right"
+    refute badge_html =~ "hero-no-symbol"
   end
 
   test "anonymous viewer sees no menu", %{conn: conn} do


### PR DESCRIPTION
## Summary
- The non-owner comment-policy badge showed the policy-specific icon (`hero-no-symbol` for disabled, `hero-user` for login-required), making the pill ambiguous out of context — "⊘ Disabled" doesn't read as "comments".
- Hardcode the chat-bubble icon on the badge to match the owner trigger pill above, which already does this for the same reason. The dropdown options keep their distinct icons (those need differentiation).

## Test plan
- [x] Updated existing non-owner badge test to assert the chat-bubble icon
- [x] Full mix precommit passes (638 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)