### PR TITLE
feat: linkify comment IDs in comment bodies

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -173,10 +173,11 @@
   --crit-editor-scrollbar-thumb: #3b4261;
 
   /* Comment reference chip */
-  --crit-comment-ref-bg:        rgba(125, 207, 255, 0.12);
-  --crit-comment-ref-color:     #7dcfff;
-  --crit-comment-ref-border:    rgba(125, 207, 255, 0.30);
-  --crit-comment-ref-hover-bg:  rgba(125, 207, 255, 0.22);
+  --crit-comment-ref-color:       #85aaf8;
+  --crit-comment-ref-color-hover: #94bcfb;
+  --crit-comment-ref-underline:   rgba(133, 170, 248, 0.35);
+  --crit-comment-ref-flash-bg:    rgba(187, 128, 9, 0.35);
+  --crit-comment-ref-flash-ring:  rgba(187, 128, 9, 0.85);
 }
 
 /* Content width toggle (matches crit local) */
@@ -2368,28 +2369,38 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 
 /* Comment Reference Chip */
 .comment-ref {
-  display: inline-block;
-  padding: 0 4px;
-  border-radius: 3px;
   font-family: var(--crit-font-mono);
-  font-size: 0.85em;
-  background: var(--crit-comment-ref-bg);
+  font-size: 0.92em;
   color: var(--crit-comment-ref-color);
-  border: 1px solid var(--crit-comment-ref-border);
-  cursor: pointer;
   text-decoration: none;
-  transition: background var(--crit-dur-fast) var(--crit-ease);
-  white-space: nowrap;
+  cursor: pointer;
+  border-radius: 3px;
+  padding: 0 1px;
+  margin: 0 -1px;
+  transition:
+    color var(--crit-dur-fast) var(--crit-ease),
+    background-color 1.6s var(--crit-ease),
+    box-shadow 1.6s var(--crit-ease);
 }
 .comment-ref:hover {
-  background: var(--crit-comment-ref-hover-bg);
+  color: var(--crit-comment-ref-color-hover);
+  text-decoration: underline;
+  text-decoration-color: var(--crit-comment-ref-underline);
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+}
+.comment-ref:focus-visible {
+  outline: 2px solid var(--crit-comment-ref-color);
+  outline-offset: 2px;
+  text-decoration: none;
 }
 .comment-ref-flash {
-  animation: comment-ref-flash 1.2s ease-out;
+  animation: comment-ref-flash 1.6s var(--crit-ease);
 }
 @keyframes comment-ref-flash {
-  0%   { box-shadow: 0 0 0 3px var(--crit-comment-ref-color); }
-  100% { box-shadow: 0 0 0 3px transparent; }
+  0%   { background-color: var(--crit-comment-ref-flash-bg); box-shadow: 0 0 0 2px var(--crit-comment-ref-flash-ring); }
+  15%  { background-color: var(--crit-comment-ref-flash-bg); box-shadow: 0 0 0 2px var(--crit-comment-ref-flash-ring); }
+  100% { background-color: transparent; box-shadow: 0 0 0 2px transparent; }
 }
 
 /* Save Template Dialog */

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -425,9 +425,9 @@
   --crit-editor-scrollbar-bg:    #ffffff;
   --crit-editor-scrollbar-thumb: #d1d9e0;
   /* Comment reference chip (light) */
-  --crit-comment-ref-color:       #0c2461;
-  --crit-comment-ref-color-hover: #071440;
-  --crit-comment-ref-underline:   rgba(12, 36, 97, 0.55);
+  --crit-comment-ref-color:       #0550ae;
+  --crit-comment-ref-color-hover: #033d8b;
+  --crit-comment-ref-underline:   rgba(5, 80, 174, 0.50);
   --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
   --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
 }
@@ -553,9 +553,9 @@
     --crit-editor-scrollbar-bg:    #ffffff;
     --crit-editor-scrollbar-thumb: #d1d9e0;
     /* Comment reference chip (light) */
-    --crit-comment-ref-color:       #0c2461;
-    --crit-comment-ref-color-hover: #071440;
-    --crit-comment-ref-underline:   rgba(12, 36, 97, 0.55);
+    --crit-comment-ref-color:       #0550ae;
+    --crit-comment-ref-color-hover: #033d8b;
+    --crit-comment-ref-underline:   rgba(5, 80, 174, 0.50);
     --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
     --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
   }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -304,6 +304,12 @@
   --crit-editor-fg-muted:        #9aa1c8;
   --crit-editor-scrollbar-bg:    #1a1b26;
   --crit-editor-scrollbar-thumb: #3b4261;
+  /* Comment reference chip (dark) */
+  --crit-comment-ref-color:       #85aaf8;
+  --crit-comment-ref-color-hover: #94bcfb;
+  --crit-comment-ref-underline:   rgba(133, 170, 248, 0.35);
+  --crit-comment-ref-flash-bg:    rgba(187, 128, 9, 0.35);
+  --crit-comment-ref-flash-ring:  rgba(187, 128, 9, 0.85);
 }
 
 [data-theme="light"] {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -171,6 +171,12 @@
   --crit-editor-fg-muted:        #9aa1c8;
   --crit-editor-scrollbar-bg:    #1a1b26;
   --crit-editor-scrollbar-thumb: #3b4261;
+
+  /* Comment reference chip */
+  --crit-comment-ref-bg:        rgba(125, 207, 255, 0.12);
+  --crit-comment-ref-color:     #7dcfff;
+  --crit-comment-ref-border:    rgba(125, 207, 255, 0.30);
+  --crit-comment-ref-hover-bg:  rgba(125, 207, 255, 0.22);
 }
 
 /* Content width toggle (matches crit local) */
@@ -2358,6 +2364,32 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   padding: 1px 5px;
   border-radius: 3px;
   white-space: nowrap;
+}
+
+/* Comment Reference Chip */
+.comment-ref {
+  display: inline-block;
+  padding: 0 4px;
+  border-radius: 3px;
+  font-family: var(--crit-font-mono);
+  font-size: 0.85em;
+  background: var(--crit-comment-ref-bg);
+  color: var(--crit-comment-ref-color);
+  border: 1px solid var(--crit-comment-ref-border);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background var(--crit-dur-fast) var(--crit-ease);
+  white-space: nowrap;
+}
+.comment-ref:hover {
+  background: var(--crit-comment-ref-hover-bg);
+}
+.comment-ref-flash {
+  animation: comment-ref-flash 1.2s ease-out;
+}
+@keyframes comment-ref-flash {
+  0%   { box-shadow: 0 0 0 3px var(--crit-comment-ref-color); }
+  100% { box-shadow: 0 0 0 3px transparent; }
 }
 
 /* Save Template Dialog */

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -173,6 +173,7 @@
   --crit-editor-scrollbar-thumb: #3b4261;
 
   /* Comment reference chip */
+  /* dark theme */
   --crit-comment-ref-color:       #85aaf8;
   --crit-comment-ref-color-hover: #94bcfb;
   --crit-comment-ref-underline:   rgba(133, 170, 248, 0.35);
@@ -423,6 +424,12 @@
   --crit-editor-fg-muted:        #59636e;
   --crit-editor-scrollbar-bg:    #ffffff;
   --crit-editor-scrollbar-thumb: #d1d9e0;
+  /* Comment reference chip (light) */
+  --crit-comment-ref-color:       #0550ae;
+  --crit-comment-ref-color-hover: #033d8b;
+  --crit-comment-ref-underline:   rgba(5, 80, 174, 0.50);
+  --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
+  --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
 }
 
 /* System preference: light — overrides dark :root defaults when OS is light */
@@ -545,6 +552,12 @@
     --crit-editor-fg-muted:        #59636e;
     --crit-editor-scrollbar-bg:    #ffffff;
     --crit-editor-scrollbar-thumb: #d1d9e0;
+    /* Comment reference chip (light) */
+    --crit-comment-ref-color:       #0550ae;
+    --crit-comment-ref-color-hover: #033d8b;
+    --crit-comment-ref-underline:   rgba(5, 80, 174, 0.50);
+    --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
+    --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
   }
 }
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -425,9 +425,9 @@
   --crit-editor-scrollbar-bg:    #ffffff;
   --crit-editor-scrollbar-thumb: #d1d9e0;
   /* Comment reference chip (light) */
-  --crit-comment-ref-color:       #0550ae;
-  --crit-comment-ref-color-hover: #033d8b;
-  --crit-comment-ref-underline:   rgba(5, 80, 174, 0.50);
+  --crit-comment-ref-color:       #0c2461;
+  --crit-comment-ref-color-hover: #071440;
+  --crit-comment-ref-underline:   rgba(12, 36, 97, 0.55);
   --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
   --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
 }
@@ -553,9 +553,9 @@
     --crit-editor-scrollbar-bg:    #ffffff;
     --crit-editor-scrollbar-thumb: #d1d9e0;
     /* Comment reference chip (light) */
-    --crit-comment-ref-color:       #0550ae;
-    --crit-comment-ref-color-hover: #033d8b;
-    --crit-comment-ref-underline:   rgba(5, 80, 174, 0.50);
+    --crit-comment-ref-color:       #0c2461;
+    --crit-comment-ref-color-hover: #071440;
+    --crit-comment-ref-underline:   rgba(12, 36, 97, 0.55);
     --crit-comment-ref-flash-bg:    rgba(255, 212, 59, 0.55);
     --crit-comment-ref-flash-ring:  rgba(154, 103, 0, 0.70);
   }

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -77,6 +77,62 @@ commentMd.renderer.rules.file_ref = function(tokens, idx) {
   return '<span class="file-ref">' + escapeHtml(path) + '</span>'
 }
 
+// ===== Comment Reference Inline Rule =====
+// Linkify bare comment IDs (c_, r_, rp_ + 6+ hex chars) in comment bodies.
+commentMd.inline.ruler.push('comment_ref', (state, silent) => {
+  const start = state.pos
+  const src = state.src
+  const m = /^(c|r|rp)_[a-f0-9]{6,}/.exec(src.slice(start))
+  if (!m) return false
+  if (start > 0 && /[a-zA-Z0-9_]/.test(src[start - 1])) return false
+  const end = start + m[0].length
+  if (end < src.length && /[a-zA-Z0-9_]/.test(src[end])) return false
+  if (!silent) {
+    const token = state.push('comment_ref', '', 0)
+    token.content = m[0]
+  }
+  state.pos = end
+  return true
+})
+commentMd.renderer.rules.comment_ref = (tokens, idx) => {
+  const id = tokens[idx].content
+  return '<span class="comment-ref" data-ref-id="' + escapeHtml(id) + '">' + escapeHtml(id) + '</span>'
+}
+
+// Override code_inline so backtick-wrapped comment IDs render as the same chip.
+const defaultCodeInline = commentMd.renderer.rules.code_inline || function(tokens, idx, options, env, self) {
+  return self.renderToken(tokens, idx, options)
+}
+commentMd.renderer.rules.code_inline = function(tokens, idx, options, env, self) {
+  const content = tokens[idx].content
+  if (/^(c|r|rp)_[a-f0-9]{6,}$/.test(content)) {
+    return '<span class="comment-ref comment-ref-code" data-ref-id="' + escapeHtml(content) + '">' + escapeHtml(content) + '</span>'
+  }
+  return defaultCodeInline(tokens, idx, options, env, self)
+}
+
+// Scroll/expand/flash a comment card located anywhere in the document, given just its id.
+function scrollToCommentRef(id) {
+  const card = document.querySelector(`.comment-card[data-comment-id="${CSS.escape(id)}"]`)
+  if (!card) return
+  const section = card.closest('details')
+  if (section && !section.open) section.open = true
+  if (card.classList.contains('collapsed')) {
+    card.classList.remove('collapsed')
+    commentCollapseOverrides[id] = false
+  }
+  card.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  card.classList.add('comment-ref-flash')
+  setTimeout(() => { card.classList.remove('comment-ref-flash') }, 1200)
+}
+
+document.addEventListener('click', (e) => {
+  const ref = e.target.closest && e.target.closest('.comment-ref')
+  if (!ref) return
+  e.preventDefault()
+  scrollToCommentRef(ref.dataset.refId)
+})
+
 // ===== Word-Level Diff =====
 
 // Split a line into tokens: words (alphanumeric + underscore) and individual non-word characters.

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -77,28 +77,6 @@ commentMd.renderer.rules.file_ref = function(tokens, idx) {
   return '<span class="file-ref">' + escapeHtml(path) + '</span>'
 }
 
-// ===== Comment Reference Inline Rule =====
-// Linkify bare comment IDs (c_, r_, rp_ + 6+ hex chars) in comment bodies.
-commentMd.inline.ruler.push('comment_ref', (state, silent) => {
-  const start = state.pos
-  const src = state.src
-  const m = /^(c|r|rp)_[a-f0-9]{6,}/.exec(src.slice(start))
-  if (!m) return false
-  if (start > 0 && /[a-zA-Z0-9_]/.test(src[start - 1])) return false
-  const end = start + m[0].length
-  if (end < src.length && /[a-zA-Z0-9_]/.test(src[end])) return false
-  if (!silent) {
-    const token = state.push('comment_ref', '', 0)
-    token.content = m[0]
-  }
-  state.pos = end
-  return true
-})
-commentMd.renderer.rules.comment_ref = (tokens, idx) => {
-  const id = tokens[idx].content
-  return '<span class="comment-ref" data-ref-id="' + escapeHtml(id) + '">' + escapeHtml(id) + '</span>'
-}
-
 // Override code_inline so backtick-wrapped comment IDs render as the same chip.
 const defaultCodeInline = commentMd.renderer.rules.code_inline || function(tokens, idx, options, env, self) {
   return self.renderToken(tokens, idx, options)
@@ -109,6 +87,34 @@ commentMd.renderer.rules.code_inline = function(tokens, idx, options, env, self)
     return '<span class="comment-ref comment-ref-code" data-ref-id="' + escapeHtml(content) + '">' + escapeHtml(content) + '</span>'
   }
   return defaultCodeInline(tokens, idx, options, env, self)
+}
+
+function linkifyCommentRefsInDom(el) {
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null, false)
+  const textNodes = []
+  let node
+  while ((node = walker.nextNode())) {
+    if (node.parentNode.closest('code, pre, .comment-ref')) continue
+    textNodes.push(node)
+  }
+  const re = /((?:c|r|rp)_[a-f0-9]{6,})/g
+  textNodes.forEach(tn => {
+    if (!re.test(tn.nodeValue)) { re.lastIndex = 0; return }
+    re.lastIndex = 0
+    const frag = document.createDocumentFragment()
+    let last = 0, m
+    while ((m = re.exec(tn.nodeValue)) !== null) {
+      if (m.index > last) frag.appendChild(document.createTextNode(tn.nodeValue.slice(last, m.index)))
+      const span = document.createElement('span')
+      span.className = 'comment-ref'
+      span.dataset.refId = m[1]
+      span.textContent = m[1]
+      frag.appendChild(span)
+      last = m.index + m[0].length
+    }
+    if (last < tn.nodeValue.length) frag.appendChild(document.createTextNode(tn.nodeValue.slice(last)))
+    tn.parentNode.replaceChild(frag, tn)
+  })
 }
 
 // Scroll/expand/flash a comment card located anywhere in the document, given just its id.
@@ -2758,6 +2764,7 @@ function createCommentElement(comment, ctx) {
     }
   }
   body.innerHTML = commentMd.render(comment.body, env)
+  linkifyCommentRefsInDom(body)
 
   card.appendChild(header)
   card.appendChild(body)
@@ -3160,6 +3167,7 @@ function renderReplyList(comment, ctx) {
     replyBody.className = 'reply-body'
     replyBody.dataset.rawBody = reply.body
     replyBody.innerHTML = commentMd.render(reply.body)
+    linkifyCommentRefsInDom(replyBody)
     replyEl.appendChild(replyBody)
 
     repliesContainer.appendChild(replyEl)
@@ -3418,6 +3426,7 @@ function createResolvedElement(comment, ctx) {
     }
   }
   body.innerHTML = commentMd.render(comment.body, env)
+  linkifyCommentRefsInDom(body)
 
   card.appendChild(header)
   card.appendChild(body)
@@ -4090,6 +4099,7 @@ function renderPanelCard(ctx, comment, filePath) {
     }
   }
   bodyEl.innerHTML = commentMd.render(comment.body, env)
+  linkifyCommentRefsInDom(bodyEl)
   card.appendChild(bodyEl)
 
   // Replies (read-only in panel)
@@ -5022,7 +5032,7 @@ export const DocumentRenderer = {
       const card = ctx.el.querySelector(`.comment-card[data-comment-id="${id}"]`)
       if (card) {
         const bodyEl = card.querySelector('.comment-body')
-        if (bodyEl) bodyEl.innerHTML = commentMd.render(body)
+        if (bodyEl) { bodyEl.innerHTML = commentMd.render(body); linkifyCommentRefsInDom(bodyEl) }
       }
       rerenderPanel(ctx)
     })
@@ -5090,6 +5100,7 @@ export const DocumentRenderer = {
         if (bodyEl) {
           bodyEl.dataset.rawBody = body
           bodyEl.innerHTML = commentMd.render(body)
+          linkifyCommentRefsInDom(bodyEl)
         }
       }
       rerenderPanel(ctx)

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -128,8 +128,10 @@ function scrollToCommentRef(id) {
     commentCollapseOverrides[id] = false
   }
   card.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  card.classList.remove('comment-ref-flash')
+  void card.offsetWidth
   card.classList.add('comment-ref-flash')
-  setTimeout(() => { card.classList.remove('comment-ref-flash') }, 1200)
+  setTimeout(() => { card.classList.remove('comment-ref-flash') }, 1650)
 }
 
 document.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- Comment IDs (`c_*`, `r_*`, `rp_*`) in comment bodies now render as monospace link chips — bare text and backtick-wrapped forms both handled
- Clicking a chip opens the file section if collapsed, expands the card, scrolls to it, and flashes it with a warm yellow highlight (GitHub Primer attention pattern)
- GitHub-style visual: no background at rest, underline on hover, 1.6s fade flash on click; restarts cleanly on rapid double-click
- Light/dark theme vars defined in all 4 CSS blocks (`[data-theme=dark]` block fix included)

## Review
- [x] Code review: passed
- [x] Parity audit: passed (JS logic, CSS rules, theme vars all in sync with crit CLI)

## Test plan
- DOM post-processing via TreeWalker correctly skips `code`/`pre` elements
- Flash animation restarts on re-click (remove+reflow+add pattern)
- See also: tomasz-tomczyk/crit#515 — CLI counterpart PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)