### PR TITLE
fix: split nested list items into individual line blocks

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -926,6 +926,13 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 .line-content li { margin: 0; }
 .line-content li::marker { color: var(--crit-editor-fg-muted); }
 .line-content ul li { list-style-type: '  \2022  '; }
+/* Outer wrappers added when a nested list item is split into its own line block.
+   They preserve semantic nesting (so CSS indentation works) without rendering
+   their own bullet/marker. */
+.line-content ul.crit-list-wrapper,
+.line-content ol.crit-list-wrapper { padding-left: 24px; margin: 0; }
+.line-content li.crit-list-wrapper { list-style: none; }
+.line-content ul.crit-list-wrapper > li.crit-list-wrapper { list-style-type: none; }
 .line-content hr { border: none; height: 1px; background: var(--crit-border); margin: 24px 0; }
 .line-content img { max-width: 100%; height: auto; border-radius: 6px; margin: 4px 0; }
 .line-content blockquote { margin: 6px 0; padding: 8px 16px; border-left: 3px solid var(--crit-blockquote-border); background: var(--crit-blockquote-bg); border-radius: 0 6px 6px 0; color: var(--crit-editor-fg-secondary); }

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -909,6 +909,139 @@ function buildLineBlocks(md, rawContent) {
     return startIdx
   }
 
+  // Find direct-child nested lists within a list item (not lists nested
+  // inside paragraphs etc.). Returns array of {openIdx, closeIdx}.
+  function findDirectNestedLists(itemOpenIdx, itemCloseIdx) {
+    const result = []
+    let depth = 0
+    for (let k = itemOpenIdx + 1; k < itemCloseIdx; k++) {
+      const t = tokens[k]
+      if (t.nesting === 1) {
+        if (depth === 0 && (t.type === "bullet_list_open" || t.type === "ordered_list_open")) {
+          const closeIdx = findClose(k)
+          result.push({ openIdx: k, closeIdx: closeIdx })
+          k = closeIdx
+          continue
+        }
+        depth++
+      } else if (t.nesting === -1) {
+        if (depth > 0) depth--
+      }
+    }
+    return result
+  }
+
+  function escapeAttr(s) {
+    return String(s).replace(/&/g, "&amp;").replace(/"/g, "&quot;")
+  }
+
+  // Recursively split a list (between listOpenIdx and listCloseIdx) into blocks.
+  // `wrap(innerHtml)` wraps the innermost item HTML with any enclosing list/li
+  // chrome from outer (parent) lists, preserving semantic nesting.
+  function splitListInto(listOpenIdx, listCloseIdx, wrap) {
+    const listOpen = tokens[listOpenIdx]
+    const listTag = listOpen.type === "bullet_list_open" ? "ul" : "ol"
+    let j = listOpenIdx + 1
+
+    while (j < listCloseIdx) {
+      if (tokens[j].type !== "list_item_open") { j++; continue }
+      const itemOpenIdx = j
+      const itemCloseIdx = findClose(j)
+      const itemMap = tokens[itemOpenIdx].map
+
+      if (!itemMap) { j = itemCloseIdx + 1; continue }
+
+      addGapLines(itemMap[0])
+
+      // Find direct-child nested lists within this item.
+      const nestedRanges = findDirectNestedLists(itemOpenIdx, itemCloseIdx)
+
+      // For ordered lists, preserve numbering across split blocks via start=N.
+      // markdown-it stores the numeric marker on the list_item_open token's info.
+      const itemStartAttr = (listTag === "ol" && tokens[itemOpenIdx].info)
+        ? ' start="' + tokens[itemOpenIdx].info + '"'
+        : ""
+
+      // The "lead" portion: tokens between item_open and the first nested list (or item_close).
+      const firstNested = nestedRanges.length > 0 ? nestedRanges[0] : null
+      const leadEndTokenIdx = firstNested ? firstNested.openIdx : itemCloseIdx
+
+      const leadStartLine = itemMap[0] + 1
+      let leadEndLine
+      if (firstNested) {
+        const nestedFirstMap = tokens[firstNested.openIdx].map
+        leadEndLine = nestedFirstMap ? nestedFirstMap[0] : itemMap[1]
+      } else {
+        leadEndLine = itemMap[1]
+        // Trim trailing blank lines (markdown-it often claims a trailing blank).
+        while (leadEndLine > leadStartLine && sourceLines[leadEndLine - 1].trim() === "") {
+          leadEndLine--
+        }
+      }
+
+      const leadInnerTokens = tokens.slice(itemOpenIdx + 1, leadEndTokenIdx)
+      const leadInnerHtml = md.renderer.render(leadInnerTokens, md.options, {})
+      const leadLiClass = tokens[itemOpenIdx].attrGet && tokens[itemOpenIdx].attrGet("class")
+      const leadLiAttr = leadLiClass ? ' class="' + escapeAttr(leadLiClass) + '"' : ""
+      const leadInnerWrapped = "<" + listTag + itemStartAttr + ">" +
+        "<li" + leadLiAttr + ">" + leadInnerHtml + "</li>" +
+        "</" + listTag + ">"
+
+      if (leadEndLine > leadStartLine - 1) {
+        blocks.push({
+          startLine: leadStartLine,
+          endLine: leadEndLine,
+          html: wrap(leadInnerWrapped),
+          isEmpty: false,
+        })
+        coveredUpTo = leadEndLine
+      }
+
+      // Recurse into each nested list. Outer wrappers use .crit-list-wrapper
+      // so CSS suppresses their phantom bullets/markers.
+      for (let n = 0; n < nestedRanges.length; n++) {
+        const nested = nestedRanges[n]
+        const childWrap = function(innerHtml) {
+          return wrap(
+            '<' + listTag + ' class="crit-list-wrapper">' +
+            '<li class="crit-list-wrapper">' + innerHtml + "</li>" +
+            "</" + listTag + ">"
+          )
+        }
+        splitListInto(nested.openIdx, nested.closeIdx, childWrap)
+      }
+
+      // Trailing content after last nested list (rare).
+      if (nestedRanges.length > 0) {
+        const lastNested = nestedRanges[nestedRanges.length - 1]
+        const trailStartTokenIdx = lastNested.closeIdx + 1
+        if (trailStartTokenIdx < itemCloseIdx) {
+          const trailStartLine = coveredUpTo
+          let trailEndLine = itemMap[1]
+          while (trailEndLine > trailStartLine && sourceLines[trailEndLine - 1].trim() === "") {
+            trailEndLine--
+          }
+          if (trailEndLine > trailStartLine) {
+            const trailInnerTokens = tokens.slice(trailStartTokenIdx, itemCloseIdx)
+            const trailInnerHtml = md.renderer.render(trailInnerTokens, md.options, {})
+            const trailWrapped = "<" + listTag + ">" +
+              "<li>" + trailInnerHtml + "</li>" +
+              "</" + listTag + ">"
+            blocks.push({
+              startLine: trailStartLine + 1,
+              endLine: trailEndLine,
+              html: wrap(trailWrapped),
+              isEmpty: false,
+            })
+            coveredUpTo = trailEndLine
+          }
+        }
+      }
+
+      j = itemCloseIdx + 1
+    }
+  }
+
   let i = 0
   while (i < tokens.length) {
     const token = tokens[i]
@@ -918,38 +1051,13 @@ function buildLineBlocks(md, rawContent) {
     const blockEnd = token.map[1]
     addGapLines(blockStart)
 
-    // Lists: split into individual items
+    // Lists: split into individual items, recursing into nested lists so each
+    // nested item is independently commentable. Nested-item blocks preserve
+    // semantic nesting (e.g. <ul><li><ul><li>content</li></ul></li></ul>) with
+    // outer wrappers marked .crit-list-wrapper so CSS suppresses their bullets.
     if (token.type === "bullet_list_open" || token.type === "ordered_list_open") {
-      const isOrdered = token.type === "ordered_list_open"
-      const listTag = isOrdered ? "ol" : "ul"
       const listCloseIdx = findClose(i)
-      let orderNum = 1
-      let j = i + 1
-      while (j < listCloseIdx) {
-        if (tokens[j].type === "list_item_open") {
-          const itemCloseIdx = findClose(j)
-          const itemMap = tokens[j].map
-          if (itemMap) {
-            addGapLines(itemMap[0])
-            let contentEnd = itemMap[1]
-            for (let ln = itemMap[1] - 1; ln > itemMap[0]; ln--) {
-              if (sourceLines[ln].trim() === "") { contentEnd = ln } else { break }
-            }
-            const itemTokens = tokens.slice(j, itemCloseIdx + 1)
-            const startAttr = isOrdered ? ' start="' + orderNum + '"' : ""
-            const itemHtml =
-              "<" + listTag + startAttr + ">" +
-              md.renderer.render(itemTokens, md.options, {}) +
-              "</" + listTag + ">"
-            blocks.push({ startLine: itemMap[0] + 1, endLine: contentEnd, html: itemHtml, isEmpty: false })
-            coveredUpTo = contentEnd
-            orderNum++
-          }
-          j = itemCloseIdx + 1
-        } else {
-          j++
-        }
-      }
+      splitListInto(i, listCloseIdx, function(html) { return html })
       i = listCloseIdx + 1
       addGapLines(blockEnd)
       continue

--- a/e2e/nested-lists.spec.ts
+++ b/e2e/nested-lists.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+import { createReview, deleteReview, loadReview } from "./helpers";
+
+test.describe("Nested list rendering — per-item line blocks", () => {
+  let token: string;
+  let deleteToken: string;
+
+  test.beforeEach(async ({ request }) => {
+    const review = await createReview(request, {
+      files: [
+        {
+          path: "nested.md",
+          content: [
+            "# Nested",
+            "",
+            "- Top alpha lead.",
+            "  - Nested alpha-one.",
+            "  - Nested alpha-two.",
+            "    - Deep alpha-two-a.",
+            "- Top beta lead.",
+            "  - Nested beta-one.",
+            "",
+          ].join("\n"),
+        },
+      ],
+    });
+    token = review.token;
+    deleteToken = review.deleteToken;
+  });
+
+  test.afterEach(async ({ request }) => {
+    await deleteReview(request, deleteToken);
+  });
+
+  test("each nested bullet item is its own commentable line block", async ({
+    page,
+  }) => {
+    await loadReview(page, token);
+
+    const items = [
+      "Top alpha lead.",
+      "Nested alpha-one.",
+      "Nested alpha-two.",
+      "Deep alpha-two-a.",
+      "Top beta lead.",
+      "Nested beta-one.",
+    ];
+
+    const startLines = new Set<string>();
+    for (const text of items) {
+      const block = page
+        .locator("#document-renderer .line-block")
+        .filter({ hasText: text })
+        .first();
+      await expect(block).toBeVisible();
+      const startLine = await block.getAttribute("data-start-line");
+      expect(startLine, `block for "${text}" should have data-start-line`).toBeTruthy();
+      startLines.add(startLine!);
+    }
+
+    expect(startLines.size).toBe(items.length);
+
+    await expect(
+      page.locator("#document-renderer ul.crit-list-wrapper").first()
+    ).toBeAttached();
+  });
+});


### PR DESCRIPTION
## Summary
- Parity port of tomasz-tomczyk/crit#514. Each nested bullet/numbered item now becomes its own commentable line block, with semantic `<ul>/<ol>` nesting preserved.
- `document-renderer.js`: recursive `splitListInto` mirrors the crit/ side, adapted to crit-web's closure-scoped `coveredUpTo` pattern.
- `app.css`: `.crit-list-wrapper` rules — preserve 24px indent, suppress phantom outer markers.

## Review
- [x] Code review: passed (frontend agent)
- [x] Parity audit: matches crit/#514

## Test plan
- New `e2e/nested-lists.spec.ts` asserts each nested item gets a distinct `data-start-line` and the wrapper class is present. Passes locally.
- Adjacent specs (drag-selection, keyboard, review-page) — 18/18 pass.

See also: tomasz-tomczyk/crit#514

🤖 Generated with [Claude Code](https://claude.com/claude-code)