### PR TITLE
feat: collapse linguist-generated files by default

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -4709,6 +4709,7 @@ export const DocumentRenderer = {
         ctx.multiFile = true
         ctx.files = files.map(f => {
           const orphaned = f.status === 'removed'
+          const generated = f.generated === true
           return {
             path: f.path,
             content: f.content,
@@ -4718,8 +4719,9 @@ export const DocumentRenderer = {
               ? buildCodeLineBlocks(f.content, f.path)
               : buildLineBlocks(md, f.content)),
             comments: comments.filter(c => c.file_path === f.path),
-            collapsed: orphaned,
+            collapsed: orphaned || generated,
             viewed: false,
+            generated,
             status: f.status || 'modified',
             orphaned,
           }

--- a/lib/crit/review_round_snapshot.ex
+++ b/lib/crit/review_round_snapshot.ex
@@ -11,13 +11,15 @@ defmodule Crit.ReviewRoundSnapshot do
       values: [:modified, :removed],
       default: :modified
 
+    field :generated, :boolean, default: false
+
     belongs_to :review, Crit.Review
     timestamps(updated_at: false)
   end
 
   def changeset(snapshot, attrs) do
     snapshot
-    |> cast(attrs, [:round_number, :file_path, :content, :position, :status])
+    |> cast(attrs, [:round_number, :file_path, :content, :position, :status, :generated])
     |> validate_required([:round_number, :file_path])
     |> then(fn cs ->
       if Ecto.Changeset.get_field(cs, :status) == :removed do

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -428,11 +428,15 @@ defmodule Crit.Reviews do
   defp content_changed?(review, new_files) do
     current =
       get_current_files(review)
-      |> Map.new(fn f -> {f.file_path, :crypto.hash(:sha256, f.content)} end)
+      |> Map.new(fn f ->
+        {f.file_path, {:crypto.hash(:sha256, f.content), f.generated == true}}
+      end)
 
     incoming =
       new_files
-      |> Map.new(fn f -> {f["path"], :crypto.hash(:sha256, f["content"] || "")} end)
+      |> Map.new(fn f ->
+        {f["path"], {:crypto.hash(:sha256, f["content"] || ""), f["generated"] == true}}
+      end)
 
     current != incoming
   end
@@ -568,7 +572,8 @@ defmodule Crit.Reviews do
           "content" => file_attrs["content"] || "",
           "round_number" => round_number,
           "position" => idx,
-          "status" => status
+          "status" => status,
+          "generated" => file_attrs["generated"] == true
         })
         |> Ecto.Changeset.put_change(:review_id, review.id)
         |> Repo.insert()

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -38,7 +38,13 @@ defmodule CritWeb.ReviewLive do
 
         files_data =
           Enum.map(review.files, fn f ->
-            %{path: f.file_path, content: f.content, position: f.position, status: f.status}
+            %{
+              path: f.file_path,
+              content: f.content,
+              position: f.position,
+              status: f.status,
+              generated: f.generated
+            }
           end)
 
         socket =

--- a/priv/repo/migrations/20260508120000_add_generated_to_review_round_snapshots.exs
+++ b/priv/repo/migrations/20260508120000_add_generated_to_review_round_snapshots.exs
@@ -1,0 +1,9 @@
+defmodule Crit.Repo.Migrations.AddGeneratedToReviewRoundSnapshots do
+  use Ecto.Migration
+
+  def change do
+    alter table(:review_round_snapshots) do
+      add :generated, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/crit/reviews_test.exs
+++ b/test/crit/reviews_test.exs
@@ -939,6 +939,62 @@ defmodule Crit.ReviewsTest do
     end
   end
 
+  describe "generated flag on round snapshots" do
+    test "persists generated: true through create_review" do
+      scope = anon_scope()
+
+      {:ok, review} =
+        Reviews.create_review(
+          scope,
+          [
+            %{"path" => "gen.md", "content" => "auto", "generated" => true},
+            %{"path" => "src.md", "content" => "human"}
+          ],
+          1,
+          [],
+          []
+        )
+
+      reloaded = Reviews.get_by_token(review.token)
+      by_path = Map.new(reloaded.files, &{&1.file_path, &1})
+      assert by_path["gen.md"].generated == true
+      assert by_path["src.md"].generated == false
+    end
+
+    test "missing generated key defaults to false" do
+      scope = anon_scope()
+
+      {:ok, review} =
+        Reviews.create_review(scope, [%{"path" => "f.md", "content" => "v1"}], 1, [], [])
+
+      reloaded = Reviews.get_by_token(review.token)
+      assert hd(reloaded.files).generated == false
+    end
+
+    test "upsert_review treats a generated-flag flip as a content change" do
+      scope = anon_scope()
+
+      {:ok, review} =
+        Reviews.create_review(
+          scope,
+          [%{"path" => "f.md", "content" => "same", "generated" => false}],
+          1,
+          [],
+          []
+        )
+
+      {:ok, :updated, updated} =
+        Reviews.upsert_review(scope, review.token, review.delete_token, %{
+          "files" => [%{"path" => "f.md", "content" => "same", "generated" => true}],
+          "comments" => []
+        })
+
+      assert updated.review_round == review.review_round + 1
+      reloaded = Reviews.get_by_token(review.token)
+      assert hd(reloaded.files).generated == true
+    end
+  end
+
   describe "review_round_snapshot" do
     test "create_round_snapshot/4 stores file content for a round" do
       scope = anon_scope()

--- a/test/crit_web/live/review_live_test.exs
+++ b/test/crit_web/live/review_live_test.exs
@@ -59,6 +59,26 @@ defmodule CritWeb.ReviewLiveTest do
       {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
       assert page_title(view) =~ "main.go"
     end
+
+    test "init push_event includes generated flag for each file", %{conn: conn} do
+      {:ok, review} =
+        Reviews.create_review(
+          anon_scope(),
+          [
+            %{"path" => "schema.pb.go", "content" => "auto", "generated" => true},
+            %{"path" => "main.go", "content" => "pkg main"}
+          ],
+          0,
+          []
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      assert_push_event view, "init", %{files: files}
+
+      by_path = Map.new(files, &{&1.path, &1})
+      assert by_path["schema.pb.go"].generated == true
+      assert by_path["main.go"].generated == false
+    end
   end
 
   describe "add_comment with file_path" do


### PR DESCRIPTION
## Summary

Server side of [tomasz-tomczyk/crit#503](https://github.com/tomasz-tomczyk/crit/issues/503): persist a per-file `generated` boolean on `review_round_snapshots`, sourced from the crit CLI's share payload (computed there from `.gitattributes linguist-generated`). Pipe it through to the LiveView init payload so `document-renderer.js` starts matching files collapsed.

- New migration: `generated boolean default false not null` on `review_round_snapshots`
- `Reviews.content_changed?` now treats a flag flip as a content change so the round bumps even when content is identical
- `document-renderer.js` initializes `collapsed = orphaned || generated`, mirroring the local CLI's behavior (parity 100%)

The CLI may not yet send `generated` (rolls out gradually) — the flag defaults to `false` when missing.

## Review

- [x] Code review: passed
- [x] Parity audit: passed — pairs with tomasz-tomczyk/crit#504

## Test plan

- New ExUnit tests cover persistence, default-false, flag-flip-as-change, LiveView push
- mix precommit passes (3 pre-existing accounts_test flakes unrelated)

Pairs with: tomasz-tomczyk/crit#504 (closes tomasz-tomczyk/crit#503)

🤖 Generated with [Claude Code](https://claude.com/claude-code)