### PR TITLE
fix: pre-release audit fixes (rate limiter config, admin demotion, clipboard)

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -2078,9 +2078,10 @@ function renderFileSection(ctx, file) {
     copyPathBtn.addEventListener('click', function(e) {
       e.preventDefault()
       e.stopPropagation()
-      navigator.clipboard.writeText(filePath)
-      copyPathBtn.innerHTML = checkSVG
-      setTimeout(function() { copyPathBtn.innerHTML = clipboardSVG }, 1500)
+      navigator.clipboard.writeText(filePath).then(function() {
+        copyPathBtn.innerHTML = checkSVG
+        setTimeout(function() { copyPathBtn.innerHTML = clipboardSVG }, 1500)
+      }).catch(function() { /* clipboard not available */ })
     })
   })(file.path)
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -47,6 +47,7 @@ config :crit, start_changelog: false
 # Disable global rate limit in tests — shared 127.0.0.1 + persistent ETS would
 # trip the limiter across the suite. Plug-specific tests opt back in locally.
 config :crit, CritWeb.Plugs.RateLimit, disabled: true
+config :crit, CritWeb.Plugs.AuthRateLimit, disabled: true
 
 config :crit, :oauth_provider,
   strategy: Assent.Strategy.Github,

--- a/lib/crit/release.ex
+++ b/lib/crit/release.ex
@@ -42,11 +42,13 @@ defmodule Crit.Release do
         end
 
         # Demote any admin whose email is no longer listed.
-        from(u in Crit.User,
-          where: u.role == ^:admin and fragment("lower(?)", u.email) not in ^emails,
-          update: [set: [role: ^:user, updated_at: ^now]]
-        )
-        |> Crit.Repo.update_all([])
+        if emails != [] do
+          from(u in Crit.User,
+            where: u.role == ^:admin and fragment("lower(?)", u.email) not in ^emails,
+            update: [set: [role: ^:user, updated_at: ^now]]
+          )
+          |> Crit.Repo.update_all([])
+        end
       end)
 
     :ok

--- a/lib/crit_web/plugs/auth_rate_limit.ex
+++ b/lib/crit_web/plugs/auth_rate_limit.ex
@@ -36,6 +36,6 @@ defmodule CritWeb.Plugs.AuthRateLimit do
 
   defp disabled? do
     System.get_env("E2E") == "true" or
-      Application.get_env(:crit, CritWeb.Plugs.RateLimit, [])[:disabled] == true
+      Application.get_env(:crit, CritWeb.Plugs.AuthRateLimit, [])[:disabled] == true
   end
 end


### PR DESCRIPTION
## Summary
- **AuthRateLimit** read the global `RateLimit` config key instead of its own — now has an independent disable switch
- **release.ex** demote query ran unconditionally, silently demoting all admins when `ADMIN_EMAILS` was unset — now guarded by `if emails != []`
- **Copy-path button** showed success feedback even when `navigator.clipboard.writeText()` failed — now chains `.then()/.catch()`

## Review
- [x] Code review: passed (independent validator agents confirmed all 3 findings)
- [x] Pre-commit checks: 752 tests pass, mix precommit clean

## Test plan
- [x] Full test suite (752 tests, 0 failures)
- [x] Compilation with --warnings-as-errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)