### PR TITLE
feat: add Permissions-Policy, opt-in HSTS, and secure cookies

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -34,6 +34,15 @@ if System.get_env("SELFHOSTED") in ~w(true 1) do
   config :crit, :selfhosted, true
 end
 
+# HSTS + secure cookies — off by default to protect self-hosters on plain HTTP.
+# When enabled, browsers remember "always use HTTPS" for this domain and cookies
+# are only sent over HTTPS. Only enable when the deployment is behind HTTPS
+# (e.g. Fly.io, Caddy, nginx with TLS).
+if System.get_env("ENABLE_HSTS") in ~w(true 1) do
+  config :crit, :hsts_enabled, true
+  config :crit, :secure_cookies, true
+end
+
 # ADMIN_EMAILS: comma-separated list of email addresses that should have the
 # instance admin role. Parsed into a list of trimmed, lowercased strings.
 # This is the single source of truth for admin status — see

--- a/lib/crit_web/endpoint.ex
+++ b/lib/crit_web/endpoint.ex
@@ -15,6 +15,9 @@ defmodule CritWeb.Endpoint do
     same_site: "Lax"
   ]
 
+  @session_init Plug.Session.init(@session_options)
+  @secure_session_init Plug.Session.init(Keyword.put(@session_options, :secure, true))
+
   socket "/live", Phoenix.LiveView.Socket,
     websocket: [connect_info: [:peer_data, :uri, :user_agent, session: @session_options]],
     longpoll: [connect_info: [:peer_data, :uri, :user_agent, session: @session_options]]
@@ -53,7 +56,7 @@ defmodule CritWeb.Endpoint do
   plug Plug.MethodOverride
   plug Plug.Head
   plug CritWeb.Plugs.CanonicalHost
-  plug Plug.Session, @session_options
+  plug :session
 
   # Drop request body and cookies — review documents and comment bodies must
   # never leave the deployment. Placed after Session/MethodOverride so the
@@ -63,4 +66,12 @@ defmodule CritWeb.Endpoint do
     cookie_scrubber: nil
 
   plug CritWeb.Router
+
+  defp session(conn, _opts) do
+    if Application.get_env(:crit, :secure_cookies) do
+      Plug.Session.call(conn, @secure_session_init)
+    else
+      Plug.Session.call(conn, @session_init)
+    end
+  end
 end

--- a/lib/crit_web/plugs/security_headers.ex
+++ b/lib/crit_web/plugs/security_headers.ex
@@ -1,6 +1,18 @@
 defmodule CritWeb.Plugs.SecurityHeaders do
   import Plug.Conn
 
+  @permissions_policy [
+    "camera=()",
+    "microphone=()",
+    "geolocation=()",
+    "accelerometer=()",
+    "gyroscope=()",
+    "magnetometer=()",
+    "payment=()",
+    "usb=()",
+    "interest-cohort=()"
+  ]
+
   def init(opts), do: opts
 
   def call(conn, _opts) do
@@ -8,6 +20,16 @@ defmodule CritWeb.Plugs.SecurityHeaders do
     |> put_resp_header("content-security-policy", csp())
     |> put_resp_header("x-content-type-options", "nosniff")
     |> put_resp_header("x-frame-options", "DENY")
+    |> put_resp_header("permissions-policy", Enum.join(@permissions_policy, ", "))
+    |> maybe_put_hsts()
+  end
+
+  defp maybe_put_hsts(conn) do
+    if Application.get_env(:crit, :hsts_enabled) do
+      put_resp_header(conn, "strict-transport-security", "max-age=31536000; includeSubDomains")
+    else
+      conn
+    end
   end
 
   defp csp do

--- a/test/crit_web/plugs/security_headers_test.exs
+++ b/test/crit_web/plugs/security_headers_test.exs
@@ -1,0 +1,43 @@
+defmodule CritWeb.Plugs.SecurityHeadersTest do
+  use CritWeb.ConnCase, async: true
+
+  describe "security headers" do
+    test "sets permissions-policy on browser requests", %{conn: conn} do
+      conn = get(conn, ~p"/")
+
+      policy = get_resp_header(conn, "permissions-policy") |> List.first()
+      assert policy =~ "camera=()"
+      assert policy =~ "microphone=()"
+      assert policy =~ "geolocation=()"
+      assert policy =~ "payment=()"
+    end
+
+    test "sets x-content-type-options and x-frame-options", %{conn: conn} do
+      conn = get(conn, ~p"/")
+
+      assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+      assert get_resp_header(conn, "x-frame-options") == ["DENY"]
+    end
+
+    test "does not set HSTS when hsts_enabled is not configured", %{conn: conn} do
+      Application.delete_env(:crit, :hsts_enabled)
+
+      on_exit(fn -> Application.delete_env(:crit, :hsts_enabled) end)
+
+      conn = get(conn, ~p"/")
+
+      assert get_resp_header(conn, "strict-transport-security") == []
+    end
+
+    test "sets HSTS when hsts_enabled is true", %{conn: conn} do
+      Application.put_env(:crit, :hsts_enabled, true)
+
+      on_exit(fn -> Application.delete_env(:crit, :hsts_enabled) end)
+
+      conn = get(conn, ~p"/")
+
+      [hsts] = get_resp_header(conn, "strict-transport-security")
+      assert hsts == "max-age=31536000; includeSubDomains"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Permissions-Policy` header (always on) restricting unused browser APIs (camera, microphone, geolocation, payment, USB, etc.)
- Add `Strict-Transport-Security` header, opt-in via `ENABLE_HSTS=true` env var — off by default to protect self-hosters on plain HTTP
- Set `Secure` flag on session cookies when HSTS is enabled (runtime switching to support both HTTP and HTTPS deployments)

## Review
- [x] Code review: passed
- [x] Pre-commit checks: 990 tests, 0 failures

## Test plan
- 4 new tests covering security headers (always-on and opt-in behavior)
- Validate with Mozilla Observatory and SecurityHeaders.com after deploy
- Set `ENABLE_HSTS=true` in Fly.io production env

🤖 Generated with [Claude Code](https://claude.com/claude-code)