### PR TITLE
refactor: extract reusable sign_in_button component

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1264,12 +1264,16 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   position: sticky;
   top: var(--crit-header-height, 0px);
   z-index: 99;
+  background: var(--crit-bg-card);
+  border-bottom: 1px solid var(--crit-border);
+}
+.crit-signin-banner-inner {
+  max-width: var(--crit-content-width);
+  margin: 0 auto;
   display: flex;
   align-items: center;
   gap: 12px;
   padding: 10px 24px;
-  background: var(--crit-bg-card);
-  border-bottom: 1px solid var(--crit-border);
 }
 .crit-signin-pill {
   display: inline-flex;
@@ -1288,12 +1292,6 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 .crit-signin-banner-text {
   font-size: 13px;
   color: var(--crit-fg-primary);
-}
-.crit-signin-banner-link {
-  margin-left: auto;
-  font-size: 0.875rem;
-  color: var(--crit-brand);
-  text-decoration: underline;
 }
 
 /* Hide all comment-creation affordances when policy disallows new comments. */
@@ -1497,19 +1495,6 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   font-size: 15px;
   color: var(--crit-editor-fg-muted);
 }
-.crit-signin-btn {
-  background: var(--crit-brand-cta);
-  color: var(--crit-fg-on-brand);
-  border-radius: 6px;
-  padding: 5px 12px;
-  font-size: 13px;
-  font-weight: 500;
-  text-decoration: none;
-}
-.crit-signin-btn:hover {
-  background: var(--crit-brand-cta-hover);
-}
-
 /* ===== Name Pill ===== */
 .crit-name-pill {
   display: inline-flex;

--- a/lib/crit_web/components/layouts.ex
+++ b/lib/crit_web/components/layouts.ex
@@ -294,17 +294,7 @@ defmodule CritWeb.Layouts do
               </div>
             </div>
           <% else %>
-            <a
-              href={~p"/auth/login?return_to=/dashboard"}
-              class="inline-flex items-center gap-1.5 h-[30px] px-3 mr-1.5 rounded-md text-sm font-medium tracking-tight no-underline bg-(--crit-brand-cta) text-white hover:bg-(--crit-brand-cta-hover) transition-colors focus:outline-none focus-visible:shadow-[0_0_0_2px_var(--crit-bg-page),0_0_0_4px_var(--crit-focus-ring)]"
-            >
-              <%= if @github_oauth? do %>
-                <svg viewBox="0 0 16 16" class="size-3.5 fill-current" aria-hidden="true">
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-                </svg>
-              <% end %>
-              Sign in
-            </a>
+            <.sign_in_button class="mr-1.5" />
           <% end %>
 
           <.theme_toggle />
@@ -762,6 +752,34 @@ defmodule CritWeb.Layouts do
 
   defp github_oauth? do
     Application.get_env(:crit, :oauth_provider, [])[:strategy] == Assent.Strategy.Github
+  end
+
+  @doc """
+  Renders the primary "Sign in" CTA button. Shows a GitHub icon when the
+  configured OAuth strategy is GitHub.
+  """
+  attr :return_to, :string, default: "/dashboard"
+  attr :class, :string, default: ""
+
+  def sign_in_button(assigns) do
+    assigns = assign(assigns, :github_oauth?, github_oauth?())
+
+    ~H"""
+    <a
+      href={~p"/auth/login?return_to=#{@return_to}"}
+      class={[
+        "inline-flex items-center gap-1.5 h-[30px] px-3 rounded-md text-sm font-medium tracking-tight no-underline bg-(--crit-brand-cta) text-white hover:bg-(--crit-brand-cta-hover) transition-colors focus:outline-none focus-visible:shadow-[0_0_0_2px_var(--crit-bg-page),0_0_0_4px_var(--crit-focus-ring)]",
+        @class
+      ]}
+    >
+      <%= if @github_oauth? do %>
+        <svg viewBox="0 0 16 16" class="size-3.5 fill-current" aria-hidden="true">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+        </svg>
+      <% end %>
+      Sign in
+    </a>
+    """
   end
 
   defp user_initial(%{name: name}) when is_binary(name) and name != "",

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -90,12 +90,7 @@
             </form>
           </div>
           <%= if @oauth_configured do %>
-            <a
-              href={~p"/auth/login?#{%{return_to: ~p"/r/#{@review.token}"}}"}
-              class="crit-signin-btn"
-            >
-              Sign in
-            </a>
+            <Layouts.sign_in_button return_to={~p"/r/#{@review.token}"} />
           <% end %>
         <% end %>
       </div>
@@ -526,16 +521,16 @@
   </div>
   <%= if @comment_policy == :logged_in_only and not @can_comment? do %>
     <div class="crit-signin-banner" role="status" aria-live="polite" data-test="signin-banner">
-      <div class="crit-signin-pill">
-        <.icon name="hero-user" class="size-3" />
-        <span>Sign-in required</span>
+      <div class="crit-signin-banner-inner">
+        <div class="crit-signin-pill">
+          <.icon name="hero-user" class="size-3" />
+          <span>Sign-in required</span>
+        </div>
+        <span class="crit-signin-banner-text">
+          Only signed-in users can comment on this review.
+        </span>
+        <Layouts.sign_in_button return_to={@current_path} class="ml-auto" />
       </div>
-      <span class="crit-signin-banner-text">
-        Only signed-in users can comment on this review.
-      </span>
-      <a href={~p"/auth/login?return_to=#{@current_path}"} class="crit-signin-banner-link">
-        Sign in
-      </a>
     </div>
   <% end %>
   <%!--


### PR DESCRIPTION
## Summary
- Extract `Layouts.sign_in_button/1` — a single component used in 3 places (marketing site header, review page header, sign-in required banner). Renders the GitHub icon when the configured OAuth strategy is GitHub.
- Sign-in required banner now constrains its inner contents to `--crit-content-width` so they align with the document body below; the colored stripe still spans full width.
- Drop dead CSS: `.crit-signin-btn`, `.crit-signin-btn:hover`, `.crit-signin-banner-link`.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (sign-in flow is crit-web only)

## Test plan
- [x] `mix precommit` — 638 tests pass
- [ ] Manual preview at `/r/:token` while signed-out (banner alignment + button match across all 3 surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)