### PR TITLE
fix: filter 410 from LiveSocket transport error reporting

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -78,6 +78,8 @@ function initSentry(liveSocket) {
       let lastOpenAt = Date.now()
 
       socket.onError(err => {
+        const msg = String(err?.message ?? err)
+        if (msg === "410") return
         consecutiveErrors += 1
         if (firstErrorAt === null) firstErrorAt = Date.now()
         if (pendingTimer !== null) return


### PR DESCRIPTION
## Summary
- Skip Sentry reporting when the LiveView transport error is a 410 (Gone)
- 410 means the server-side session expired after idle — the client auto-reloads
- Reduces noise from expected Safari idle-tab behavior (24 events / 2 users over 2 weeks)

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (Sentry reporting is crit-web only)

## Test plan
- Verified `mix precommit` passes (990 tests, 0 failures)
- Manual reasoning: the early return prevents `consecutiveErrors` from incrementing and the persistence timer from firing on 410s

🤖 Generated with [Claude Code](https://claude.com/claude-code)