### PR TITLE
feat: vim-style visual line mode (V) for multi-line comments

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -819,6 +819,13 @@
 }
 .line-block.focused .line-gutter { background: var(--crit-line-focus-bg); }
 
+/* Visual line mode: recolor the focused block's left accent so it's clearly
+   distinct from the default j/k cursor, signalling that j/k now extends the
+   selection instead of moving focus. Mirrors crit/frontend/style.css. */
+body.visual-mode .line-block.focused {
+  box-shadow: inset 3px 0 0 var(--crit-orange);
+}
+
 /* ===== Gutter ===== */
 .line-gutter {
   position: relative;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -82,6 +82,7 @@
   --crit-red:    #f7768e;
   --crit-orange: #ff9e64;
   --crit-yellow: #e0af68;
+  --crit-visual-accent: #e0af68;
 
   /* ---- Borders ---- */
   --crit-border:         #232632;
@@ -206,6 +207,7 @@
   --crit-red:    #f7768e;
   --crit-orange: #ff9e64;
   --crit-yellow: #e0af68;
+  --crit-visual-accent: #e0af68;
 
   /* ---- Borders ---- */
   --crit-border:         #232632;
@@ -325,6 +327,7 @@
   --crit-red:    #cf222e;
   --crit-orange: #bc4c00;
   --crit-yellow: #7a5800;
+  --crit-visual-accent: #b8860b;
 
   /* ---- Borders ---- */
   --crit-border:         #d8dee4;
@@ -446,7 +449,8 @@
     --crit-red:    #cf222e;
     --crit-orange: #bc4c00;
     --crit-yellow: #7a5800;
-  
+    --crit-visual-accent: #b8860b;
+
     /* ---- Borders ---- */
     --crit-border:         #d8dee4;
     --crit-border-strong:  #bac3cf;
@@ -821,9 +825,11 @@
 
 /* Visual line mode: recolor the focused block's left accent so it's clearly
    distinct from the default j/k cursor, signalling that j/k now extends the
-   selection instead of moving focus. Mirrors crit/frontend/style.css. */
+   selection instead of moving focus. Mirrors crit/frontend/style.css. Uses a
+   dedicated --crit-visual-accent so we don't conflate it with the modified-
+   line indicator (--crit-orange) or modified-file badges (--crit-yellow). */
 body.visual-mode .line-block.focused {
-  box-shadow: inset 3px 0 0 var(--crit-orange);
+  box-shadow: inset 3px 0 0 var(--crit-visual-accent);
 }
 
 /* ===== Gutter ===== */

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -677,12 +677,14 @@ function enterVisualMode(ctx) {
   }
   ctx.selectionStart = block.startLine
   ctx.selectionEnd = block.endLine
+  document.body.classList.add('visual-mode')
   refreshVisualSelectionVisuals(ctx)
 }
 
 function exitVisualMode(ctx, clearSelection) {
   if (!ctx.visualMode) return
   ctx.visualMode = null
+  document.body.classList.remove('visual-mode')
   if (clearSelection) {
     ctx.selectionStart = null
     ctx.selectionEnd = null
@@ -5121,6 +5123,7 @@ export const DocumentRenderer = {
               const startLine = ctx.selectionStart
               const endLine = ctx.selectionEnd
               ctx.visualMode = null
+              document.body.classList.remove('visual-mode')
               openForm(ctx, {
                 afterBlockIndex: lastBlockIndex,
                 startLine: startLine,
@@ -5215,6 +5218,7 @@ export const DocumentRenderer = {
     this.visualMode = null
     this.selectionStart = null
     this.selectionEnd = null
+    document.body.classList.remove('visual-mode')
     if (this._scrollHandler) {
       window.removeEventListener("scroll", this._scrollHandler)
     }

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -5111,22 +5111,24 @@ export const DocumentRenderer = {
             const lineBlocks = fp
               ? (ctx.files.find(f => f.path === fp)?.lineBlocks || [])
               : ctx.lineBlocks
-            let lastBlockIndex = 0
+            let lastBlockIndex = -1
             for (let i = 0; i < lineBlocks.length; i++) {
               if (lineBlocks[i].startLine >= ctx.selectionStart && lineBlocks[i].endLine <= ctx.selectionEnd) {
                 lastBlockIndex = i
               }
             }
-            const startLine = ctx.selectionStart
-            const endLine = ctx.selectionEnd
-            ctx.visualMode = null
-            openForm(ctx, {
-              afterBlockIndex: lastBlockIndex,
-              startLine: startLine,
-              endLine: endLine,
-              editingId: null,
-              filePath: fp,
-            })
+            if (lastBlockIndex >= 0) {
+              const startLine = ctx.selectionStart
+              const endLine = ctx.selectionEnd
+              ctx.visualMode = null
+              openForm(ctx, {
+                afterBlockIndex: lastBlockIndex,
+                startLine: startLine,
+                endLine: endLine,
+                editingId: null,
+                filePath: fp,
+              })
+            }
             break
           }
           // If text is selected, comment on the selection (with quote).
@@ -5209,6 +5211,10 @@ export const DocumentRenderer = {
 
   destroyed() {
     document.body.classList.remove("dragging")
+    // Drop any visual-mode state so a remount starts clean.
+    this.visualMode = null
+    this.selectionStart = null
+    this.selectionEnd = null
     if (this._scrollHandler) {
       window.removeEventListener("scroll", this._scrollHandler)
     }

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -664,6 +664,68 @@ function clearFocus(ctx) {
   if (prev) prev.classList.remove('focused')
 }
 
+// Vim-style visual line mode: anchor on the focused block, extend with j/k.
+function enterVisualMode(ctx) {
+  if (ctx.focusedBlockIndex < 0) return
+  const lineBlocks = getFocusedLineBlocks(ctx)
+  const block = lineBlocks[ctx.focusedBlockIndex]
+  if (!block) return
+  ctx.visualMode = {
+    anchorStartLine: block.startLine,
+    anchorEndLine: block.endLine,
+    filePath: ctx.focusedFilePath || null,
+  }
+  ctx.selectionStart = block.startLine
+  ctx.selectionEnd = block.endLine
+  refreshVisualSelectionVisuals(ctx)
+}
+
+function exitVisualMode(ctx, clearSelection) {
+  if (!ctx.visualMode) return
+  ctx.visualMode = null
+  if (clearSelection) {
+    ctx.selectionStart = null
+    ctx.selectionEnd = null
+    refreshVisualSelectionVisuals(ctx)
+  }
+}
+
+function extendVisualSelection(ctx) {
+  if (!ctx.visualMode || ctx.focusedBlockIndex < 0) return
+  const blocks = ctx.el.querySelectorAll('.line-block')
+  const focused = blocks[ctx.focusedBlockIndex]
+  if (!focused) return
+  const focusedFp = focused.dataset.filePath || null
+  if (focusedFp !== (ctx.visualMode.filePath || null)) {
+    // Crossed file boundary — exit visual mode.
+    exitVisualMode(ctx, true)
+    return
+  }
+  const sLine = parseInt(focused.dataset.startLine)
+  const eLine = parseInt(focused.dataset.endLine)
+  ctx.selectionStart = Math.min(ctx.visualMode.anchorStartLine, sLine)
+  ctx.selectionEnd = Math.max(ctx.visualMode.anchorEndLine, eLine)
+  refreshVisualSelectionVisuals(ctx)
+}
+
+// Toggle .selected on line-blocks for the currently active visual selection
+// without re-rendering the whole tree. A full render replaces .line-block nodes
+// and breaks the focusedBlockIndex / DOM-position contract j/k relies on.
+function refreshVisualSelectionVisuals(ctx) {
+  const blocks = ctx.el.querySelectorAll('.line-block')
+  const fp = ctx.visualMode ? (ctx.visualMode.filePath || null) : null
+  for (let i = 0; i < blocks.length; i++) {
+    const lb = blocks[i]
+    const lbFp = lb.dataset.filePath || null
+    const sLine = parseInt(lb.dataset.startLine)
+    const eLine = parseInt(lb.dataset.endLine)
+    const matches = ctx.selectionStart !== null && ctx.selectionEnd !== null
+      && (fp === null || lbFp === fp)
+      && sLine >= ctx.selectionStart && eLine <= ctx.selectionEnd
+    lb.classList.toggle('selected', matches)
+  }
+}
+
 function formatTime(isoStr) {
   if (!isoStr) return ""
   const d = new Date(isoStr)
@@ -4370,6 +4432,7 @@ function renderShortcutsPane() {
     { label: 'Navigation', shortcuts: [
       { key: '<kbd>j</kbd>', action: 'Next block' },
       { key: '<kbd>k</kbd>', action: 'Previous block' },
+      { key: '<kbd>Shift</kbd>+<kbd>V</kbd>', action: 'Visual line mode (extend with j/k, then c to comment)' },
       { key: '<kbd>]</kbd>', action: 'Next comment' },
       { key: '<kbd>[</kbd>', action: 'Previous comment' },
     ]},
@@ -4469,6 +4532,9 @@ export const DocumentRenderer = {
     ctx.selectionEnd = null
     ctx.activeForms = []
     ctx.dragState = null
+    // Vim-style visual line mode (entered with Shift+V).
+    // null or { anchorBlockIndex, anchorStartLine, anchorEndLine, filePath }
+    ctx.visualMode = null
     ctx.focusedBlockIndex = -1
     ctx.identity = ctx.el.dataset.identity || ""
     ctx.userId = ctx.el.dataset.userId || ""
@@ -5017,16 +5083,52 @@ export const DocumentRenderer = {
           e.preventDefault()
           const next = ctx.focusedBlockIndex < blockCount - 1 ? ctx.focusedBlockIndex + 1 : 0
           focusBlock(ctx, next)
+          if (ctx.visualMode) extendVisualSelection(ctx)
           break
         }
         case 'k': {
           e.preventDefault()
           const prev = ctx.focusedBlockIndex > 0 ? ctx.focusedBlockIndex - 1 : blockCount - 1
           focusBlock(ctx, prev)
+          if (ctx.visualMode) extendVisualSelection(ctx)
+          break
+        }
+        case 'V': {
+          if (!e.shiftKey) break
+          e.preventDefault()
+          if (ctx.visualMode) {
+            exitVisualMode(ctx, true)
+          } else {
+            enterVisualMode(ctx)
+          }
           break
         }
         case 'c': {
           e.preventDefault()
+          // Visual mode: comment on the active selection.
+          if (ctx.visualMode && ctx.selectionStart !== null && ctx.selectionEnd !== null) {
+            const fp = ctx.visualMode.filePath
+            const lineBlocks = fp
+              ? (ctx.files.find(f => f.path === fp)?.lineBlocks || [])
+              : ctx.lineBlocks
+            let lastBlockIndex = 0
+            for (let i = 0; i < lineBlocks.length; i++) {
+              if (lineBlocks[i].startLine >= ctx.selectionStart && lineBlocks[i].endLine <= ctx.selectionEnd) {
+                lastBlockIndex = i
+              }
+            }
+            const startLine = ctx.selectionStart
+            const endLine = ctx.selectionEnd
+            ctx.visualMode = null
+            openForm(ctx, {
+              afterBlockIndex: lastBlockIndex,
+              startLine: startLine,
+              endLine: endLine,
+              editingId: null,
+              filePath: fp,
+            })
+            break
+          }
           // If text is selected, comment on the selection (with quote).
           // Otherwise fall back to the focused block.
           if (ctx._tryOpenFormFromSelection && ctx._tryOpenFormFromSelection()) break
@@ -5093,6 +5195,8 @@ export const DocumentRenderer = {
           if (ctx.activeForms.length > 0) {
             const top = ctx.activeForms[ctx.activeForms.length - 1]
             if (confirmDiscardIfDirty(top)) cancelComment(top, ctx)
+          } else if (ctx.visualMode) {
+            exitVisualMode(ctx, true)
           } else if (ctx.focusedBlockIndex >= 0) {
             clearFocus(ctx)
           }


### PR DESCRIPTION
## Summary

Mirror of [tomasz-tomczyk/crit#510](https://github.com/tomasz-tomczyk/crit/pull/510) for the hosted renderer.

Adds vim-style **visual line mode** to the shared review at `/r/:token`: **Shift+V** anchors on the focused line-block, **j/k** extend the selection, **c** opens a comment form spanning the range, **Esc** clears and leaves focus on the furthest expansion line.

The focused block's left accent turns amber (new `--crit-visual-accent` theme var, dark `#e0af68` / light `#b8860b`) while in visual mode so j/k reads as 'extending selection' rather than 'moving focus'.

Selection visuals update in place to avoid invalidating the `.line-block` DOM nodes that j/k navigation indexes into. `destroyed()` clears visual-mode state so a LiveView remount starts clean.

## Test plan

- [x] mix compile --warnings-as-errors clean
- [x] mix format clean
- [x] mix test clean (3 unrelated pre-existing failures in `accounts_test.exs`)
- [ ] Human testing of visual mode in shared review

🤖 Generated with [Claude Code](https://claude.com/claude-code)