### PR TITLE
fix: keyboard-nav line highlight visible in light mode

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -73,7 +73,7 @@
   --crit-brand-hover:     #89b4fa;
   --crit-brand-subtle:    rgba(122,162,247,0.10);
   --crit-brand-bg:        rgba(122,162,247,0.15);
-  --crit-line-focus-bg:   rgba(122,162,247,0.18);
+  --crit-line-focus-bg:   rgba(122,162,247,0.10);
   --crit-brand-cta:       #406fcc;
   --crit-brand-cta-hover: #4574cc;
 
@@ -197,7 +197,7 @@
   --crit-brand-hover:     #89b4fa;
   --crit-brand-subtle:    rgba(122,162,247,0.10);
   --crit-brand-bg:        rgba(122,162,247,0.15);
-  --crit-line-focus-bg:   rgba(122,162,247,0.18);
+  --crit-line-focus-bg:   rgba(122,162,247,0.10);
   --crit-brand-cta:       #406fcc;
   --crit-brand-cta-hover: #4574cc;
 
@@ -316,7 +316,7 @@
   --crit-brand-hover:     #396ec6;
   --crit-brand-subtle:    rgba(41,96,188,0.08);
   --crit-brand-bg:        rgba(41,96,188,0.12);
-  --crit-line-focus-bg:   rgba(41,96,188,0.18);
+  --crit-line-focus-bg:   rgba(41,96,188,0.10);
   --crit-brand-cta:       #3a72d4;
   --crit-brand-cta-hover: #3568c8;
 
@@ -437,7 +437,7 @@
     --crit-brand-hover:     #4a80de;
     --crit-brand-subtle:    rgba(58,114,212,0.08);
     --crit-brand-bg:        rgba(58,114,212,0.12);
-    --crit-line-focus-bg:   rgba(58,114,212,0.18);
+    --crit-line-focus-bg:   rgba(58,114,212,0.10);
     --crit-brand-cta:       #3a72d4;
     --crit-brand-cta-hover: #3568c8;
 
@@ -813,7 +813,10 @@
 .line-block.selected { background: var(--crit-brand-subtle); }
 .line-block.form-selected { background: var(--crit-brand-subtle); }
 /* Block focus highlight */
-.line-block.focused { background: var(--crit-line-focus-bg); }
+.line-block.focused {
+  background: var(--crit-line-focus-bg);
+  box-shadow: inset 2px 0 0 var(--crit-brand);
+}
 .line-block.focused .line-gutter { background: var(--crit-line-focus-bg); }
 
 /* ===== Gutter ===== */

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -73,6 +73,7 @@
   --crit-brand-hover:     #89b4fa;
   --crit-brand-subtle:    rgba(122,162,247,0.10);
   --crit-brand-bg:        rgba(122,162,247,0.15);
+  --crit-line-focus-bg:   rgba(122,162,247,0.18);
   --crit-brand-cta:       #406fcc;
   --crit-brand-cta-hover: #4574cc;
 
@@ -196,6 +197,7 @@
   --crit-brand-hover:     #89b4fa;
   --crit-brand-subtle:    rgba(122,162,247,0.10);
   --crit-brand-bg:        rgba(122,162,247,0.15);
+  --crit-line-focus-bg:   rgba(122,162,247,0.18);
   --crit-brand-cta:       #406fcc;
   --crit-brand-cta-hover: #4574cc;
 
@@ -314,6 +316,7 @@
   --crit-brand-hover:     #396ec6;
   --crit-brand-subtle:    rgba(41,96,188,0.08);
   --crit-brand-bg:        rgba(41,96,188,0.12);
+  --crit-line-focus-bg:   rgba(41,96,188,0.18);
   --crit-brand-cta:       #3a72d4;
   --crit-brand-cta-hover: #3568c8;
 
@@ -434,6 +437,7 @@
     --crit-brand-hover:     #4a80de;
     --crit-brand-subtle:    rgba(58,114,212,0.08);
     --crit-brand-bg:        rgba(58,114,212,0.12);
+    --crit-line-focus-bg:   rgba(58,114,212,0.18);
     --crit-brand-cta:       #3a72d4;
     --crit-brand-cta-hover: #3568c8;
 
@@ -809,8 +813,8 @@
 .line-block.selected { background: var(--crit-brand-subtle); }
 .line-block.form-selected { background: var(--crit-brand-subtle); }
 /* Block focus highlight */
-.line-block.focused { background: var(--crit-editor-bg-elevated); }
-.line-block.focused .line-gutter { background: var(--crit-editor-bg-elevated); }
+.line-block.focused { background: var(--crit-line-focus-bg); }
+.line-block.focused .line-gutter { background: var(--crit-line-focus-bg); }
 
 /* ===== Gutter ===== */
 .line-gutter {


### PR DESCRIPTION
## Summary
- Mirrors crit fix for tomasz-tomczyk/crit#506.
- `.line-block.focused` previously used `--crit-editor-bg-elevated` (gray, low contrast against light page background).
- Introduce `--crit-line-focus-bg` at 18% brand-color opacity in all 4 theme blocks; `.line-block.focused` (and its gutter) now use it.

## Test plan
- [ ] Visual: light mode shows clear highlight on focused line

See also: tomasz-tomczyk/crit#507

🤖 Generated with [Claude Code](https://claude.com/claude-code)