### PR TITLE
feat: add HEEx syntax highlighting for .heex/.leex files

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1,11 +1,13 @@
 import markdownit from "markdown-it"
 import hljs from "highlight.js"
 import { registerMarkdownPatch } from "./highlight-markdown-patch"
+import { heex } from "highlightjs-heex"
 import { makeDiff, cleanupSemantic, DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT } from "@sanity/diff-match-patch"
 
 // Re-register hljs 'markdown' with patched grammar. Must run before any
 // hljs.highlight() call. See highlight-markdown-patch.js for rationale.
 registerMarkdownPatch(hljs)
+hljs.registerLanguage('heex', heex)
 
 // ---- Helpers ----------------------------------------------------------------
 
@@ -865,6 +867,8 @@ const EXT_OVERRIDES = {
   sh: 'bash',
   zig: 'zig',
   md: 'markdown',    // normalize: callers compare lang against 'markdown'
+  heex: 'heex',
+  leex: 'heex',
 }
 // Files identified by basename rather than extension.
 const BASENAME_LANG = {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -13,6 +13,7 @@
         "@sentry/browser": "^10.51.0",
         "@tailwindcss/typography": "^0.5.19",
         "highlight.js": "^11.11.1",
+        "highlightjs-heex": "^1.0.1",
         "markdown-it": "^14.1.1",
         "mermaid": "^11.14.0"
       }
@@ -1099,6 +1100,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/highlightjs-heex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/highlightjs-heex/-/highlightjs-heex-1.0.1.tgz",
+      "integrity": "sha512-tAkFBN9eW8IvyIwLaVBCLR1zJqeD++lJI62gXnPGXEQcf2kmu6xfXZIAA0XVl/kJb43MCdfjO2sXIKzXSZmzNw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "highlight.js": ">=11.0.0"
       }
     },
     "node_modules/iconv-lite": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -15,6 +15,7 @@
     "@sentry/browser": "^10.51.0",
     "@tailwindcss/typography": "^0.5.19",
     "highlight.js": "^11.11.1",
+    "highlightjs-heex": "^1.0.1",
     "markdown-it": "^14.1.1",
     "mermaid": "^11.14.0"
   }


### PR DESCRIPTION
## Summary
- Add HEEx (HTML+Embedded Elixir) syntax highlighting using the [`highlightjs-heex`](https://www.npmjs.com/package/highlightjs-heex) npm package
- Register heex/leex extensions in `EXT_OVERRIDES` for automatic language detection
- Phoenix LiveView templates now get combined HTML + Elixir highlighting

## Review
- [x] Code review: passed
- [x] Parity audit: matching changes in tomasz-tomczyk/crit

## Test plan
- Verified highlighting renders correctly on a real .heex file via local crit build
- mix precommit passes (752 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)