### PR TITLE
fix: position TOC below header, inline with document

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2837,14 +2837,28 @@ body.sidebar-resizing * {
 }
 
 /* ===== Table of Contents ===== */
+/*
+  Anchor is a zero-height sticky element placed where the document
+  body begins (below the page header + review meta). The TOC is
+  absolutely positioned inside it, so at scroll=0 it appears inline
+  with the document. As the page scrolls past, the anchor sticks
+  just under the sticky page header so the TOC never overlaps it.
+*/
+.crit-toc-anchor {
+  position: sticky;
+  top: 56px;
+  height: 0;
+  z-index: 90;
+  pointer-events: none;
+}
 .crit-toc {
-  position: fixed;
-  top: 72px;
+  position: absolute;
+  top: 0;
   right: 16px;
   width: 210px;
-  max-height: calc(100vh - 88px);
+  max-height: calc(100vh - 72px);
   overflow-y: auto;
-  z-index: 90;
+  pointer-events: auto;
   background: var(--crit-editor-bg-card);
   border: 1px solid var(--crit-border);
   border-radius: 8px;

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -350,20 +350,6 @@
     </div>
   </div>
 
-  <div id="crit-toc" class="crit-toc crit-toc-hidden">
-    <div class="crit-toc-header">
-      <span>Contents</span>
-      <button
-        class="crit-toc-close"
-        title="Close table of contents"
-        aria-label="Close table of contents"
-      >
-        &#x2715;
-      </button>
-    </div>
-    <ul class="crit-toc-list"></ul>
-  </div>
-
   <% owner? = !!(@current_scope.user && @review.user_id == @current_scope.user.id) %>
   <% author = @review.user %>
   <% comment_count =
@@ -565,6 +551,21 @@
     The only dynamic Elixir lives inside `#document-renderer`, which is
     itself phx-update="ignore" and reads its own data-* attrs via the hook.
   --%>
+  <div class="crit-toc-anchor">
+    <div id="crit-toc" class="crit-toc crit-toc-hidden">
+      <div class="crit-toc-header">
+        <span>Contents</span>
+        <button
+          class="crit-toc-close"
+          title="Close table of contents"
+          aria-label="Close table of contents"
+        >
+          &#x2715;
+        </button>
+      </div>
+      <ul class="crit-toc-list"></ul>
+    </div>
+  </div>
   <div id="crit-main-layout" class="crit-main-layout" phx-update="ignore">
     <div id="fileTreePanel" class="tree-panel" style="display:none">
       <div id="treeConversationSection" class="tree-section--conversation"></div>


### PR DESCRIPTION
## Summary
- TOC was overlapping the sticky page header (z-index masked it, but it physically rendered too high).
- Wrap the TOC in a zero-height `position: sticky` anchor placed where the document body begins (after header + review meta), and absolutely position the panel inside it.
- At scroll=0 the TOC sits inline with the document start; on scroll the anchor sticks just below the sticky header so the panel never overlaps it.

## Review
- [x] Code review: passed (CSS/template only, no logic changes)
- [x] Parity audit: N/A — crit/ has no TOC implementation

## Test plan
- mix precommit: 638 tests pass
- e2e/toc.spec.ts selectors (#crit-toc, .crit-toc-list, .crit-toc-hidden) unchanged
- Manual: TOC starts aligned with document content; sticks below header on scroll; mobile breakpoint still hides it

🤖 Generated with [Claude Code](https://claude.com/claude-code)