### PR TITLE
port .comment-body img rule for crit#505 parity

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -999,6 +999,7 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 .comment-body code { background: var(--crit-editor-bg-elevated); padding: 1px 5px; border-radius: 3px; font-size: 0.9em; }
 .comment-body pre { background: var(--crit-editor-bg-elevated); padding: 8px 10px; border-radius: 4px; overflow-x: auto; margin: 0.5em 0; }
 .comment-body pre code { background: none; padding: 0; }
+.comment-body img { max-width: 100%; height: auto; border-radius: 4px; border: 1px solid var(--crit-border); margin: 4px 0; display: block; }
 
 /* Suggestion diff inside comments */
 .suggestion-diff {


### PR DESCRIPTION
## Summary

Mirrors the `.comment-body img` rule added to `crit/frontend/style.css` in [crit#505](https://github.com/tomasz-tomczyk/crit/pull/505), which introduces image paste into comments. Pasted screenshots ride along in the share payload as `data:` URIs, so they render in shared reviews on crit-web — but without this rule they render unstyled (overflow past the comment column, no border, no rounding, inline-flow rather than block).

The `crit-mono` CLAUDE.md mandates parity for review-page styles between `crit/frontend/style.css` and `crit-web/assets/css/app.css`. This PR upholds that contract.

## Changes

- `assets/css/app.css`: add `.comment-body img { max-width: 100%; height: auto; border-radius: 4px; border: 1px solid var(--crit-border); margin: 4px 0; display: block; }` adjacent to the existing `.comment-body` rules.

Custom CSS only — no Tailwind/daisyUI on the review surface.

## Coordination

Should land **alongside** [crit#505](https://github.com/tomasz-tomczyk/crit/pull/505). Do not merge until that PR lands — kept as draft until then.

## Test plan

- [ ] crit#505 merges
- [ ] Verify pasted-image comment in a shared review renders bordered, rounded, block, no horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)