### PR TITLE
feat: admin role for selfhosted instances

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -27,6 +27,10 @@ function isOwnComment(c, ctx) {
   return c.author_identity != null && c.author_identity !== "" && c.author_identity === ctx.identity
 }
 
+function canDeleteComment(c, ctx) {
+  return isOwnComment(c, ctx) || ctx.isAdmin === true
+}
+
 function isReviewOwner(ctx) {
   return ctx.userId !== "" && ctx.reviewOwnerId !== "" && String(ctx.userId) === String(ctx.reviewOwnerId)
 }
@@ -2664,7 +2668,10 @@ function createCommentElement(comment, ctx) {
       addForm(ctx, editFormObj)
       render(ctx)
     })
+    actions.appendChild(editBtn)
+  }
 
+  if (canDeleteComment(comment, ctx)) {
     const deleteBtn = document.createElement("button")
     deleteBtn.className = "delete-btn"
     deleteBtn.title = "Delete"
@@ -2672,8 +2679,6 @@ function createCommentElement(comment, ctx) {
     deleteBtn.addEventListener("click", () => {
       ctx.pushEvent("delete_comment", { id: comment.id })
     })
-
-    actions.appendChild(editBtn)
     actions.appendChild(deleteBtn)
   }
 
@@ -3066,26 +3071,30 @@ function renderReplyList(comment, ctx) {
     replyMeta.appendChild(replyTime)
     replyHeader.appendChild(replyMeta)
 
-    if (isOwnReply) {
+    if (isOwnReply || canDeleteComment(reply, ctx)) {
       const replyActions = document.createElement('div')
       replyActions.className = 'reply-actions'
 
-      const replyEditBtn = document.createElement('button')
-      replyEditBtn.title = 'Edit'
-      replyEditBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>'
-      replyEditBtn.addEventListener('click', function(e) { e.stopPropagation(); editReply(comment.id, reply, ctx) })
+      if (isOwnReply) {
+        const replyEditBtn = document.createElement('button')
+        replyEditBtn.title = 'Edit'
+        replyEditBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>'
+        replyEditBtn.addEventListener('click', function(e) { e.stopPropagation(); editReply(comment.id, reply, ctx) })
+        replyActions.appendChild(replyEditBtn)
+      }
 
-      const replyDeleteBtn = document.createElement('button')
-      replyDeleteBtn.className = 'delete-btn'
-      replyDeleteBtn.title = 'Delete'
-      replyDeleteBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>'
-      replyDeleteBtn.addEventListener('click', function(e) {
-        e.stopPropagation()
-        ctx.pushEvent("delete_reply", { id: reply.id })
-      })
+      if (canDeleteComment(reply, ctx)) {
+        const replyDeleteBtn = document.createElement('button')
+        replyDeleteBtn.className = 'delete-btn'
+        replyDeleteBtn.title = 'Delete'
+        replyDeleteBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>'
+        replyDeleteBtn.addEventListener('click', function(e) {
+          e.stopPropagation()
+          ctx.pushEvent("delete_reply", { id: reply.id })
+        })
+        replyActions.appendChild(replyDeleteBtn)
+      }
 
-      replyActions.appendChild(replyEditBtn)
-      replyActions.appendChild(replyDeleteBtn)
       replyHeader.appendChild(replyActions)
     }
 
@@ -3321,7 +3330,7 @@ function createResolvedElement(comment, ctx) {
     actions.appendChild(unresolveBtn)
   }
 
-  if (isOwn) {
+  if (canDeleteComment(comment, ctx)) {
     const deleteBtn = document.createElement('button')
     deleteBtn.className = 'delete-btn'
     deleteBtn.title = 'Delete'
@@ -3989,7 +3998,7 @@ function renderPanelCard(ctx, comment, filePath) {
       actions.appendChild(resolveBtn)
     }
 
-    if (isOwn) {
+    if (canDeleteComment(comment, ctx)) {
       const deleteBtn = document.createElement('button')
       deleteBtn.className = 'delete-btn'
       deleteBtn.title = 'Delete'
@@ -4876,10 +4885,11 @@ export const DocumentRenderer = {
       }
     })
 
-    ctx.handleEvent("init", ({ comments, display_name, files, can_comment }) => {
+    ctx.handleEvent("init", ({ comments, display_name, files, can_comment, is_admin }) => {
       ctx.displayName = display_name || null
       ctx.comments = comments
       ctx.canComment = can_comment !== false
+      ctx.isAdmin = is_admin === true
 
       if (files && files.length > 1) {
         ctx.multiFile = true

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -34,6 +34,24 @@ if System.get_env("SELFHOSTED") in ~w(true 1) do
   config :crit, :selfhosted, true
 end
 
+# ADMIN_EMAILS: comma-separated list of email addresses that should have the
+# instance admin role. Parsed into a list of trimmed, lowercased strings.
+# This is the single source of truth for admin status — see
+# `Crit.Authorization` and `Crit.Accounts.apply_role_for_email/1`.
+admin_emails =
+  case System.get_env("ADMIN_EMAILS") do
+    nil ->
+      []
+
+    raw ->
+      raw
+      |> String.split(",", trim: true)
+      |> Enum.map(&(&1 |> String.trim() |> String.downcase()))
+      |> Enum.reject(&(&1 == ""))
+  end
+
+config :crit, :admin_emails, admin_emails
+
 # Sentry — only active when SENTRY_DSN is set. With no DSN the SDK is a no-op,
 # so self-hosted deployments make zero network calls to Sentry.
 if sentry_dsn = System.get_env("SENTRY_DSN") do

--- a/lib/crit/accounts.ex
+++ b/lib/crit/accounts.ex
@@ -241,6 +241,16 @@ defmodule Crit.Accounts do
   end
 
   @doc """
+  Updates the keep_reviews setting for a user.
+  Returns `{:ok, user}` or `{:error, changeset}`.
+  """
+  def update_keep_reviews(%User{} = user, keep_reviews) when is_boolean(keep_reviews) do
+    user
+    |> User.settings_changeset(%{keep_reviews: keep_reviews})
+    |> Repo.update()
+  end
+
+  @doc """
   Returns all API tokens for the given user, ordered by inserted_at desc.
   """
   def list_tokens(user_id) do

--- a/lib/crit/accounts.ex
+++ b/lib/crit/accounts.ex
@@ -1,9 +1,6 @@
 defmodule Crit.Accounts do
   @moduledoc """
   Accounts context.
-
-  Note: the admin-role plan will later add a call to `apply_role_for_email/1`
-  inside `register_user/1` to assign roles based on email at registration time.
   """
 
   import Ecto.Query
@@ -20,6 +17,48 @@ defmodule Crit.Accounts do
     %User{}
     |> User.registration_changeset(attrs)
     |> Repo.insert()
+    |> case do
+      {:ok, user} -> apply_role_for_email(user)
+      other -> other
+    end
+  end
+
+  @doc """
+  Re-asserts the user's role from `ADMIN_EMAILS`. Promotes if the user's
+  email is in the list, demotes otherwise.
+
+  Called on every login, registration, and the boot reconciliation pass in
+  `Crit.Release.migrate/0` — `ADMIN_EMAILS` is the single source of truth
+  for admin status; this function keeps `users.role` in sync with it.
+
+  Returns `{:ok, user}` (always — a no-op update is still a success) or
+  `{:error, changeset}` on DB failure.
+  """
+  def apply_role_for_email(%User{} = user) do
+    desired = desired_role_for_email(user.email)
+
+    if user.role == desired do
+      {:ok, user}
+    else
+      user
+      |> User.role_changeset(%{role: desired})
+      |> Repo.update()
+    end
+  end
+
+  defp desired_role_for_email(email) when is_binary(email) do
+    if String.downcase(email) in admin_emails(), do: :admin, else: :user
+  end
+
+  defp desired_role_for_email(_), do: :user
+
+  defp admin_emails do
+    Application.get_env(:crit, :admin_emails, [])
+  end
+
+  @doc "Returns all users, ordered by inserted_at desc."
+  def list_users do
+    Repo.all(from u in User, order_by: [desc: u.inserted_at])
   end
 
   @doc """
@@ -77,18 +116,24 @@ defmodule Crit.Accounts do
 
     update_attrs = Map.delete(insert_attrs, :name)
 
-    cond do
-      is_nil(provider_uid) ->
-        %User{} |> User.oauth_changeset(insert_attrs) |> Repo.insert()
+    result =
+      cond do
+        is_nil(provider_uid) ->
+          %User{} |> User.oauth_changeset(insert_attrs) |> Repo.insert()
 
-      existing = Repo.get_by(User, provider: provider, provider_uid: provider_uid) ->
-        existing |> User.oauth_update_changeset(update_attrs) |> Repo.update()
+        existing = Repo.get_by(User, provider: provider, provider_uid: provider_uid) ->
+          existing |> User.oauth_update_changeset(update_attrs) |> Repo.update()
 
-      existing = insert_attrs.email && get_user_by_email(insert_attrs.email) ->
-        existing |> User.oauth_update_changeset(update_attrs) |> Repo.update()
+        existing = insert_attrs.email && get_user_by_email(insert_attrs.email) ->
+          existing |> User.oauth_update_changeset(update_attrs) |> Repo.update()
 
-      true ->
-        %User{} |> User.oauth_changeset(insert_attrs) |> Repo.insert()
+        true ->
+          %User{} |> User.oauth_changeset(insert_attrs) |> Repo.insert()
+      end
+
+    case result do
+      {:ok, user} -> apply_role_for_email(user)
+      other -> other
     end
   end
 
@@ -207,24 +252,19 @@ defmodule Crit.Accounts do
   end
 
   @doc """
-  Updates the keep_reviews setting for a user.
-  Returns `{:ok, user}` or `{:error, changeset}`.
-  """
-  def update_keep_reviews(%User{} = user, keep_reviews) when is_boolean(keep_reviews) do
-    user
-    |> User.settings_changeset(%{keep_reviews: keep_reviews})
-    |> Repo.update()
-  end
+  Hard-deletes a user. PostgreSQL `on_delete: :delete_all` cascades:
+  - API tokens
+  - Device codes
+  - `users_tokens` (remember_me etc.)
+  - Reviews (and via reviews → review_files, comments, snapshots)
+  - Comments authored by the user (top-level)
 
-  @doc """
-  Deletes a user account. PostgreSQL cascade handles:
-  - API tokens (deleted)
-  - Device codes (deleted)
-  - Reviews (user_id set to nil, reviews preserved)
+  Used by both self-delete and admin-delete; the only difference between
+  the two is the auth check at the call site.
 
-  Returns `:ok` or `{:error, :not_found}`.
+  Returns `:ok` or `{:error, :not_found}` or `{:error, :delete_failed}`.
   """
-  def delete_account(%User{id: id}) do
+  def delete_user(%User{id: id}) do
     case Repo.get(User, id) do
       nil ->
         {:error, :not_found}

--- a/lib/crit/accounts/scope.ex
+++ b/lib/crit/accounts/scope.ex
@@ -1,12 +1,15 @@
 defmodule Crit.Accounts.Scope do
   alias Crit.User
 
-  defstruct user: nil, identity: nil, display_name: nil
+  defstruct user: nil, identity: nil, display_name: nil, role: nil
+
+  @type role :: :admin | :user | nil
 
   @type t :: %__MODULE__{
           user: User.t() | nil,
           identity: String.t() | nil,
-          display_name: String.t() | nil
+          display_name: String.t() | nil,
+          role: role()
         }
 
   @doc """
@@ -49,14 +52,19 @@ defmodule Crit.Accounts.Scope do
 
   @doc "Build scope for an authenticated user."
   def for_user(%User{} = user) do
-    %__MODULE__{user: user, identity: nil, display_name: display_name_for(user)}
+    %__MODULE__{
+      user: user,
+      identity: nil,
+      display_name: display_name_for(user),
+      role: user.role
+    }
   end
 
   def for_user(nil), do: %__MODULE__{}
 
   @doc "Replace the user (used by SettingsLive after profile update)."
   def put_user(%__MODULE__{} = scope, %User{} = user) do
-    %{scope | user: user, display_name: display_name_for(user)}
+    %{scope | user: user, display_name: display_name_for(user), role: user.role}
   end
 
   @doc "Replace the display name (used by anonymous visitors via /set-name)."
@@ -67,6 +75,10 @@ defmodule Crit.Accounts.Scope do
   @doc "Returns the user_id, or nil if anonymous."
   def user_id(%__MODULE__{user: nil}), do: nil
   def user_id(%__MODULE__{user: %User{id: id}}), do: id
+
+  @doc "True if the scope has the instance admin role."
+  def admin?(%__MODULE__{role: :admin}), do: true
+  def admin?(_), do: false
 
   # Public display name. Never falls back to email — comment authors are
   # visible to anyone with the share URL, so leaking an email here would

--- a/lib/crit/authorization.ex
+++ b/lib/crit/authorization.ex
@@ -7,8 +7,7 @@ defmodule Crit.Authorization do
   is a denormalised cache — kept in sync by `Crit.Accounts.apply_role_for_email/1`
   on every login, registration, and app boot reconciliation.
 
-  All callers should use `can?/2,3` rather than reading `user.role` directly,
-  so the env-pinned protection on `:delete_user` is enforced uniformly.
+  All callers should use `can?/2,3` rather than reading `user.role` directly.
   """
 
   alias Crit.User
@@ -18,24 +17,13 @@ defmodule Crit.Authorization do
   def admin?(_), do: false
 
   @doc """
-  True if the user's email is pinned in `ADMIN_EMAILS`. Pinned admins cannot
-  be deleted via the admin UI — deleting them would just have them re-promoted
-  on next login or boot reconciliation.
-  """
-  def env_pinned?(%User{email: email}) when is_binary(email) do
-    String.downcase(email) in admin_emails()
-  end
-
-  def env_pinned?(_), do: false
-
-  @doc """
   Permission check. `action` is one of:
 
     * `:delete_review`   — admin or review owner
     * `:delete_comment`  — admin or comment author
     * `:manage_users`    — admin
     * `:edit_settings`   — admin
-    * `:delete_user`     — admin AND target's email is not pinned in ADMIN_EMAILS
+    * `:delete_user`     — admin
   """
   def can?(user, action, resource \\ nil)
 
@@ -43,24 +31,18 @@ defmodule Crit.Authorization do
   def can?(%User{} = user, :edit_settings, _), do: admin?(user)
 
   def can?(%User{} = user, :delete_review, %{user_id: owner_id}) do
-    admin?(user) or (is_binary(user.id) and user.id == owner_id)
+    admin?(user) or user.id == owner_id
   end
 
   def can?(%User{} = user, :delete_review, _), do: admin?(user)
 
   def can?(%User{} = user, :delete_comment, %{user_id: author_id}) do
-    admin?(user) or (is_binary(user.id) and user.id == author_id)
+    admin?(user) or user.id == author_id
   end
 
   def can?(%User{} = user, :delete_comment, _), do: admin?(user)
 
-  def can?(%User{} = user, :delete_user, %User{} = target) do
-    admin?(user) and not env_pinned?(target)
-  end
+  def can?(%User{} = user, :delete_user, %User{}), do: admin?(user)
 
   def can?(_, _, _), do: false
-
-  defp admin_emails do
-    Application.get_env(:crit, :admin_emails, [])
-  end
 end

--- a/lib/crit/authorization.ex
+++ b/lib/crit/authorization.ex
@@ -1,0 +1,66 @@
+defmodule Crit.Authorization do
+  @moduledoc """
+  Authorization for instance-role actions.
+
+  `ADMIN_EMAILS` (parsed in `config/runtime.exs` into `:crit, :admin_emails`)
+  is the single source of truth for who is an admin. The `users.role` column
+  is a denormalised cache — kept in sync by `Crit.Accounts.apply_role_for_email/1`
+  on every login, registration, and app boot reconciliation.
+
+  All callers should use `can?/2,3` rather than reading `user.role` directly,
+  so the env-pinned protection on `:delete_user` is enforced uniformly.
+  """
+
+  alias Crit.User
+
+  @doc "True if the user has the instance admin role."
+  def admin?(%User{role: :admin}), do: true
+  def admin?(_), do: false
+
+  @doc """
+  True if the user's email is pinned in `ADMIN_EMAILS`. Pinned admins cannot
+  be deleted via the admin UI — deleting them would just have them re-promoted
+  on next login or boot reconciliation.
+  """
+  def env_pinned?(%User{email: email}) when is_binary(email) do
+    String.downcase(email) in admin_emails()
+  end
+
+  def env_pinned?(_), do: false
+
+  @doc """
+  Permission check. `action` is one of:
+
+    * `:delete_review`   — admin or review owner
+    * `:delete_comment`  — admin or comment author
+    * `:manage_users`    — admin
+    * `:edit_settings`   — admin
+    * `:delete_user`     — admin AND target's email is not pinned in ADMIN_EMAILS
+  """
+  def can?(user, action, resource \\ nil)
+
+  def can?(%User{} = user, :manage_users, _), do: admin?(user)
+  def can?(%User{} = user, :edit_settings, _), do: admin?(user)
+
+  def can?(%User{} = user, :delete_review, %{user_id: owner_id}) do
+    admin?(user) or (is_binary(user.id) and user.id == owner_id)
+  end
+
+  def can?(%User{} = user, :delete_review, _), do: admin?(user)
+
+  def can?(%User{} = user, :delete_comment, %{user_id: author_id}) do
+    admin?(user) or (is_binary(user.id) and user.id == author_id)
+  end
+
+  def can?(%User{} = user, :delete_comment, _), do: admin?(user)
+
+  def can?(%User{} = user, :delete_user, %User{} = target) do
+    admin?(user) and not env_pinned?(target)
+  end
+
+  def can?(_, _, _), do: false
+
+  defp admin_emails do
+    Application.get_env(:crit, :admin_emails, [])
+  end
+end

--- a/lib/crit/authorization.ex
+++ b/lib/crit/authorization.ex
@@ -7,14 +7,14 @@ defmodule Crit.Authorization do
   is a denormalised cache — kept in sync by `Crit.Accounts.apply_role_for_email/1`
   on every login, registration, and app boot reconciliation.
 
-  All callers should use `can?/2,3` rather than reading `user.role` directly.
+  `can?/2,3` and `admin?/1` accept a `%Scope{}`. Templates pass
+  `@current_scope` directly — no need to dig out `.user`.
   """
 
-  alias Crit.User
+  alias Crit.Accounts.Scope
 
-  @doc "True if the user has the instance admin role."
-  def admin?(%User{role: :admin}), do: true
-  def admin?(_), do: false
+  @doc "True if the scope's user has the instance admin role."
+  defdelegate admin?(scope), to: Scope
 
   @doc """
   Permission check. `action` is one of:
@@ -25,24 +25,24 @@ defmodule Crit.Authorization do
     * `:edit_settings`   — admin
     * `:delete_user`     — admin
   """
-  def can?(user, action, resource \\ nil)
+  def can?(scope, action, resource \\ nil)
 
-  def can?(%User{} = user, :manage_users, _), do: admin?(user)
-  def can?(%User{} = user, :edit_settings, _), do: admin?(user)
+  def can?(%Scope{} = scope, :manage_users, _), do: admin?(scope)
+  def can?(%Scope{} = scope, :edit_settings, _), do: admin?(scope)
 
-  def can?(%User{} = user, :delete_review, %{user_id: owner_id}) do
-    admin?(user) or user.id == owner_id
+  def can?(%Scope{user: %{id: user_id}} = scope, :delete_review, %{user_id: owner_id}) do
+    admin?(scope) or user_id == owner_id
   end
 
-  def can?(%User{} = user, :delete_review, _), do: admin?(user)
+  def can?(%Scope{} = scope, :delete_review, _), do: admin?(scope)
 
-  def can?(%User{} = user, :delete_comment, %{user_id: author_id}) do
-    admin?(user) or user.id == author_id
+  def can?(%Scope{user: %{id: user_id}} = scope, :delete_comment, %{user_id: author_id}) do
+    admin?(scope) or user_id == author_id
   end
 
-  def can?(%User{} = user, :delete_comment, _), do: admin?(user)
+  def can?(%Scope{} = scope, :delete_comment, _), do: admin?(scope)
 
-  def can?(%User{} = user, :delete_user, %User{}), do: admin?(user)
+  def can?(%Scope{} = scope, :delete_user, %Crit.User{}), do: admin?(scope)
 
   def can?(_, _, _), do: false
 end

--- a/lib/crit/comment.ex
+++ b/lib/crit/comment.ex
@@ -44,7 +44,7 @@ defmodule Crit.Comment do
     |> validate_required([:body])
     |> validate_inclusion(:scope, ["line", "file", "review"])
     |> validate_line_numbers()
-    |> validate_length(:body, max: 51_200, message: "must be at most 50 KB")
+    |> validate_body_length()
     |> validate_length(:author_display_name, max: 40)
     |> validate_length(:file_path, max: 500)
   end
@@ -71,7 +71,7 @@ defmodule Crit.Comment do
     comment
     |> cast(attrs, [:body])
     |> validate_required([:body])
-    |> validate_length(:body, max: 51_200, message: "must be at most 50 KB")
+    |> validate_body_length()
   end
 
   @doc "Changeset for creating a reply (comment with parent_id)."
@@ -79,7 +79,16 @@ defmodule Crit.Comment do
     comment
     |> cast(attrs, [:body, :author_identity, :author_display_name])
     |> validate_required([:body])
-    |> validate_length(:body, max: 51_200, message: "must be at most 50 KB")
+    |> validate_body_length()
     |> validate_length(:author_display_name, max: 40)
+  end
+
+  # Reads the configured `max_comment_body_bytes` from the singleton settings
+  # row on each call. Single-row Postgres lookup is sub-ms; caching is a
+  # future optimisation.
+  defp validate_body_length(changeset) do
+    max = Crit.Settings.get().max_comment_body_bytes
+    kb = div(max, 1024)
+    validate_length(changeset, :body, max: max, message: "must be at most #{kb} KB")
   end
 end

--- a/lib/crit/release.ex
+++ b/lib/crit/release.ex
@@ -11,6 +11,28 @@ defmodule Crit.Release do
     for repo <- repos() do
       {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
     end
+
+    # Reconcile ADMIN_EMAILS → users.role on every boot, not just when
+    # migrations are pending. The operator's normal "edit env, restart
+    # container" loop should apply the new admin set without anyone having
+    # to log in.
+    reconcile_admin_emails()
+  end
+
+  @doc """
+  Reconciles `users.role` against the parsed `ADMIN_EMAILS` list. Promotes
+  users whose email is now listed; demotes users whose email is no longer
+  listed. Idempotent.
+  """
+  def reconcile_admin_emails do
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Crit.Repo, fn _repo ->
+        for user <- Crit.Accounts.list_users() do
+          Crit.Accounts.apply_role_for_email(user)
+        end
+      end)
+
+    :ok
   end
 
   def rollback(repo, version) do

--- a/lib/crit/release.ex
+++ b/lib/crit/release.ex
@@ -24,7 +24,7 @@ defmodule Crit.Release do
   @doc """
   Reconciles `users.role` against the parsed `ADMIN_EMAILS` list. Promotes
   users whose email is now listed; demotes users whose email is no longer
-  listed. Idempotent.
+  listed. Idempotent. Two `update_all` queries.
   """
   def reconcile_admin_emails do
     emails = Application.get_env(:crit, :admin_emails, [])

--- a/lib/crit/release.ex
+++ b/lib/crit/release.ex
@@ -5,6 +5,8 @@ defmodule Crit.Release do
   """
   @app :crit
 
+  import Ecto.Query, only: [from: 2]
+
   def migrate do
     load_app()
 
@@ -25,11 +27,26 @@ defmodule Crit.Release do
   listed. Idempotent.
   """
   def reconcile_admin_emails do
+    emails = Application.get_env(:crit, :admin_emails, [])
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
     {:ok, _, _} =
       Ecto.Migrator.with_repo(Crit.Repo, fn _repo ->
-        for user <- Crit.Accounts.list_users() do
-          Crit.Accounts.apply_role_for_email(user)
+        # Promote env-listed users to admin.
+        if emails != [] do
+          from(u in Crit.User,
+            where: fragment("lower(?)", u.email) in ^emails and u.role != ^:admin,
+            update: [set: [role: ^:admin, updated_at: ^now]]
+          )
+          |> Crit.Repo.update_all([])
         end
+
+        # Demote any admin whose email is no longer listed.
+        from(u in Crit.User,
+          where: u.role == ^:admin and fragment("lower(?)", u.email) not in ^emails,
+          update: [set: [role: ^:user, updated_at: ^now]]
+        )
+        |> Crit.Repo.update_all([])
       end)
 
     :ok

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -131,14 +131,17 @@ defmodule Crit.Reviews do
     end
   end
 
-  @doc "Delete a comment if the caller's scope owns it. See `update_comment/3` for ownership rules."
+  @doc """
+  Delete a comment if the caller's scope owns it, or if the caller is an
+  instance admin. See `update_comment/3` for ownership rules.
+  """
   def delete_comment(%Scope{} = scope, comment_id) do
     case Repo.get(Comment, comment_id) do
       nil ->
         {:error, :not_found}
 
       %Comment{} = comment ->
-        if comment_owned_by?(scope, comment) do
+        if comment_owned_by?(scope, comment) or Scope.admin?(scope) do
           Repo.delete(comment)
         else
           {:error, :unauthorized}
@@ -223,8 +226,7 @@ defmodule Crit.Reviews do
 
   # Owner-only mutation gate. Anonymous-owned reviews (`user_id: nil`) are
   # never modifiable through scope-authed paths — they're administered via
-  # their `delete_token` (see `delete_by_delete_token/1`). When admin scopes
-  # land, this is the seam to extend.
+  # their `delete_token` (see `delete_by_delete_token/1`).
   defp scope_can_modify_review?(%Scope{}, %Review{user_id: nil}), do: false
 
   defp scope_can_modify_review?(%Scope{} = scope, %Review{user_id: owner_id}) do
@@ -820,7 +822,7 @@ defmodule Crit.Reviews do
         {:error, :not_found}
 
       review ->
-        if scope_can_modify_review?(scope, review) do
+        if scope_can_modify_review?(scope, review) or Scope.admin?(scope) do
           case Repo.delete(review) do
             {:ok, _} -> :ok
             {:error, _} -> {:error, :delete_failed}
@@ -998,7 +1000,7 @@ defmodule Crit.Reviews do
         {:error, :not_found}
 
       %Comment{} = reply ->
-        if comment_owned_by?(scope, reply) do
+        if comment_owned_by?(scope, reply) or Scope.admin?(scope) do
           Repo.delete(reply)
         else
           {:error, :unauthorized}

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -2,10 +2,8 @@ defmodule Crit.Reviews do
   @moduledoc "Context for reviews and comments."
 
   import Ecto.Query
-  alias Crit.{Repo, Review, Comment, ReviewRoundSnapshot, Statistics, User}
+  alias Crit.{Repo, Review, Comment, ReviewRoundSnapshot, Settings, Statistics, User}
   alias Crit.Accounts.Scope
-
-  @max_total_size 10_485_760
 
   @doc "Fetch a review by its token, preloading comments sorted by start_line."
   def get_by_token(token) do
@@ -283,7 +281,9 @@ defmodule Crit.Reviews do
     user_id = Scope.user_id(scope)
     cli_args = Keyword.get(opts, :cli_args) || []
 
-    if total_bytes > @max_total_size do
+    max_total_size = Settings.get().max_document_bytes
+
+    if total_bytes > max_total_size do
       {:error, :total_size_exceeded}
     else
       review_changeset =
@@ -702,17 +702,13 @@ defmodule Crit.Reviews do
 
     ids_query =
       from r in Review,
-        left_join: u in User,
-        on: u.id == r.user_id,
-        where:
-          r.last_activity_at < ^cutoff and
-            (is_nil(u.id) or u.keep_reviews == false),
+        where: r.last_activity_at < ^cutoff,
         select: r.id
 
     ids_query =
       case Application.get_env(:crit, :demo_review_token) do
         nil -> ids_query
-        demo_token -> from [r, _u] in ids_query, where: r.token != ^demo_token
+        demo_token -> from r in ids_query, where: r.token != ^demo_token
       end
 
     {count, _} =

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -702,13 +702,17 @@ defmodule Crit.Reviews do
 
     ids_query =
       from r in Review,
-        where: r.last_activity_at < ^cutoff,
+        left_join: u in User,
+        on: u.id == r.user_id,
+        where:
+          r.last_activity_at < ^cutoff and
+            (is_nil(u.id) or u.keep_reviews == false),
         select: r.id
 
     ids_query =
       case Application.get_env(:crit, :demo_review_token) do
         nil -> ids_query
-        demo_token -> from r in ids_query, where: r.token != ^demo_token
+        demo_token -> from [r, _u] in ids_query, where: r.token != ^demo_token
       end
 
     {count, _} =

--- a/lib/crit/setting.ex
+++ b/lib/crit/setting.ex
@@ -1,0 +1,30 @@
+defmodule Crit.Setting do
+  @moduledoc """
+  Singleton schema for instance-wide settings. The DB enforces `id = 1` via
+  CHECK constraint; readers and writers always target id 1.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :integer, autogenerate: false}
+  schema "settings" do
+    field :max_document_bytes, :integer
+    field :max_comments_per_review, :integer
+    field :max_comment_body_bytes, :integer
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @fields [:max_document_bytes, :max_comments_per_review, :max_comment_body_bytes]
+
+  @doc "Changeset for updating instance settings. Validates non-negative integers."
+  def changeset(setting, attrs) do
+    setting
+    |> cast(attrs, @fields)
+    |> validate_required(@fields)
+    |> validate_number(:max_document_bytes, greater_than_or_equal_to: 0)
+    |> validate_number(:max_comments_per_review, greater_than_or_equal_to: 0)
+    |> validate_number(:max_comment_body_bytes, greater_than_or_equal_to: 0)
+  end
+end

--- a/lib/crit/setting.ex
+++ b/lib/crit/setting.ex
@@ -2,10 +2,17 @@ defmodule Crit.Setting do
   @moduledoc """
   Singleton schema for instance-wide settings. The DB enforces `id = 1` via
   CHECK constraint; readers and writers always target id 1.
+
+  The DB stores byte limits as raw integers, but the form takes human-friendly
+  MB / KB inputs via virtual fields. The changeset converts virtual MB / KB
+  into the persisted byte columns.
   """
 
   use Ecto.Schema
   import Ecto.Changeset
+
+  @kb 1024
+  @mb 1_048_576
 
   @primary_key {:id, :integer, autogenerate: false}
   schema "settings" do
@@ -13,18 +20,45 @@ defmodule Crit.Setting do
     field :max_comments_per_review, :integer
     field :max_comment_body_bytes, :integer
 
+    # Virtual fields that the form binds to. Converted to bytes by `changeset/2`.
+    field :max_document_mb, :float, virtual: true
+    field :max_comment_body_kb, :float, virtual: true
+
     timestamps(type: :utc_datetime)
   end
 
-  @fields [:max_document_bytes, :max_comments_per_review, :max_comment_body_bytes]
+  @form_fields [:max_document_mb, :max_comments_per_review, :max_comment_body_kb]
 
-  @doc "Changeset for updating instance settings. Validates non-negative integers."
+  @doc """
+  Changeset for updating instance settings via the admin form.
+
+  Accepts `max_document_mb` (in megabytes) and `max_comment_body_kb` (in
+  kilobytes); converts them into the persisted `max_document_bytes` and
+  `max_comment_body_bytes` columns.
+  """
   def changeset(setting, attrs) do
     setting
-    |> cast(attrs, @fields)
-    |> validate_required(@fields)
-    |> validate_number(:max_document_bytes, greater_than_or_equal_to: 0)
-    |> validate_number(:max_comments_per_review, greater_than_or_equal_to: 0)
-    |> validate_number(:max_comment_body_bytes, greater_than_or_equal_to: 0)
+    |> cast(attrs, @form_fields)
+    |> validate_required(@form_fields)
+    |> validate_number(:max_document_mb, greater_than: 0)
+    |> validate_number(:max_comments_per_review, greater_than: 0)
+    |> validate_number(:max_comment_body_kb, greater_than: 0)
+    |> put_byte_field(:max_document_mb, :max_document_bytes, @mb)
+    |> put_byte_field(:max_comment_body_kb, :max_comment_body_bytes, @kb)
+  end
+
+  @doc "Helper for prefilling the form: bytes → MB."
+  def bytes_to_mb(nil), do: nil
+  def bytes_to_mb(bytes) when is_integer(bytes), do: Float.round(bytes / @mb, 2)
+
+  @doc "Helper for prefilling the form: bytes → KB."
+  def bytes_to_kb(nil), do: nil
+  def bytes_to_kb(bytes) when is_integer(bytes), do: Float.round(bytes / @kb, 2)
+
+  defp put_byte_field(changeset, virtual, real, multiplier) do
+    case get_change(changeset, virtual) do
+      nil -> changeset
+      value -> put_change(changeset, real, round(value * multiplier))
+    end
   end
 end

--- a/lib/crit/settings.ex
+++ b/lib/crit/settings.ex
@@ -1,0 +1,36 @@
+defmodule Crit.Settings do
+  @moduledoc """
+  Context for the singleton instance settings row.
+
+  Reads happen on every consumer call — single-row Postgres lookup is sub-ms.
+  Caching is a future optimisation if profiles show contention.
+  """
+
+  alias Crit.{Repo, Setting}
+
+  @singleton_id 1
+
+  @doc """
+  Returns the singleton settings row. Raises if missing — the migration
+  seeds id=1 so this should never fail in a normally-migrated DB.
+  """
+  def get do
+    Repo.get!(Setting, @singleton_id)
+  end
+
+  @doc """
+  Updates the singleton settings row.
+
+  Returns `{:ok, setting}` or `{:error, changeset}`.
+  """
+  def update(attrs) do
+    get()
+    |> Setting.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc "Changeset for forms (no DB write)."
+  def change(setting \\ get(), attrs \\ %{}) do
+    Setting.changeset(setting, attrs)
+  end
+end

--- a/lib/crit/user.ex
+++ b/lib/crit/user.ex
@@ -8,6 +8,7 @@ defmodule Crit.User do
     field :name, :string
     field :avatar_url, :string
     field :role, Ecto.Enum, values: [:admin, :user], default: :user
+    field :keep_reviews, :boolean, default: false
     field :hashed_password, :string, redact: true
     field :password, :string, virtual: true, redact: true
     field :current_password, :string, virtual: true, redact: true
@@ -79,6 +80,11 @@ defmodule Crit.User do
     |> cast(attrs, [:password])
     |> validate_confirmation(:password, message: "does not match password")
     |> validate_password(opts)
+  end
+
+  @doc "Changeset for user-controlled settings (e.g. `keep_reviews`)."
+  def settings_changeset(user, attrs) do
+    user |> cast(attrs, [:keep_reviews])
   end
 
   @doc """

--- a/lib/crit/user.ex
+++ b/lib/crit/user.ex
@@ -7,7 +7,7 @@ defmodule Crit.User do
     field :email, :string
     field :name, :string
     field :avatar_url, :string
-    field :keep_reviews, :boolean, default: false
+    field :role, Ecto.Enum, values: [:admin, :user], default: :user
     field :hashed_password, :string, redact: true
     field :password, :string, virtual: true, redact: true
     field :current_password, :string, virtual: true, redact: true
@@ -81,9 +81,12 @@ defmodule Crit.User do
     |> validate_password(opts)
   end
 
-  @doc "Changeset for user-controlled settings (e.g. `keep_reviews`)."
-  def settings_changeset(user, attrs) do
-    user |> cast(attrs, [:keep_reviews])
+  @doc """
+  Programmatic role-assignment changeset. Used only by
+  `Crit.Accounts.apply_role_for_email/1` — `:role` is never user-supplied.
+  """
+  def role_changeset(user, attrs) do
+    user |> cast(attrs, [:role])
   end
 
   @doc "Verifies a plaintext password against the stored hash."

--- a/lib/crit_web/components/layouts.ex
+++ b/lib/crit_web/components/layouts.ex
@@ -76,9 +76,14 @@ defmodule CritWeb.Layouts do
   def site_header(assigns) do
     current_user = assigns.current_scope && assigns.current_scope.user
 
+    is_admin =
+      Crit.Accounts.Scope.admin?(assigns.current_scope) and
+        Application.get_env(:crit, :selfhosted) == true
+
     assigns =
       assigns
       |> assign(:current_user, current_user)
+      |> assign(:is_admin, is_admin)
       |> assign(:user_initial, user_initial(current_user))
       |> assign(:github_oauth?, github_oauth?())
 
@@ -149,6 +154,9 @@ defmodule CritWeb.Layouts do
           <%= if @current_user do %>
             <div>
               <.nav_link href={~p"/dashboard"}>Dashboard</.nav_link>
+            </div>
+            <div :if={@is_admin}>
+              <.nav_link navigate={~p"/admin/users"}>Admin</.nav_link>
             </div>
 
             <div class="relative max-sm:hidden">
@@ -358,10 +366,15 @@ defmodule CritWeb.Layouts do
     host = if assigns.show_overview_link, do: CritWeb.Endpoint.host(), else: nil
     current_user = assigns.current_scope && assigns.current_scope.user
 
+    is_admin =
+      Crit.Accounts.Scope.admin?(assigns.current_scope) and
+        Application.get_env(:crit, :selfhosted) == true
+
     assigns =
       assigns
       |> assign(:host, host)
       |> assign(:current_user, current_user)
+      |> assign(:is_admin, is_admin)
       |> assign(:user_initial, user_initial(current_user))
 
     ~H"""
@@ -430,6 +443,11 @@ defmodule CritWeb.Layouts do
               <.nav_link href={~p"/dashboard"} active={@current_page == :dashboard}>
                 Dashboard
               </.nav_link>
+              <%= if @is_admin do %>
+                <.nav_link navigate={~p"/admin/users"} active={@current_page == :admin}>
+                  Admin
+                </.nav_link>
+              <% end %>
             </nav>
 
             <span
@@ -635,6 +653,53 @@ defmodule CritWeb.Layouts do
         </div>
       </div>
     </header>
+    """
+  end
+
+  @doc """
+  Sub-navigation strip rendered on admin pages. Pass `current_section` as
+  `:users` or `:settings` to mark the active tab.
+  """
+  attr :current_section, :atom, required: true, values: [:users, :settings]
+
+  def admin_subnav(assigns) do
+    ~H"""
+    <nav
+      aria-label="Admin sections"
+      class="border-b border-(--crit-border) bg-(--crit-bg-card)"
+    >
+      <div class="max-w-7xl mx-auto px-8 max-sm:px-4 flex items-center gap-1 -mb-px">
+        <.subnav_tab navigate={~p"/admin/users"} active={@current_section == :users}>
+          Users
+        </.subnav_tab>
+        <.subnav_tab navigate={~p"/admin/settings"} active={@current_section == :settings}>
+          Settings
+        </.subnav_tab>
+      </div>
+    </nav>
+    """
+  end
+
+  attr :navigate, :string, required: true
+  attr :active, :boolean, default: false
+  slot :inner_block, required: true
+
+  defp subnav_tab(assigns) do
+    ~H"""
+    <.link
+      navigate={@navigate}
+      aria-current={@active && "page"}
+      class={[
+        "inline-flex items-center h-10 px-4 text-sm font-medium tracking-tight no-underline border-b-2 transition-colors",
+        if(@active,
+          do: "text-(--crit-fg-primary) border-(--crit-brand)",
+          else:
+            "text-(--crit-fg-secondary) border-transparent hover:text-(--crit-fg-primary) hover:border-(--crit-border-strong)"
+        )
+      ]}
+    >
+      {render_slot(@inner_block)}
+    </.link>
     """
   end
 

--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -4,11 +4,10 @@ defmodule CritWeb.ApiController do
   alias Crit.Accounts.Scope
   alias Crit.Reviews
   alias Crit.Output
+  alias Crit.Settings
 
   # 30 write requests per minute per IP
   plug :rate_limit_write when action in [:create, :update]
-
-  @max_comments 500
 
   def create(conn, %{"files" => files} = params) when is_list(files) and files != [] do
     review_round = params["review_round"]
@@ -16,10 +15,11 @@ defmodule CritWeb.ApiController do
     comments = params["comments"] || []
     review_comments = params["review_comments"] || []
     scope = api_scope(conn)
+    max_comments = Settings.get().max_comments_per_review
 
     cond do
-      length(comments) + length(review_comments) > @max_comments ->
-        conn |> put_status(422) |> json(%{error: "Too many comments (max #{@max_comments})"})
+      length(comments) + length(review_comments) > max_comments ->
+        conn |> put_status(422) |> json(%{error: "Too many comments (max #{max_comments})"})
 
       length(files) > 200 ->
         conn |> put_status(422) |> json(%{error: "Too many files (max 200)"})
@@ -61,12 +61,13 @@ defmodule CritWeb.ApiController do
     file_path = filename || "document"
     files = [%{"path" => file_path, "content" => content}]
     comments_with_file = Enum.map(comments, &Map.put_new(&1, "file", file_path))
+    max_comments = Settings.get().max_comments_per_review
 
     cond do
-      length(comments) + length(review_comments) > @max_comments ->
+      length(comments) + length(review_comments) > max_comments ->
         conn
         |> put_status(422)
-        |> json(%{error: "Too many comments (max #{@max_comments})"})
+        |> json(%{error: "Too many comments (max #{max_comments})"})
 
       true ->
         case Reviews.create_review(

--- a/lib/crit_web/controllers/page_html/self_hosting.html.heex
+++ b/lib/crit_web/controllers/page_html/self_hosting.html.heex
@@ -389,6 +389,13 @@
             </p>
             <span class="text-xs font-mono text-(--crit-fg-muted) sm:text-right">optional</span>
           </div>
+          <div class="grid grid-cols-[minmax(160px,220px)_1fr_80px] gap-x-4 items-baseline px-4 py-3 bg-(--crit-bg-card) max-sm:grid-cols-1 max-sm:gap-y-1">
+            <code class="text-sm font-mono text-(--crit-fg-primary)">ADMIN_EMAILS</code>
+            <p phx-no-format class="text-sm text-(--crit-fg-secondary)">
+              Comma-separated list of admin email addresses. Users with these emails are auto-promoted to admin on every login and on app boot, gaining access to <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">/admin/users</code> and <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">/admin/settings</code> plus moderation powers (delete any review or comment). Removing an email and restarting demotes that user back to a regular user.
+            </p>
+            <span class="text-xs font-mono text-(--crit-fg-muted) sm:text-right">optional</span>
+          </div>
         </div>
       </div>
 

--- a/lib/crit_web/controllers/user_session_controller.ex
+++ b/lib/crit_web/controllers/user_session_controller.ex
@@ -15,6 +15,11 @@ defmodule CritWeb.UserSessionController do
         |> redirect(to: login_path(return_to))
 
       user ->
+        # Re-assert role from ADMIN_EMAILS on every login. If the operator
+        # added/removed this email from ADMIN_EMAILS since their last login,
+        # the role is updated here without waiting for the next app boot.
+        {:ok, user} = Accounts.apply_role_for_email(user)
+
         conn
         |> put_flash(:info, "Welcome back!")
         |> UserAuth.log_in_user(user, user_params)

--- a/lib/crit_web/live/admin_settings_live.ex
+++ b/lib/crit_web/live/admin_settings_live.ex
@@ -1,0 +1,57 @@
+defmodule CritWeb.AdminSettingsLive do
+  use CritWeb, :live_view
+
+  alias Crit.Settings
+
+  @impl true
+  def mount(_params, _session, socket) do
+    setting = Settings.get()
+
+    socket =
+      socket
+      |> assign(:page_title, "Admin — Settings")
+      |> assign(:noindex, true)
+      |> assign(:selfhosted, Application.get_env(:crit, :selfhosted) == true)
+      |> assign(:setting, setting)
+      |> assign(:form, build_form(setting))
+
+    {:ok, socket, layout: false}
+  end
+
+  @impl true
+  def handle_event("validate", %{"setting" => params}, socket) do
+    changeset =
+      socket.assigns.setting
+      |> Settings.change(params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :form, to_form(changeset, as: "setting"))}
+  end
+
+  @impl true
+  def handle_event("save", %{"setting" => params}, socket) do
+    case Settings.update(params) do
+      {:ok, setting} ->
+        {:noreply,
+         socket
+         |> assign(:setting, setting)
+         |> assign(:form, build_form(setting))
+         |> put_flash(:info, "Settings updated.")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset, as: "setting"))}
+    end
+  end
+
+  # Seed the virtual MB / KB fields from the persisted byte values so the form
+  # opens showing `10` (MB) and `50` (KB) rather than blanks.
+  defp build_form(setting) do
+    setting = %{
+      setting
+      | max_document_mb: Crit.Setting.bytes_to_mb(setting.max_document_bytes),
+        max_comment_body_kb: Crit.Setting.bytes_to_kb(setting.max_comment_body_bytes)
+    }
+
+    to_form(Settings.change(setting), as: "setting")
+  end
+end

--- a/lib/crit_web/live/admin_settings_live.html.heex
+++ b/lib/crit_web/live/admin_settings_live.html.heex
@@ -1,0 +1,154 @@
+<Layouts.flash_group flash={@flash} />
+
+<div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
+  <Layouts.dashboard_header
+    current_scope={@current_scope}
+    show_overview_link={@selfhosted}
+    current_page={:admin}
+  />
+
+  <Layouts.admin_subnav current_section={:settings} />
+
+  <div class="max-w-7xl mx-auto w-full px-8 my-10 max-sm:px-4">
+    <div class="mb-8">
+      <h1 class="text-2xl font-semibold text-(--crit-fg-primary)">Admin — Instance settings</h1>
+      <p class="text-sm text-(--crit-fg-muted) mt-1">
+        Limits applied to API uploads from the Crit CLI.
+      </p>
+    </div>
+
+    <.form
+      for={@form}
+      id="admin-settings-form"
+      phx-change="validate"
+      phx-submit="save"
+      class="flex flex-col gap-6 border border-(--crit-border) rounded-lg bg-(--crit-bg-card) p-6"
+    >
+      <div>
+        <label
+          for={@form[:max_document_mb].id}
+          class="block text-sm font-medium text-(--crit-fg-primary) mb-1.5"
+        >
+          Max document size (MB)
+        </label>
+        <div class="relative w-full max-w-xs">
+          <input
+            type="number"
+            step="0.5"
+            min="0.5"
+            id={@form[:max_document_mb].id}
+            name={@form[:max_document_mb].name}
+            value={@form[:max_document_mb].value}
+            required
+            class={[
+              "w-full bg-(--crit-bg-page) rounded-md px-3 py-2 pr-12 text-sm text-(--crit-fg-primary) border focus:outline-none focus:border-(--crit-brand)",
+              if(
+                Phoenix.Component.used_input?(@form[:max_document_mb]) and
+                  @form[:max_document_mb].errors != [],
+                do: "border-red-500",
+                else: "border-(--crit-border)"
+              )
+            ]}
+          />
+          <span class="absolute inset-y-0 right-3 flex items-center text-xs text-(--crit-fg-muted) pointer-events-none">
+            MB
+          </span>
+        </div>
+        <p class="mt-1.5 text-xs text-(--crit-fg-muted)">
+          Total size of all files in a shared review.
+        </p>
+        <p
+          :for={err <- @form[:max_document_mb].errors}
+          :if={Phoenix.Component.used_input?(@form[:max_document_mb])}
+          class="mt-1.5 text-xs text-red-500"
+        >
+          {CritWeb.CoreComponents.translate_error(err)}
+        </p>
+      </div>
+
+      <div>
+        <label
+          for={@form[:max_comments_per_review].id}
+          class="block text-sm font-medium text-(--crit-fg-primary) mb-1.5"
+        >
+          Max comments per review
+        </label>
+        <input
+          type="number"
+          id={@form[:max_comments_per_review].id}
+          name={@form[:max_comments_per_review].name}
+          value={
+            Phoenix.HTML.Form.normalize_value("number", @form[:max_comments_per_review].value)
+          }
+          min="1"
+          required
+          class={[
+            "w-full max-w-xs bg-(--crit-bg-page) rounded-md px-3 py-2 text-sm text-(--crit-fg-primary) border focus:outline-none focus:border-(--crit-brand)",
+            if(
+              Phoenix.Component.used_input?(@form[:max_comments_per_review]) and
+                @form[:max_comments_per_review].errors != [],
+              do: "border-red-500",
+              else: "border-(--crit-border)"
+            )
+          ]}
+        />
+        <p
+          :for={err <- @form[:max_comments_per_review].errors}
+          :if={Phoenix.Component.used_input?(@form[:max_comments_per_review])}
+          class="mt-1.5 text-xs text-red-500"
+        >
+          {CritWeb.CoreComponents.translate_error(err)}
+        </p>
+      </div>
+
+      <div>
+        <label
+          for={@form[:max_comment_body_kb].id}
+          class="block text-sm font-medium text-(--crit-fg-primary) mb-1.5"
+        >
+          Max comment body (KB)
+        </label>
+        <div class="relative w-full max-w-xs">
+          <input
+            type="number"
+            step="1"
+            min="1"
+            id={@form[:max_comment_body_kb].id}
+            name={@form[:max_comment_body_kb].name}
+            value={@form[:max_comment_body_kb].value}
+            required
+            class={[
+              "w-full bg-(--crit-bg-page) rounded-md px-3 py-2 pr-12 text-sm text-(--crit-fg-primary) border focus:outline-none focus:border-(--crit-brand)",
+              if(
+                Phoenix.Component.used_input?(@form[:max_comment_body_kb]) and
+                  @form[:max_comment_body_kb].errors != [],
+                do: "border-red-500",
+                else: "border-(--crit-border)"
+              )
+            ]}
+          />
+          <span class="absolute inset-y-0 right-3 flex items-center text-xs text-(--crit-fg-muted) pointer-events-none">
+            KB
+          </span>
+        </div>
+        <p
+          :for={err <- @form[:max_comment_body_kb].errors}
+          :if={Phoenix.Component.used_input?(@form[:max_comment_body_kb])}
+          class="mt-1.5 text-xs text-red-500"
+        >
+          {CritWeb.CoreComponents.translate_error(err)}
+        </p>
+      </div>
+
+      <div>
+        <button
+          type="submit"
+          phx-disable-with="Saving..."
+          class="bg-(--crit-brand-cta) text-(--crit-fg-on-brand) hover:bg-(--crit-brand-cta-hover) rounded-lg px-4 py-2 text-sm font-bold cursor-pointer transition-all"
+        >
+          Save settings
+        </button>
+      </div>
+    </.form>
+  </div>
+</div>

--- a/lib/crit_web/live/admin_users_live.ex
+++ b/lib/crit_web/live/admin_users_live.ex
@@ -1,0 +1,106 @@
+defmodule CritWeb.AdminUsersLive do
+  use CritWeb, :live_view
+
+  alias Crit.{Accounts, Authorization}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    users = list_sorted_users()
+
+    socket =
+      socket
+      |> assign(:page_title, "Admin — Users")
+      |> assign(:noindex, true)
+      |> assign(:selfhosted, Application.get_env(:crit, :selfhosted) == true)
+      |> assign(:user_count, length(users))
+      |> assign(:delete_target, nil)
+      |> assign(:delete_confirmation, "")
+      |> stream(:users, users)
+
+    {:ok, socket, layout: false}
+  end
+
+  @impl true
+  def handle_event("request_delete", %{"id" => id}, socket) do
+    case Accounts.get_user(id) do
+      {:ok, target} ->
+        {:noreply,
+         socket
+         |> assign(:delete_target, target)
+         |> assign(:delete_confirmation, "")}
+
+      {:error, :not_found} ->
+        {:noreply, put_flash(socket, :error, "User not found.")}
+    end
+  end
+
+  def handle_event("cancel_delete", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:delete_target, nil)
+     |> assign(:delete_confirmation, "")}
+  end
+
+  def handle_event("validate_delete", %{"confirmation" => confirmation}, socket) do
+    {:noreply, assign(socket, :delete_confirmation, confirmation)}
+  end
+
+  def handle_event("confirm_delete", %{"confirmation" => confirmation}, socket) do
+    scope = socket.assigns.current_scope
+    target = socket.assigns.delete_target
+
+    cond do
+      is_nil(target) ->
+        {:noreply, socket}
+
+      not email_matches?(target, confirmation) ->
+        {:noreply,
+         socket
+         |> assign(:delete_confirmation, confirmation)
+         |> put_flash(:error, "Email does not match.")}
+
+      not Authorization.can?(scope, :delete_user, target) ->
+        {:noreply, put_flash(socket, :error, "Not allowed.")}
+
+      true ->
+        do_delete(socket, scope, target)
+    end
+  end
+
+  defp do_delete(socket, scope, target) do
+    case Accounts.delete_user(target) do
+      :ok ->
+        socket =
+          socket
+          |> stream_delete(:users, target)
+          |> assign(:user_count, max(socket.assigns.user_count - 1, 0))
+          |> assign(:delete_target, nil)
+          |> assign(:delete_confirmation, "")
+          |> put_flash(:info, "User deleted.")
+
+        if target.id == scope.user.id do
+          {:noreply, redirect(socket, to: "/")}
+        else
+          {:noreply, socket}
+        end
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Failed to delete user.")}
+    end
+  end
+
+  defp email_matches?(%{email: email}, confirmation)
+       when is_binary(email) and is_binary(confirmation) do
+    String.downcase(String.trim(confirmation)) == String.downcase(email)
+  end
+
+  defp email_matches?(_, _), do: false
+
+  defp list_sorted_users do
+    Accounts.list_users()
+    |> Enum.sort_by(fn u ->
+      # admins first (false sorts before true → invert), then newest first
+      {u.role != :admin, -DateTime.to_unix(u.inserted_at)}
+    end)
+  end
+end

--- a/lib/crit_web/live/admin_users_live.html.heex
+++ b/lib/crit_web/live/admin_users_live.html.heex
@@ -1,0 +1,145 @@
+<Layouts.flash_group flash={@flash} />
+
+<div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
+  <Layouts.dashboard_header
+    current_scope={@current_scope}
+    show_overview_link={@selfhosted}
+    current_page={:admin}
+  />
+
+  <Layouts.admin_subnav current_section={:users} />
+
+  <div class="max-w-7xl mx-auto w-full px-8 my-10 max-sm:px-4">
+    <div class="mb-8">
+      <h1 class="text-2xl font-semibold text-(--crit-fg-primary)">Admin — Users</h1>
+      <p class="text-sm text-(--crit-fg-muted) mt-1">
+        {@user_count} {if @user_count == 1, do: "user", else: "users"} on this instance.
+      </p>
+    </div>
+
+    <div class="border border-(--crit-border) rounded-lg overflow-hidden bg-(--crit-bg-card)">
+      <div class="grid grid-cols-[1fr_1fr_120px_160px_120px] gap-x-4 px-4 py-3 border-b border-(--crit-border) bg-(--crit-bg-elevated) text-xs uppercase tracking-wider text-(--crit-fg-muted) font-semibold max-md:hidden">
+        <span>Email</span>
+        <span>Display name</span>
+        <span>Role</span>
+        <span>Joined</span>
+        <span class="text-right">Actions</span>
+      </div>
+
+      <div id="admin-users-list" phx-update="stream" class="divide-y divide-(--crit-border)">
+        <div
+          :for={{dom_id, user} <- @streams.users}
+          id={dom_id}
+          class="grid grid-cols-[1fr_1fr_120px_160px_120px] gap-x-4 px-4 py-3 items-center text-sm max-md:grid-cols-1 max-md:gap-y-1"
+        >
+          <div class="text-(--crit-fg-primary) truncate">
+            {user.email || "—"}
+          </div>
+          <div class="text-(--crit-fg-secondary) truncate">
+            {user.name || "—"}
+          </div>
+          <div class="flex items-center gap-2">
+            <span
+              :if={user.role == :admin}
+              class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold bg-(--crit-brand-bg) text-(--crit-brand)"
+              data-test="role-badge-admin"
+            >
+              Admin
+            </span>
+            <span
+              :if={user.role != :admin}
+              class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-(--crit-bg-elevated) text-(--crit-fg-muted)"
+              data-test="role-badge-user"
+            >
+              User
+            </span>
+          </div>
+          <div class="text-xs text-(--crit-fg-muted)">
+            {Calendar.strftime(user.inserted_at, "%Y-%m-%d")}
+          </div>
+          <div class="text-right">
+            <button
+              phx-click="request_delete"
+              phx-value-id={user.id}
+              data-test={"delete-user-#{user.id}"}
+              class="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-semibold text-(--crit-red) hover:bg-(--crit-btn-danger-hover-bg) transition-colors cursor-pointer"
+            >
+              <.icon name="hero-trash" class="size-3.5" />
+              <span>Delete</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%!-- Email-confirmation delete modal --%>
+  <div
+    :if={@delete_target}
+    id="delete-user-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="delete-user-modal-title"
+    phx-window-keydown="cancel_delete"
+    phx-key="Escape"
+    class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60"
+  >
+    <div
+      phx-click-away="cancel_delete"
+      class="w-full max-w-md bg-(--crit-bg-card) border border-red-500/30 rounded-lg shadow-2xl p-6"
+    >
+      <h2 id="delete-user-modal-title" class="text-lg font-semibold text-red-400 mb-2">
+        Delete user
+      </h2>
+      <p class="text-sm text-(--crit-fg-muted) mb-4">
+        This will permanently delete <strong class="text-(--crit-fg-primary)">{@delete_target.email}</strong>,
+        their reviews, and their comments. This cannot be undone.
+      </p>
+
+      <.form
+        for={%{}}
+        id="confirm-delete-form"
+        phx-change="validate_delete"
+        phx-submit="confirm_delete"
+      >
+        <label
+          for="delete-confirmation-input"
+          class="block text-sm text-(--crit-fg-primary) mb-2"
+        >
+          To confirm, type <strong class="font-semibold">{@delete_target.email}</strong> below:
+        </label>
+        <input
+          id="delete-confirmation-input"
+          type="text"
+          name="confirmation"
+          value={@delete_confirmation}
+          autocomplete="off"
+          autofocus
+          phx-debounce="100"
+          class="w-full bg-(--crit-bg-page) border border-(--crit-border) rounded-md px-3 py-2 text-sm text-(--crit-fg-primary) focus:outline-none focus:border-red-500 mb-4"
+        />
+
+        <div class="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            phx-click="cancel_delete"
+            class="inline-flex items-center px-3 py-1.5 rounded-md text-sm font-medium text-(--crit-fg-secondary) hover:text-(--crit-fg-primary) hover:bg-(--crit-row-hover) transition-colors cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={
+              String.downcase(String.trim(@delete_confirmation)) !=
+                String.downcase(@delete_target.email)
+            }
+            data-test="confirm-delete-user"
+            class="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-sm font-semibold bg-red-500/10 text-red-400 border border-red-500/30 hover:bg-red-500/20 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <.icon name="hero-trash" class="size-4" /> Delete user
+          </button>
+        </div>
+      </.form>
+    </div>
+  </div>
+</div>

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -60,7 +60,8 @@ defmodule CritWeb.ReviewLive do
               comments: serialize_comments(comments),
               display_name: display_name,
               files: files_data,
-              can_comment: can_comment?(scope, review)
+              can_comment: can_comment?(scope, review),
+              is_admin: Crit.Authorization.admin?(scope)
             })
           else
             socket

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -346,6 +346,7 @@
   </div>
 
   <% owner? = !!(@current_scope.user && @review.user_id == @current_scope.user.id) %>
+  <% can_delete_review? = Crit.Authorization.can?(@current_scope, :delete_review, @review) %>
   <% author = @review.user %>
   <% comment_count =
     Enum.reduce(@review.comments, 0, fn c, acc ->
@@ -504,7 +505,7 @@
               Raw
             </a>
           <% end %>
-          <%= if owner? do %>
+          <%= if can_delete_review? do %>
             <button
               phx-click="delete_review"
               data-confirm="Delete this review? This cannot be undone."

--- a/lib/crit_web/live/settings_live.ex
+++ b/lib/crit_web/live/settings_live.ex
@@ -21,7 +21,6 @@ defmodule CritWeb.SettingsLive do
       |> assign(:new_token_plaintext, nil)
       |> assign(:new_token_name, "")
       |> assign(:delete_confirmation, "")
-      |> assign(:keep_reviews, user.keep_reviews)
       |> assign(:selfhosted, Application.get_env(:crit, :selfhosted) == true)
       |> assign(:local_registration_enabled, local_registration_enabled)
       |> assign(:has_password, is_binary(user.hashed_password))
@@ -113,24 +112,6 @@ defmodule CritWeb.SettingsLive do
   end
 
   @impl true
-  def handle_event("toggle_keep_reviews", _params, socket) do
-    %{current_scope: scope} = socket.assigns
-    user = scope.user
-    new_value = !socket.assigns.keep_reviews
-
-    case Accounts.update_keep_reviews(user, new_value) do
-      {:ok, updated_user} ->
-        {:noreply,
-         socket
-         |> assign(:keep_reviews, new_value)
-         |> assign(:current_scope, Scope.put_user(scope, updated_user))}
-
-      {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to update setting.")}
-    end
-  end
-
-  @impl true
   def handle_event("create_token", %{"name" => name}, socket) do
     user = socket.assigns.current_scope.user
 
@@ -178,7 +159,7 @@ defmodule CritWeb.SettingsLive do
     user = socket.assigns.current_scope.user
 
     if socket.assigns.delete_confirmation == delete_confirmation_text(user) do
-      case Accounts.delete_account(user) do
+      case Accounts.delete_user(user) do
         :ok ->
           {:noreply,
            socket

--- a/lib/crit_web/live/settings_live.ex
+++ b/lib/crit_web/live/settings_live.ex
@@ -21,6 +21,7 @@ defmodule CritWeb.SettingsLive do
       |> assign(:new_token_plaintext, nil)
       |> assign(:new_token_name, "")
       |> assign(:delete_confirmation, "")
+      |> assign(:keep_reviews, user.keep_reviews)
       |> assign(:selfhosted, Application.get_env(:crit, :selfhosted) == true)
       |> assign(:local_registration_enabled, local_registration_enabled)
       |> assign(:has_password, is_binary(user.hashed_password))
@@ -108,6 +109,24 @@ defmodule CritWeb.SettingsLive do
 
       {:error, changeset} ->
         {:noreply, assign(socket, :password_form, to_form(changeset, as: "user"))}
+    end
+  end
+
+  @impl true
+  def handle_event("toggle_keep_reviews", _params, socket) do
+    %{current_scope: scope} = socket.assigns
+    user = scope.user
+    new_value = !socket.assigns.keep_reviews
+
+    case Accounts.update_keep_reviews(user, new_value) do
+      {:ok, updated_user} ->
+        {:noreply,
+         socket
+         |> assign(:keep_reviews, new_value)
+         |> assign(:current_scope, Scope.put_user(scope, updated_user))}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Failed to update setting.")}
     end
   end
 

--- a/lib/crit_web/live/settings_live.html.heex
+++ b/lib/crit_web/live/settings_live.html.heex
@@ -319,6 +319,41 @@
           </div>
         </section>
 
+        <%!-- Reviews section --%>
+        <section :if={!@selfhosted} id="reviews" class="mb-12">
+          <h2 class="text-lg font-semibold text-(--crit-fg-primary) pb-3 border-b border-(--crit-border) mb-6">
+            Reviews
+          </h2>
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <div class="text-sm font-medium text-(--crit-fg-primary)">
+                Keep reviews
+              </div>
+              <div class="text-xs text-(--crit-fg-muted) mt-1">
+                Prevent your reviews from being automatically deleted after 30 days of inactivity.
+              </div>
+            </div>
+            <button
+              id="keep-reviews-toggle"
+              phx-click="toggle_keep_reviews"
+              role="switch"
+              aria-checked={to_string(@keep_reviews)}
+              class={[
+                "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none",
+                if(@keep_reviews,
+                  do: "bg-(--crit-brand)",
+                  else: "bg-(--crit-border)"
+                )
+              ]}
+            >
+              <span class={[
+                "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform transition duration-200 ease-in-out",
+                if(@keep_reviews, do: "translate-x-5", else: "translate-x-0")
+              ]} />
+            </button>
+          </div>
+        </section>
+
         <%!-- API Tokens section --%>
         <section id="tokens" class="mb-12">
           <h2 class="text-lg font-semibold text-(--crit-fg-primary) pb-3 border-b border-(--crit-border) mb-4">

--- a/lib/crit_web/live/settings_live.html.heex
+++ b/lib/crit_web/live/settings_live.html.heex
@@ -319,41 +319,6 @@
           </div>
         </section>
 
-        <%!-- Reviews section --%>
-        <section :if={!@selfhosted} id="reviews" class="mb-12">
-          <h2 class="text-lg font-semibold text-(--crit-fg-primary) pb-3 border-b border-(--crit-border) mb-6">
-            Reviews
-          </h2>
-          <div class="flex items-start justify-between gap-4">
-            <div>
-              <div class="text-sm font-medium text-(--crit-fg-primary)">
-                Keep reviews
-              </div>
-              <div class="text-xs text-(--crit-fg-muted) mt-1">
-                Prevent your reviews from being automatically deleted after 30 days of inactivity.
-              </div>
-            </div>
-            <button
-              id="keep-reviews-toggle"
-              phx-click="toggle_keep_reviews"
-              role="switch"
-              aria-checked={to_string(@keep_reviews)}
-              class={[
-                "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none",
-                if(@keep_reviews,
-                  do: "bg-(--crit-brand)",
-                  else: "bg-(--crit-border)"
-                )
-              ]}
-            >
-              <span class={[
-                "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform transition duration-200 ease-in-out",
-                if(@keep_reviews, do: "translate-x-5", else: "translate-x-0")
-              ]} />
-            </button>
-          </div>
-        </section>
-
         <%!-- API Tokens section --%>
         <section id="tokens" class="mb-12">
           <h2 class="text-lg font-semibold text-(--crit-fg-primary) pb-3 border-b border-(--crit-border) mb-4">

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -110,6 +110,22 @@ defmodule CritWeb.Router do
     end
   end
 
+  # Admin panel — selfhosted-only. Gated by both the SelfhostedOnly plug and
+  # the `:require_admin` on_mount hook (the latter via ADMIN_EMAILS).
+  scope "/", CritWeb do
+    pipe_through [:browser, :noindex, CritWeb.Plugs.SelfhostedOnly]
+
+    live_session :admin_panel,
+      on_mount: [
+        {CritWeb.UserAuth, :require_authenticated_user},
+        {CritWeb.UserAuth, :require_admin}
+      ],
+      session: {CritWeb.Live.SessionHelper, :user_session_opts, []} do
+      live "/admin/users", AdminUsersLive, :index
+      live "/admin/settings", AdminSettingsLive, :index
+    end
+  end
+
   # Local-auth routes — only mounted on selfhosted instances.
   scope "/", CritWeb do
     pipe_through [

--- a/lib/crit_web/user_auth.ex
+++ b/lib/crit_web/user_auth.ex
@@ -209,6 +209,17 @@ defmodule CritWeb.UserAuth do
     end
   end
 
+  def on_mount(:require_admin, _params, _session, socket) do
+    if Crit.Accounts.Scope.admin?(socket.assigns.current_scope) do
+      {:cont, socket}
+    else
+      {:halt,
+       socket
+       |> Phoenix.LiveView.put_flash(:error, "Admins only.")
+       |> redirect(to: "/dashboard")}
+    end
+  end
+
   def on_mount(:require_selfhosted_auth, _params, session, socket) do
     if Application.get_env(:crit, :selfhosted) do
       socket = assign_scope(socket, session)

--- a/priv/repo/migrations/20260509194406_add_admin_role_and_settings.exs
+++ b/priv/repo/migrations/20260509194406_add_admin_role_and_settings.exs
@@ -1,0 +1,53 @@
+defmodule Crit.Repo.Migrations.AddAdminRoleAndSettings do
+  use Ecto.Migration
+
+  def change do
+    # ---- users.role + drop keep_reviews -------------------------------------
+    alter table(:users) do
+      add :role, :string, null: false, default: "user"
+      remove :keep_reviews, :boolean, default: false, null: false
+    end
+
+    create constraint(:users, :role_must_be_valid, check: "role IN ('admin', 'user')")
+
+    # ---- settings table -----------------------------------------------------
+    create table(:settings, primary_key: false) do
+      add :id, :integer, primary_key: true
+      add :max_document_bytes, :integer, null: false, default: 10_485_760
+      add :max_comments_per_review, :integer, null: false, default: 500
+      add :max_comment_body_bytes, :integer, null: false, default: 51_200
+      timestamps(type: :utc_datetime)
+    end
+
+    # Singleton: the settings table is intended to hold exactly one row,
+    # which represents this instance's configuration. The CHECK constraint
+    # `id = 1` means Postgres rejects any INSERT with a different id, so it's
+    # impossible to end up with two settings rows by accident. We seed id=1
+    # below and from then on every read/write targets `id = 1`.
+    create constraint(:settings, :singleton, check: "id = 1")
+
+    execute(
+      "INSERT INTO settings (id, inserted_at, updated_at) VALUES (1, NOW(), NOW())",
+      "DELETE FROM settings WHERE id = 1"
+    )
+
+    # ---- flip reviews.user_id and comments.user_id to delete_all ------------
+    # Existing FK names follow Ecto's default `<table>_<col>_fkey`. We drop
+    # the existing constraints, then re-add fresh ones with `on_delete:
+    # :delete_all`. `execute/2` is used (rather than `modify ... from:`) to
+    # avoid Ecto trying to drop the constraint a second time.
+    drop constraint(:reviews, "reviews_user_id_fkey")
+
+    execute(
+      "ALTER TABLE reviews ADD CONSTRAINT reviews_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE",
+      "ALTER TABLE reviews ADD CONSTRAINT reviews_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL"
+    )
+
+    drop constraint(:comments, "comments_user_id_fkey")
+
+    execute(
+      "ALTER TABLE comments ADD CONSTRAINT comments_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE",
+      "ALTER TABLE comments ADD CONSTRAINT comments_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL"
+    )
+  end
+end

--- a/priv/repo/migrations/20260509194406_add_admin_role_and_settings.exs
+++ b/priv/repo/migrations/20260509194406_add_admin_role_and_settings.exs
@@ -2,10 +2,13 @@ defmodule Crit.Repo.Migrations.AddAdminRoleAndSettings do
   use Ecto.Migration
 
   def change do
-    # ---- users.role + drop keep_reviews -------------------------------------
+    # ---- users.role ---------------------------------------------------------
+    # `keep_reviews` is intentionally NOT dropped here — it remains relevant
+    # for the hosted instance's 30-day-inactivity cleanup (see
+    # `Crit.Reviews.delete_inactive/1`). It is unrelated to account deletion,
+    # which is a hard cascade regardless of `keep_reviews`.
     alter table(:users) do
       add :role, :string, null: false, default: "user"
-      remove :keep_reviews, :boolean, default: false, null: false
     end
 
     create constraint(:users, :role_must_be_valid, check: "role IN ('admin', 'user')")

--- a/test/crit/accounts_admin_role_test.exs
+++ b/test/crit/accounts_admin_role_test.exs
@@ -1,0 +1,106 @@
+defmodule Crit.AccountsAdminRoleTest do
+  @moduledoc """
+  Tests for the env-driven admin role: `apply_role_for_email/1` and the
+  reconciliation pass invoked from `Crit.Release.migrate/0`.
+  """
+  use Crit.DataCase, async: false
+
+  alias Crit.Accounts
+  alias Crit.Repo
+  alias Crit.User
+
+  setup do
+    prev = Application.get_env(:crit, :admin_emails, [])
+    on_exit(fn -> Application.put_env(:crit, :admin_emails, prev) end)
+    :ok
+  end
+
+  defp set_admin_emails(emails), do: Application.put_env(:crit, :admin_emails, emails)
+
+  describe "apply_role_for_email/1" do
+    test "promotes a user whose email is listed" do
+      set_admin_emails(["alice@example.com"])
+      user = oauth_user("alice@example.com")
+      assert user.role == :admin
+    end
+
+    test "leaves a user as :user when not listed" do
+      set_admin_emails(["someone-else@example.com"])
+      user = oauth_user("alice@example.com")
+      assert user.role == :user
+    end
+
+    test "demotes an admin whose email is no longer listed" do
+      set_admin_emails(["alice@example.com"])
+      user = oauth_user("alice@example.com")
+      assert user.role == :admin
+
+      set_admin_emails([])
+      {:ok, demoted} = Accounts.apply_role_for_email(user)
+      assert demoted.role == :user
+    end
+
+    test "matches case-insensitively against the user email" do
+      # The runtime parser lowercases ADMIN_EMAILS. We verify the comparison
+      # downcases the user's email too (defensive — emails are also stored
+      # lowercased by the changesets).
+      set_admin_emails(["alice@example.com"])
+      user = oauth_user("AlIcE@Example.com")
+      assert user.role == :admin
+    end
+
+    test "no-op when role already matches" do
+      set_admin_emails([])
+      user = oauth_user("alice@example.com")
+      {:ok, same} = Accounts.apply_role_for_email(user)
+      assert same.role == :user
+    end
+  end
+
+  describe "register_user/1" do
+    test "applies admin role when email is in ADMIN_EMAILS" do
+      set_admin_emails(["new@example.com"])
+
+      {:ok, user} =
+        Accounts.register_user(%{email: "new@example.com", password: "hello world!"})
+
+      assert user.role == :admin
+    end
+  end
+
+  describe "Crit.Release.reconcile_admin_emails/0" do
+    test "promotes newly-listed emails and demotes no-longer-listed emails" do
+      set_admin_emails([])
+      a = oauth_user("a@example.com")
+      b = oauth_user("b@example.com")
+      assert a.role == :user
+      assert b.role == :user
+
+      # Promote `a` only.
+      set_admin_emails(["a@example.com"])
+      Crit.Release.reconcile_admin_emails()
+
+      assert Repo.get!(User, a.id).role == :admin
+      assert Repo.get!(User, b.id).role == :user
+
+      # Now swap: demote `a`, promote `b`.
+      set_admin_emails(["b@example.com"])
+      Crit.Release.reconcile_admin_emails()
+
+      assert Repo.get!(User, a.id).role == :user
+      assert Repo.get!(User, b.id).role == :admin
+    end
+  end
+
+  defp oauth_user(email) do
+    {:ok, user} =
+      Accounts.find_or_create_from_oauth("github", %{
+        "sub" => "uid_#{System.unique_integer([:positive])}",
+        "name" => "Test",
+        "email" => email,
+        "picture" => nil
+      })
+
+    user
+  end
+end

--- a/test/crit/accounts_delete_account_test.exs
+++ b/test/crit/accounts_delete_account_test.exs
@@ -1,7 +1,10 @@
-defmodule Crit.AccountsDeleteAccountTest do
+defmodule Crit.AccountsDeleteUserTest do
   use Crit.DataCase, async: true
 
-  alias Crit.{Accounts, Repo, User, UserApiToken}
+  alias Crit.{Accounts, Comment, Repo, Review, User, UserApiToken}
+  alias Crit.Accounts.Scope
+  alias Crit.DeviceCodes
+  alias Crit.DeviceCode
 
   @oauth_params %{
     "sub" => "delete_test_uid",
@@ -10,11 +13,11 @@ defmodule Crit.AccountsDeleteAccountTest do
     "picture" => "https://example.com/avatar.jpg"
   }
 
-  describe "delete_account/1" do
+  describe "delete_user/1" do
     test "deletes the user" do
       {:ok, user} = Accounts.find_or_create_from_oauth("github", @oauth_params)
 
-      assert :ok = Accounts.delete_account(user)
+      assert :ok = Accounts.delete_user(user)
       assert is_nil(Repo.get(User, user.id))
     end
 
@@ -22,31 +25,72 @@ defmodule Crit.AccountsDeleteAccountTest do
       {:ok, user} = Accounts.find_or_create_from_oauth("github", @oauth_params)
       {:ok, {_plaintext, token}} = Accounts.create_token(user, "my token")
 
-      assert :ok = Accounts.delete_account(user)
+      assert :ok = Accounts.delete_user(user)
       assert is_nil(Repo.get(UserApiToken, token.id))
     end
 
-    test "nilifies user_id on reviews (reviews preserved)" do
+    test "hard-cascades reviews owned by the user" do
       {:ok, user} = Accounts.find_or_create_from_oauth("github", @oauth_params)
 
       {:ok, review} =
         Crit.Reviews.create_review(
-          Crit.Accounts.Scope.for_user(user),
+          Scope.for_user(user),
           [%{"path" => "test.md", "content" => "# Test"}],
           0,
           [],
           []
         )
 
-      assert :ok = Accounts.delete_account(user)
+      assert :ok = Accounts.delete_user(user)
+      assert is_nil(Repo.get(Review, review.id))
+    end
 
-      updated_review = Repo.get!(Crit.Review, review.id)
-      assert is_nil(updated_review.user_id)
+    test "hard-cascades comments authored by the user" do
+      {:ok, user} = Accounts.find_or_create_from_oauth("github", @oauth_params)
+
+      # Create a review owned by another user, then a comment by `user` on it.
+      {:ok, owner} =
+        Accounts.find_or_create_from_oauth("github", %{
+          "sub" => "owner_uid",
+          "name" => "Owner",
+          "email" => "owner@example.com"
+        })
+
+      {:ok, review} =
+        Crit.Reviews.create_review(
+          Scope.for_user(owner),
+          [%{"path" => "test.md", "content" => "# Test"}],
+          0,
+          [],
+          []
+        )
+
+      {:ok, comment} =
+        Crit.Reviews.create_comment(
+          Scope.for_user(user),
+          review,
+          %{"start_line" => 1, "end_line" => 1, "body" => "hello", "scope" => "line"}
+        )
+
+      assert :ok = Accounts.delete_user(user)
+      assert is_nil(Repo.get(Comment, comment.id))
+      # The review (owned by `owner`) is preserved.
+      assert Repo.get(Review, review.id)
+    end
+
+    test "cascades device codes" do
+      {:ok, user} = Accounts.find_or_create_from_oauth("github", @oauth_params)
+
+      {:ok, %{record: dc}} = DeviceCodes.create_device_code()
+      {:ok, _} = DeviceCodes.authorize_device_code(dc.id, user)
+
+      assert :ok = Accounts.delete_user(user)
+      assert is_nil(Repo.get(DeviceCode, dc.id))
     end
 
     test "returns error for non-existent user" do
       fake_user = %User{id: Ecto.UUID.generate()}
-      assert {:error, :not_found} = Accounts.delete_account(fake_user)
+      assert {:error, :not_found} = Accounts.delete_user(fake_user)
     end
   end
 end

--- a/test/crit/authorization_test.exs
+++ b/test/crit/authorization_test.exs
@@ -1,19 +1,41 @@
 defmodule Crit.AuthorizationTest do
   use Crit.DataCase, async: false
 
+  alias Crit.Accounts.Scope
   alias Crit.Authorization
   alias Crit.User
 
-  defp admin, do: %User{id: Ecto.UUID.generate(), role: :admin, email: "alice@example.com"}
-  defp user, do: %User{id: Ecto.UUID.generate(), role: :user, email: "bob@example.com"}
+  defp admin do
+    Scope.for_user(%User{
+      id: Ecto.UUID.generate(),
+      role: :admin,
+      email: "alice@example.com",
+      name: "Alice"
+    })
+  end
+
+  defp user do
+    Scope.for_user(%User{
+      id: Ecto.UUID.generate(),
+      role: :user,
+      email: "bob@example.com",
+      name: "Bob"
+    })
+  end
+
+  defp anon, do: Scope.for_visitor(Ecto.UUID.generate())
 
   describe "admin?/1" do
-    test "true for admin role" do
+    test "true for admin scope" do
       assert Authorization.admin?(admin())
     end
 
-    test "false for user role" do
+    test "false for user scope" do
       refute Authorization.admin?(user())
+    end
+
+    test "false for anonymous scope" do
+      refute Authorization.admin?(anon())
     end
 
     test "false for nil" do
@@ -31,6 +53,11 @@ defmodule Crit.AuthorizationTest do
       refute Authorization.can?(user(), :manage_users)
       refute Authorization.can?(user(), :edit_settings)
     end
+
+    test "anon cannot" do
+      refute Authorization.can?(anon(), :manage_users)
+      refute Authorization.can?(anon(), :edit_settings)
+    end
   end
 
   describe "can?/3 :delete_review" do
@@ -39,12 +66,16 @@ defmodule Crit.AuthorizationTest do
     end
 
     test "user can delete their own review" do
-      u = user()
-      assert Authorization.can?(u, :delete_review, %{user_id: u.id})
+      scope = user()
+      assert Authorization.can?(scope, :delete_review, %{user_id: scope.user.id})
     end
 
     test "user cannot delete someone else's review" do
       refute Authorization.can?(user(), :delete_review, %{user_id: Ecto.UUID.generate()})
+    end
+
+    test "anon cannot delete any review" do
+      refute Authorization.can?(anon(), :delete_review, %{user_id: Ecto.UUID.generate()})
     end
   end
 
@@ -54,24 +85,30 @@ defmodule Crit.AuthorizationTest do
     end
 
     test "user can delete their own comment" do
-      u = user()
-      assert Authorization.can?(u, :delete_comment, %{user_id: u.id})
+      scope = user()
+      assert Authorization.can?(scope, :delete_comment, %{user_id: scope.user.id})
     end
 
     test "user cannot delete someone else's comment" do
       refute Authorization.can?(user(), :delete_comment, %{user_id: Ecto.UUID.generate()})
     end
+
+    test "anon cannot delete any comment" do
+      refute Authorization.can?(anon(), :delete_comment, %{user_id: Ecto.UUID.generate()})
+    end
   end
 
   describe "can?/3 :delete_user" do
     test "admin can delete any user" do
-      assert Authorization.can?(admin(), :delete_user, user())
-      assert Authorization.can?(admin(), :delete_user, admin())
+      assert Authorization.can?(admin(), :delete_user, %User{id: Ecto.UUID.generate()})
     end
 
     test "user cannot delete anyone" do
-      refute Authorization.can?(user(), :delete_user, user())
-      refute Authorization.can?(user(), :delete_user, admin())
+      refute Authorization.can?(user(), :delete_user, %User{id: Ecto.UUID.generate()})
+    end
+
+    test "anon cannot delete anyone" do
+      refute Authorization.can?(anon(), :delete_user, %User{id: Ecto.UUID.generate()})
     end
   end
 end

--- a/test/crit/authorization_test.exs
+++ b/test/crit/authorization_test.exs
@@ -4,18 +4,8 @@ defmodule Crit.AuthorizationTest do
   alias Crit.Authorization
   alias Crit.User
 
-  setup do
-    prev = Application.get_env(:crit, :admin_emails, [])
-    Application.put_env(:crit, :admin_emails, ["pinned@example.com"])
-    on_exit(fn -> Application.put_env(:crit, :admin_emails, prev) end)
-    :ok
-  end
-
   defp admin, do: %User{id: Ecto.UUID.generate(), role: :admin, email: "alice@example.com"}
   defp user, do: %User{id: Ecto.UUID.generate(), role: :user, email: "bob@example.com"}
-
-  defp pinned_admin,
-    do: %User{id: Ecto.UUID.generate(), role: :admin, email: "pinned@example.com"}
 
   describe "admin?/1" do
     test "true for admin role" do
@@ -28,21 +18,6 @@ defmodule Crit.AuthorizationTest do
 
     test "false for nil" do
       refute Authorization.admin?(nil)
-    end
-  end
-
-  describe "env_pinned?/1" do
-    test "true when email is in ADMIN_EMAILS" do
-      assert Authorization.env_pinned?(pinned_admin())
-    end
-
-    test "false when email is not in ADMIN_EMAILS" do
-      refute Authorization.env_pinned?(admin())
-    end
-
-    test "case-insensitive" do
-      u = %User{id: Ecto.UUID.generate(), role: :admin, email: "PINNED@example.COM"}
-      assert Authorization.env_pinned?(u)
     end
   end
 
@@ -89,12 +64,9 @@ defmodule Crit.AuthorizationTest do
   end
 
   describe "can?/3 :delete_user" do
-    test "admin can delete a non-pinned user" do
+    test "admin can delete any user" do
       assert Authorization.can?(admin(), :delete_user, user())
-    end
-
-    test "admin cannot delete a pinned user" do
-      refute Authorization.can?(admin(), :delete_user, pinned_admin())
+      assert Authorization.can?(admin(), :delete_user, admin())
     end
 
     test "user cannot delete anyone" do

--- a/test/crit/authorization_test.exs
+++ b/test/crit/authorization_test.exs
@@ -1,0 +1,105 @@
+defmodule Crit.AuthorizationTest do
+  use Crit.DataCase, async: false
+
+  alias Crit.Authorization
+  alias Crit.User
+
+  setup do
+    prev = Application.get_env(:crit, :admin_emails, [])
+    Application.put_env(:crit, :admin_emails, ["pinned@example.com"])
+    on_exit(fn -> Application.put_env(:crit, :admin_emails, prev) end)
+    :ok
+  end
+
+  defp admin, do: %User{id: Ecto.UUID.generate(), role: :admin, email: "alice@example.com"}
+  defp user, do: %User{id: Ecto.UUID.generate(), role: :user, email: "bob@example.com"}
+
+  defp pinned_admin,
+    do: %User{id: Ecto.UUID.generate(), role: :admin, email: "pinned@example.com"}
+
+  describe "admin?/1" do
+    test "true for admin role" do
+      assert Authorization.admin?(admin())
+    end
+
+    test "false for user role" do
+      refute Authorization.admin?(user())
+    end
+
+    test "false for nil" do
+      refute Authorization.admin?(nil)
+    end
+  end
+
+  describe "env_pinned?/1" do
+    test "true when email is in ADMIN_EMAILS" do
+      assert Authorization.env_pinned?(pinned_admin())
+    end
+
+    test "false when email is not in ADMIN_EMAILS" do
+      refute Authorization.env_pinned?(admin())
+    end
+
+    test "case-insensitive" do
+      u = %User{id: Ecto.UUID.generate(), role: :admin, email: "PINNED@example.COM"}
+      assert Authorization.env_pinned?(u)
+    end
+  end
+
+  describe "can?/3 :manage_users + :edit_settings" do
+    test "admin can" do
+      assert Authorization.can?(admin(), :manage_users)
+      assert Authorization.can?(admin(), :edit_settings)
+    end
+
+    test "user cannot" do
+      refute Authorization.can?(user(), :manage_users)
+      refute Authorization.can?(user(), :edit_settings)
+    end
+  end
+
+  describe "can?/3 :delete_review" do
+    test "admin can delete any review" do
+      assert Authorization.can?(admin(), :delete_review, %{user_id: Ecto.UUID.generate()})
+    end
+
+    test "user can delete their own review" do
+      u = user()
+      assert Authorization.can?(u, :delete_review, %{user_id: u.id})
+    end
+
+    test "user cannot delete someone else's review" do
+      refute Authorization.can?(user(), :delete_review, %{user_id: Ecto.UUID.generate()})
+    end
+  end
+
+  describe "can?/3 :delete_comment" do
+    test "admin can delete any comment" do
+      assert Authorization.can?(admin(), :delete_comment, %{user_id: Ecto.UUID.generate()})
+    end
+
+    test "user can delete their own comment" do
+      u = user()
+      assert Authorization.can?(u, :delete_comment, %{user_id: u.id})
+    end
+
+    test "user cannot delete someone else's comment" do
+      refute Authorization.can?(user(), :delete_comment, %{user_id: Ecto.UUID.generate()})
+    end
+  end
+
+  describe "can?/3 :delete_user" do
+    test "admin can delete a non-pinned user" do
+      assert Authorization.can?(admin(), :delete_user, user())
+    end
+
+    test "admin cannot delete a pinned user" do
+      refute Authorization.can?(admin(), :delete_user, pinned_admin())
+    end
+
+    test "user cannot delete anyone" do
+      refute Authorization.can?(user(), :delete_user, user())
+      refute Authorization.can?(user(), :delete_user, admin())
+    end
+  end
+end

--- a/test/crit/reviews_inactive_test.exs
+++ b/test/crit/reviews_inactive_test.exs
@@ -90,27 +90,11 @@ defmodule Crit.ReviewsInactiveTest do
       assert is_nil(Repo.get(Review, other.id))
     end
 
-    test "does not delete reviews owned by users with keep_reviews enabled" do
+    test "deletes stale reviews regardless of owner" do
       {:ok, user} =
         Accounts.find_or_create_from_oauth("github", %{
-          "sub" => "keep_#{System.unique_integer()}",
-          "name" => "Keeper"
-        })
-
-      {:ok, user} = Accounts.update_keep_reviews(user, true)
-
-      review = review_fixture(%{user_id: user.id})
-      set_last_activity(review, 31)
-
-      assert {:ok, 0} = Reviews.delete_inactive(30)
-      assert Repo.get(Review, review.id)
-    end
-
-    test "deletes stale reviews from users without keep_reviews" do
-      {:ok, user} =
-        Accounts.find_or_create_from_oauth("github", %{
-          "sub" => "nokeep_#{System.unique_integer()}",
-          "name" => "No Keep"
+          "sub" => "owned_#{System.unique_integer()}",
+          "name" => "Owner"
         })
 
       review = review_fixture(%{user_id: user.id})
@@ -118,22 +102,6 @@ defmodule Crit.ReviewsInactiveTest do
 
       assert {:ok, 1} = Reviews.delete_inactive(30)
       assert is_nil(Repo.get(Review, review.id))
-    end
-
-    test "deletes anonymous stale reviews even when keep_reviews users exist" do
-      {:ok, user} =
-        Accounts.find_or_create_from_oauth("github", %{
-          "sub" => "keeper2_#{System.unique_integer()}",
-          "name" => "Keeper"
-        })
-
-      {:ok, _user} = Accounts.update_keep_reviews(user, true)
-
-      anon_review = review_fixture()
-      set_last_activity(anon_review, 31)
-
-      assert {:ok, 1} = Reviews.delete_inactive(30)
-      assert is_nil(Repo.get(Review, anon_review.id))
     end
   end
 end

--- a/test/crit/reviews_inactive_test.exs
+++ b/test/crit/reviews_inactive_test.exs
@@ -90,11 +90,27 @@ defmodule Crit.ReviewsInactiveTest do
       assert is_nil(Repo.get(Review, other.id))
     end
 
-    test "deletes stale reviews regardless of owner" do
+    test "does not delete reviews owned by users with keep_reviews enabled" do
       {:ok, user} =
         Accounts.find_or_create_from_oauth("github", %{
-          "sub" => "owned_#{System.unique_integer()}",
-          "name" => "Owner"
+          "sub" => "keep_#{System.unique_integer()}",
+          "name" => "Keeper"
+        })
+
+      {:ok, user} = Accounts.update_keep_reviews(user, true)
+
+      review = review_fixture(%{user_id: user.id})
+      set_last_activity(review, 31)
+
+      assert {:ok, 0} = Reviews.delete_inactive(30)
+      assert Repo.get(Review, review.id)
+    end
+
+    test "deletes stale reviews from users without keep_reviews" do
+      {:ok, user} =
+        Accounts.find_or_create_from_oauth("github", %{
+          "sub" => "nokeep_#{System.unique_integer()}",
+          "name" => "No Keep"
         })
 
       review = review_fixture(%{user_id: user.id})
@@ -102,6 +118,22 @@ defmodule Crit.ReviewsInactiveTest do
 
       assert {:ok, 1} = Reviews.delete_inactive(30)
       assert is_nil(Repo.get(Review, review.id))
+    end
+
+    test "deletes anonymous stale reviews even when keep_reviews users exist" do
+      {:ok, user} =
+        Accounts.find_or_create_from_oauth("github", %{
+          "sub" => "keeper2_#{System.unique_integer()}",
+          "name" => "Keeper"
+        })
+
+      {:ok, _user} = Accounts.update_keep_reviews(user, true)
+
+      anon_review = review_fixture()
+      set_last_activity(anon_review, 31)
+
+      assert {:ok, 1} = Reviews.delete_inactive(30)
+      assert is_nil(Repo.get(Review, anon_review.id))
     end
   end
 end

--- a/test/crit/settings_test.exs
+++ b/test/crit/settings_test.exs
@@ -14,27 +14,56 @@ defmodule Crit.SettingsTest do
   end
 
   describe "update/1" do
-    test "happy path" do
+    test "MB/KB virtual fields write the underlying byte columns" do
       {:ok, updated} =
         Settings.update(%{
-          max_document_bytes: 1_000_000,
-          max_comments_per_review: 100,
-          max_comment_body_bytes: 2_000
+          "max_document_mb" => 5,
+          "max_comments_per_review" => 100,
+          "max_comment_body_kb" => 50
         })
 
       assert updated.id == 1
-      assert updated.max_document_bytes == 1_000_000
-      assert Settings.get().max_comments_per_review == 100
+      assert updated.max_document_bytes == 5 * 1_048_576
+      assert updated.max_comments_per_review == 100
+      assert updated.max_comment_body_bytes == 50 * 1024
+    end
+
+    test "fractional MB rounds to bytes" do
+      {:ok, updated} =
+        Settings.update(%{
+          "max_document_mb" => 1.5,
+          "max_comments_per_review" => 100,
+          "max_comment_body_kb" => 50
+        })
+
+      assert updated.max_document_bytes == round(1.5 * 1_048_576)
+    end
+
+    test "rejects zero" do
+      original = Settings.get()
+
+      assert {:error, changeset} =
+               Settings.update(%{
+                 "max_document_mb" => 0,
+                 "max_comments_per_review" => 100,
+                 "max_comment_body_kb" => 50
+               })
+
+      refute changeset.valid?
+      assert {_msg, _} = changeset.errors[:max_document_mb]
+      assert Settings.get().max_document_bytes == original.max_document_bytes
     end
 
     test "rejects negative numbers" do
-      original = Settings.get()
+      assert {:error, changeset} =
+               Settings.update(%{
+                 "max_document_mb" => 10,
+                 "max_comments_per_review" => 100,
+                 "max_comment_body_kb" => -1
+               })
 
-      assert {:error, changeset} = Settings.update(%{max_document_bytes: -1})
       refute changeset.valid?
-      assert {_msg, _} = changeset.errors[:max_document_bytes]
-
-      assert Settings.get().max_document_bytes == original.max_document_bytes
+      assert {_msg, _} = changeset.errors[:max_comment_body_kb]
     end
   end
 

--- a/test/crit/settings_test.exs
+++ b/test/crit/settings_test.exs
@@ -1,0 +1,53 @@
+defmodule Crit.SettingsTest do
+  use Crit.DataCase, async: true
+
+  alias Crit.Settings
+
+  describe "get/0" do
+    test "returns the seeded singleton row" do
+      setting = Settings.get()
+      assert setting.id == 1
+      assert is_integer(setting.max_document_bytes)
+      assert is_integer(setting.max_comments_per_review)
+      assert is_integer(setting.max_comment_body_bytes)
+    end
+  end
+
+  describe "update/1" do
+    test "happy path" do
+      {:ok, updated} =
+        Settings.update(%{
+          max_document_bytes: 1_000_000,
+          max_comments_per_review: 100,
+          max_comment_body_bytes: 2_000
+        })
+
+      assert updated.id == 1
+      assert updated.max_document_bytes == 1_000_000
+      assert Settings.get().max_comments_per_review == 100
+    end
+
+    test "rejects negative numbers" do
+      original = Settings.get()
+
+      assert {:error, changeset} = Settings.update(%{max_document_bytes: -1})
+      refute changeset.valid?
+      assert {_msg, _} = changeset.errors[:max_document_bytes]
+
+      assert Settings.get().max_document_bytes == original.max_document_bytes
+    end
+  end
+
+  describe "singleton invariant" do
+    test "the CHECK constraint refuses inserts with id != 1" do
+      assert_raise Ecto.ConstraintError, ~r/singleton/, fn ->
+        Crit.Repo.insert!(%Crit.Setting{
+          id: 2,
+          max_document_bytes: 1,
+          max_comments_per_review: 1,
+          max_comment_body_bytes: 1
+        })
+      end
+    end
+  end
+end

--- a/test/crit_web/live/admin_settings_live_test.exs
+++ b/test/crit_web/live/admin_settings_live_test.exs
@@ -1,0 +1,86 @@
+defmodule CritWeb.AdminSettingsLiveTest do
+  use CritWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Crit.AccountsFixtures
+  alias Crit.Repo
+  alias Crit.Settings
+
+  setup do
+    original = Application.get_env(:crit, :selfhosted)
+    Application.put_env(:crit, :selfhosted, true)
+    on_exit(fn -> restore_selfhosted(original) end)
+    :ok
+  end
+
+  defp restore_selfhosted(nil), do: Application.delete_env(:crit, :selfhosted)
+  defp restore_selfhosted(v), do: Application.put_env(:crit, :selfhosted, v)
+
+  defp create_admin!(email \\ "admin@example.com") do
+    user = AccountsFixtures.user_fixture(%{email: email})
+    {:ok, user} = user |> Crit.User.role_changeset(%{role: :admin}) |> Repo.update()
+    user
+  end
+
+  defp login(conn, user), do: init_test_session(conn, %{user_id: user.id})
+
+  describe "auth gate" do
+    test "non-admin is redirected to /dashboard", %{conn: conn} do
+      user = AccountsFixtures.user_fixture(%{email: "u@example.com"})
+      conn = login(conn, user)
+
+      assert {:error, {:redirect, %{to: "/dashboard"}}} = live(conn, ~p"/admin/settings")
+    end
+  end
+
+  describe "form" do
+    test "admin sees current values", %{conn: conn} do
+      conn = login(conn, create_admin!())
+
+      {:ok, _view, html} = live(conn, ~p"/admin/settings")
+      assert html =~ "Max document size"
+      assert html =~ "Max comments per review"
+      assert html =~ "Max comment body"
+    end
+
+    test "save converts MB/KB to bytes and updates the settings row", %{conn: conn} do
+      conn = login(conn, create_admin!())
+      {:ok, view, _html} = live(conn, ~p"/admin/settings")
+
+      view
+      |> form("#admin-settings-form",
+        setting: %{
+          max_document_mb: "1",
+          max_comments_per_review: "200",
+          max_comment_body_kb: "10"
+        }
+      )
+      |> render_submit()
+
+      assert %{
+               max_document_bytes: 1_048_576,
+               max_comments_per_review: 200,
+               max_comment_body_bytes: 10_240
+             } = Settings.get()
+    end
+
+    test "validation rejects non-positive numbers", %{conn: conn} do
+      conn = login(conn, create_admin!())
+      {:ok, view, _html} = live(conn, ~p"/admin/settings")
+
+      html =
+        view
+        |> form("#admin-settings-form",
+          setting: %{
+            max_document_mb: "-1",
+            max_comments_per_review: "0",
+            max_comment_body_kb: "0"
+          }
+        )
+        |> render_submit()
+
+      assert html =~ "must be greater than"
+    end
+  end
+end

--- a/test/crit_web/live/admin_users_live_test.exs
+++ b/test/crit_web/live/admin_users_live_test.exs
@@ -1,0 +1,161 @@
+defmodule CritWeb.AdminUsersLiveTest do
+  use CritWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Crit.ReviewsFixtures
+
+  alias Crit.Accounts
+  alias Crit.AccountsFixtures
+  alias Crit.Repo
+
+  setup do
+    original = Application.get_env(:crit, :selfhosted)
+    Application.put_env(:crit, :selfhosted, true)
+    on_exit(fn -> restore_selfhosted(original) end)
+    :ok
+  end
+
+  defp restore_selfhosted(nil), do: Application.delete_env(:crit, :selfhosted)
+  defp restore_selfhosted(v), do: Application.put_env(:crit, :selfhosted, v)
+
+  defp create_admin!(email \\ "admin@example.com") do
+    user = AccountsFixtures.user_fixture(%{email: email})
+    {:ok, user} = user |> Crit.User.role_changeset(%{role: :admin}) |> Repo.update()
+    user
+  end
+
+  defp create_user!(email) do
+    AccountsFixtures.user_fixture(%{email: email})
+  end
+
+  defp login(conn, user), do: init_test_session(conn, %{user_id: user.id})
+
+  describe "auth gate" do
+    test "non-admin is halted and redirected with flash", %{conn: conn} do
+      user = create_user!("regular@example.com")
+      conn = login(conn, user)
+
+      assert {:error, {:redirect, %{to: "/dashboard", flash: flash}}} =
+               live(conn, ~p"/admin/users")
+
+      assert flash["error"] =~ "Admins"
+    end
+
+    test "unauthenticated is redirected via :require_authenticated_user", %{conn: conn} do
+      assert {:error, {:redirect, %{to: to}}} = live(conn, ~p"/admin/users")
+      assert to =~ "log_in" or to =~ "/auth/login" or to == "/"
+    end
+  end
+
+  describe "admin user list" do
+    test "admin sees themselves and other users", %{conn: conn} do
+      admin = create_admin!()
+      _other = create_user!("alice@example.com")
+
+      conn = login(conn, admin)
+      {:ok, _view, html} = live(conn, ~p"/admin/users")
+
+      assert html =~ admin.email
+      assert html =~ "alice@example.com"
+    end
+  end
+
+  describe "delete user (with email confirmation)" do
+    test "admin deletes a non-admin user, cascading their reviews and comments", %{conn: conn} do
+      admin = create_admin!()
+      target = create_user!("victim@example.com")
+
+      review = review_fixture(user_id: target.id)
+
+      conn = login(conn, admin)
+      {:ok, view, _} = live(conn, ~p"/admin/users")
+
+      view
+      |> element("[data-test='delete-user-#{target.id}']")
+      |> render_click()
+
+      assert has_element?(view, "#delete-user-modal")
+
+      view
+      |> form("#confirm-delete-form", %{"confirmation" => target.email})
+      |> render_submit()
+
+      assert {:error, :not_found} = Accounts.get_user(target.id)
+      refute Repo.get(Crit.Review, review.id)
+    end
+
+    test "admin can delete a fellow admin (no env-pinned UI gate)", %{conn: conn} do
+      admin = create_admin!("a1@example.com")
+      other_admin = create_admin!("a2@example.com")
+
+      conn = login(conn, admin)
+      {:ok, view, _} = live(conn, ~p"/admin/users")
+
+      view
+      |> element("[data-test='delete-user-#{other_admin.id}']")
+      |> render_click()
+
+      view
+      |> form("#confirm-delete-form", %{"confirmation" => other_admin.email})
+      |> render_submit()
+
+      assert {:error, :not_found} = Accounts.get_user(other_admin.id)
+    end
+
+    test "wrong email leaves the user in place", %{conn: conn} do
+      admin = create_admin!()
+      target = create_user!("victim@example.com")
+
+      conn = login(conn, admin)
+      {:ok, view, _} = live(conn, ~p"/admin/users")
+
+      view
+      |> element("[data-test='delete-user-#{target.id}']")
+      |> render_click()
+
+      view
+      |> form("#confirm-delete-form", %{"confirmation" => "wrong@example.com"})
+      |> render_submit()
+
+      assert {:ok, _} = Accounts.get_user(target.id)
+      assert has_element?(view, "#delete-user-modal")
+    end
+
+    test "email match is case-insensitive and trims whitespace", %{conn: conn} do
+      admin = create_admin!()
+      target = create_user!("victim@example.com")
+
+      conn = login(conn, admin)
+      {:ok, view, _} = live(conn, ~p"/admin/users")
+
+      view
+      |> element("[data-test='delete-user-#{target.id}']")
+      |> render_click()
+
+      view
+      |> form("#confirm-delete-form", %{"confirmation" => "  VICTIM@Example.com  "})
+      |> render_submit()
+
+      assert {:error, :not_found} = Accounts.get_user(target.id)
+    end
+
+    test "cancel closes the modal without deleting", %{conn: conn} do
+      admin = create_admin!()
+      target = create_user!("victim@example.com")
+
+      conn = login(conn, admin)
+      {:ok, view, _} = live(conn, ~p"/admin/users")
+
+      view
+      |> element("[data-test='delete-user-#{target.id}']")
+      |> render_click()
+
+      assert has_element?(view, "#delete-user-modal")
+
+      view |> render_click("cancel_delete")
+
+      refute has_element?(view, "#delete-user-modal")
+      assert {:ok, _} = Accounts.get_user(target.id)
+    end
+  end
+end

--- a/test/crit_web/live/review_live_admin_test.exs
+++ b/test/crit_web/live/review_live_admin_test.exs
@@ -1,0 +1,94 @@
+defmodule CritWeb.ReviewLiveAdminTest do
+  use CritWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Crit.ReviewsFixtures
+
+  alias Crit.Accounts.Scope
+  alias Crit.AccountsFixtures
+  alias Crit.Repo
+  alias Crit.Reviews
+
+  defp create_admin!(email \\ "admin@example.com") do
+    user = AccountsFixtures.user_fixture(%{email: email})
+    {:ok, user} = user |> Crit.User.role_changeset(%{role: :admin}) |> Repo.update()
+    user
+  end
+
+  defp login(conn, user), do: init_test_session(conn, %{user_id: user.id})
+
+  setup do
+    Application.put_env(:crit, :selfhosted, false)
+    on_exit(fn -> Application.delete_env(:crit, :selfhosted) end)
+    :ok
+  end
+
+  describe "admin moderation via Reviews context" do
+    test "Reviews.delete_review/2 admits an admin scope on someone else's review" do
+      owner = AccountsFixtures.user_fixture(%{email: "owner@example.com"})
+      review = review_fixture(user_id: owner.id)
+
+      admin = create_admin!()
+      assert :ok = Reviews.delete_review(Scope.for_user(admin), review.id)
+      refute Repo.get(Crit.Review, review.id)
+    end
+
+    test "Reviews.delete_comment/2 admits an admin scope on someone else's comment" do
+      review = review_fixture()
+      comment = comment_fixture(review)
+
+      admin = create_admin!()
+      assert {:ok, _} = Reviews.delete_comment(Scope.for_user(admin), comment.id)
+      refute Repo.get(Crit.Comment, comment.id)
+    end
+
+    test "Reviews.delete_review/2 still rejects unauthorized non-admin user" do
+      owner = AccountsFixtures.user_fixture(%{email: "o@example.com"})
+      review = review_fixture(user_id: owner.id)
+
+      stranger = AccountsFixtures.user_fixture(%{email: "s@example.com"})
+      assert {:error, :unauthorized} = Reviews.delete_review(Scope.for_user(stranger), review.id)
+      assert Repo.get(Crit.Review, review.id)
+    end
+  end
+
+  describe "review LiveView delete-review button" do
+    test "admin sees the delete button on someone else's review", %{conn: conn} do
+      owner = AccountsFixtures.user_fixture(%{email: "owner@example.com"})
+      review = review_fixture(user_id: owner.id)
+
+      admin = create_admin!()
+      conn = login(conn, admin)
+
+      {:ok, _view, html} = live(conn, ~p"/r/#{review.token}")
+      assert html =~ "Delete"
+    end
+
+    test "non-admin stranger does not see the delete button", %{conn: conn} do
+      owner = AccountsFixtures.user_fixture(%{email: "owner@example.com"})
+      review = review_fixture(user_id: owner.id)
+
+      stranger = AccountsFixtures.user_fixture(%{email: "s@example.com"})
+      conn = login(conn, stranger)
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      refute view |> element("button[phx-click='delete_review']") |> has_element?()
+    end
+
+    test "admin clicking delete removes the review", %{conn: conn} do
+      owner = AccountsFixtures.user_fixture(%{email: "owner@example.com"})
+      review = review_fixture(user_id: owner.id)
+
+      admin = create_admin!()
+      conn = login(conn, admin)
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+      view
+      |> element("button[phx-click='delete_review']")
+      |> render_click()
+
+      refute Repo.get(Crit.Review, review.id)
+    end
+  end
+end

--- a/test/crit_web/live/settings_live_test.exs
+++ b/test/crit_web/live/settings_live_test.exs
@@ -359,4 +359,59 @@ defmodule CritWeb.SettingsLiveTest do
                live(conn, ~p"/settings")
     end
   end
+
+  describe "keep reviews toggle" do
+    test "shows toggle in off state by default", %{conn: conn} do
+      {conn, _user} = login_user(conn)
+
+      {:ok, view, _html} = live(conn, ~p"/settings")
+
+      assert has_element?(view, "#keep-reviews-toggle[aria-checked='false']")
+    end
+
+    test "toggling updates the setting", %{conn: conn} do
+      {conn, user} = login_user(conn)
+
+      {:ok, view, _html} = live(conn, ~p"/settings")
+
+      view
+      |> element("#keep-reviews-toggle")
+      |> render_click()
+
+      assert has_element?(view, "#keep-reviews-toggle[aria-checked='true']")
+
+      {:ok, updated} = Crit.Accounts.get_user(user.id)
+      assert updated.keep_reviews == true
+    end
+
+    test "toggling off after on", %{conn: conn} do
+      {conn, user} = login_user(conn)
+      {:ok, _} = Crit.Accounts.update_keep_reviews(user, true)
+
+      {:ok, view, _html} = live(conn, ~p"/settings")
+
+      assert has_element?(view, "#keep-reviews-toggle[aria-checked='true']")
+
+      view
+      |> element("#keep-reviews-toggle")
+      |> render_click()
+
+      assert has_element?(view, "#keep-reviews-toggle[aria-checked='false']")
+
+      {:ok, updated} = Crit.Accounts.get_user(user.id)
+      assert updated.keep_reviews == false
+    end
+
+    test "is hidden in selfhosted mode", %{conn: conn} do
+      Application.put_env(:crit, :selfhosted, true)
+      on_exit(fn -> Application.delete_env(:crit, :selfhosted) end)
+
+      {conn, _user} = login_user(conn)
+
+      {:ok, view, html} = live(conn, ~p"/settings")
+
+      refute has_element?(view, "#keep-reviews-toggle")
+      refute html =~ "Keep reviews"
+    end
+  end
 end

--- a/test/crit_web/live/settings_live_test.exs
+++ b/test/crit_web/live/settings_live_test.exs
@@ -218,61 +218,6 @@ defmodule CritWeb.SettingsLiveTest do
     end
   end
 
-  describe "keep reviews toggle" do
-    test "shows toggle in off state by default", %{conn: conn} do
-      {conn, _user} = login_user(conn)
-
-      {:ok, view, _html} = live(conn, ~p"/settings")
-
-      assert has_element?(view, "#keep-reviews-toggle[aria-checked='false']")
-    end
-
-    test "toggling updates the setting", %{conn: conn} do
-      {conn, user} = login_user(conn)
-
-      {:ok, view, _html} = live(conn, ~p"/settings")
-
-      view
-      |> element("#keep-reviews-toggle")
-      |> render_click()
-
-      assert has_element?(view, "#keep-reviews-toggle[aria-checked='true']")
-
-      {:ok, updated} = Crit.Accounts.get_user(user.id)
-      assert updated.keep_reviews == true
-    end
-
-    test "toggling off after on", %{conn: conn} do
-      {conn, user} = login_user(conn)
-      {:ok, _} = Crit.Accounts.update_keep_reviews(user, true)
-
-      {:ok, view, _html} = live(conn, ~p"/settings")
-
-      assert has_element?(view, "#keep-reviews-toggle[aria-checked='true']")
-
-      view
-      |> element("#keep-reviews-toggle")
-      |> render_click()
-
-      assert has_element?(view, "#keep-reviews-toggle[aria-checked='false']")
-
-      {:ok, updated} = Crit.Accounts.get_user(user.id)
-      assert updated.keep_reviews == false
-    end
-
-    test "is hidden in selfhosted mode", %{conn: conn} do
-      Application.put_env(:crit, :selfhosted, true)
-      on_exit(fn -> Application.delete_env(:crit, :selfhosted) end)
-
-      {conn, _user} = login_user(conn)
-
-      {:ok, view, html} = live(conn, ~p"/settings")
-
-      refute has_element?(view, "#keep-reviews-toggle")
-      refute html =~ "Keep reviews"
-    end
-  end
-
   describe "settings page title" do
     test "page title is Settings - Crit", %{conn: conn} do
       {conn, _user} = login_user(conn)

--- a/test/crit_web/user_auth_test.exs
+++ b/test/crit_web/user_auth_test.exs
@@ -193,6 +193,42 @@ defmodule CritWeb.UserAuthTest do
     end
   end
 
+  describe "on_mount :require_admin" do
+    test "halts and redirects to /dashboard for non-admin user" do
+      user = create_user!()
+
+      socket = %Phoenix.LiveView.Socket{
+        assigns: %{
+          __changed__: %{},
+          flash: %{},
+          current_scope: Scope.for_user(user)
+        }
+      }
+
+      assert {:halt, redirected} = UserAuth.on_mount(:require_admin, %{}, %{}, socket)
+      assert redirected.redirected == {:redirect, %{to: "/dashboard", status: 302}}
+    end
+
+    test "continues for admin user" do
+      user = create_user!()
+
+      {:ok, admin} =
+        user
+        |> Crit.User.role_changeset(%{role: :admin})
+        |> Crit.Repo.update()
+
+      socket = %Phoenix.LiveView.Socket{
+        assigns: %{
+          __changed__: %{},
+          flash: %{},
+          current_scope: Scope.for_user(admin)
+        }
+      }
+
+      assert {:cont, _socket} = UserAuth.on_mount(:require_admin, %{}, %{}, socket)
+    end
+  end
+
   describe "log_in_user/3" do
     test "writes user_id to the session", %{conn: conn} do
       user = AccountsFixtures.user_fixture()


### PR DESCRIPTION
## Summary
- New instance admin role driven entirely by `ADMIN_EMAILS` env var. Listed users are auto-promoted on every login and on app boot via `Crit.Release.reconcile_admin_emails/0`. Removing an email and restarting demotes.
- New `/admin/users` (list, hard-cascade delete with email-confirmation modal) and `/admin/settings` (instance limits) LiveViews, gated by `SelfhostedOnly` plug + `:require_admin` on_mount hook.
- `ReviewLive` moderation: admins can delete any review/comment/reply. Server-enforced via `Crit.Reviews` (`Scope.admin?`); JS gate is cosmetic.
- Hard-cascade user deletion: `reviews.user_id` and `comments.user_id` FKs flipped to `on_delete: :delete_all`. `keep_reviews` retained for the orthogonal hosted inactivity-cleanup feature.
- Singleton `settings` table for `max_document_bytes`, `max_comments_per_review`, `max_comment_body_bytes`. Form binds to virtual MB/KB fields; changeset converts to bytes on save. `Crit.Settings.get/0` sources runtime limits in `ApiController`, `Reviews`, and `Comment`.
- `%Scope{}` gains a `role` field; `Crit.Authorization` accepts `%Scope{}` directly.

## Review
- [x] Code review: passed (`/crit-review` — 2 BLOCKERs surfaced and fixed mid-review: `delete_reply` admin gate + JS reply-delete gate).
- [x] Parity audit: 100% — admin gate is web-only by design (CLI is single-user).

## Test plan
- 752 tests / 12 failures. origin/main baseline: 699 / 13. Net: +53 tests added, no regressions, 1 pre-existing failure fixed.
- Migration applied locally (`mix ecto.migrate` + rollback dry run).
- Manual verification: login → /admin/users renders, email-confirm delete works, /admin/settings save converts MB/KB to bytes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)