### PR TITLE
feat: add copy-path button to file headers

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2570,6 +2570,9 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   font-weight: 500;
   color: var(--crit-editor-fg);
   flex: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 .file-header-name .dir { color: var(--crit-editor-fg-muted); }
 
@@ -2801,6 +2804,30 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 
 .tree-dir {
   color: var(--crit-editor-fg-muted);
+}
+
+/* Copy path button in file header */
+.file-header-copy-path {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  color: var(--crit-editor-fg-muted);
+  opacity: 0;
+  transition: opacity 0.15s;
+  line-height: 1;
+  border-radius: 3px;
+}
+.file-header:hover .file-header-copy-path,
+.file-header-copy-path:focus-visible {
+  opacity: 1;
+}
+.file-header-copy-path:hover {
+  color: var(--crit-brand);
 }
 
 /* Comment badge in tree */

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -2061,9 +2061,24 @@ function renderFileSection(ctx, file) {
   header.innerHTML =
     '<div class="file-header-chevron"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg></div>' +
     '<svg class="file-header-icon" viewBox="0 0 16 16" fill="var(--crit-editor-fg-muted)"><path fill-rule="evenodd" d="M3.75 1.5a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V6H9.75A1.75 1.75 0 0 1 8 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25V1.75z"/></svg>' +
-    '<span class="file-header-name"><span class="dir">' + escapeHtml(dirPath) + '</span>' + escapeHtml(fileName) + '</span>' +
+    '<span class="file-header-name"><span class="dir">' + escapeHtml(dirPath) + '</span>' + escapeHtml(fileName) +
+      '<button type="button" class="file-header-copy-path" aria-label="Copy file path"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25v-7.5z"/><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25v-7.5zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25h-7.5z"/></svg></button>' +
+    '</span>' +
     (file.orphaned ? '<span class="file-header-badge removed">Removed</span>' : '') +
     '<a class="crit-round-diff-btn" href="' + rawHref + '" target="_blank" rel="noopener" title="View raw">Raw</a>'
+
+  ;(function(filePath) {
+    const copyPathBtn = header.querySelector('.file-header-copy-path')
+    const clipboardSVG = copyPathBtn.innerHTML
+    const checkSVG = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/></svg>'
+    copyPathBtn.addEventListener('click', function(e) {
+      e.preventDefault()
+      e.stopPropagation()
+      navigator.clipboard.writeText(filePath)
+      copyPathBtn.innerHTML = checkSVG
+      setTimeout(function() { copyPathBtn.innerHTML = clipboardSVG }, 1500)
+    })
+  })(file.path)
 
   // File comment button — not for orphaned files (no point adding comments to removed files).
   // Also gated on canComment: when policy disallows new comments, don't create the


### PR DESCRIPTION
## Summary
- Copy-to-clipboard button next to each file path in the file section header
- Visible on hover (and keyboard focus), copies relative path
- Checkmark feedback for 1.5s after copy
- Parity with crit/ local CLI

## Test plan
- Hover file header → copy icon appears → click → path copied, checkmark shown
- Keyboard tab to button → focus-visible reveals it
- Click does not toggle file section collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)