### PR TITLE
chore: bump mermaid to ^11.15.0 to match crit local

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -15,7 +15,7 @@
         "highlight.js": "^11.11.1",
         "highlightjs-heex": "^1.0.1",
         "markdown-it": "^14.1.1",
-        "mermaid": "^11.14.0"
+        "mermaid": "^11.15.0"
       }
     },
     "node_modules/@antfu/install-pkg": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -17,6 +17,6 @@
     "highlight.js": "^11.11.1",
     "highlightjs-heex": "^1.0.1",
     "markdown-it": "^14.1.1",
-    "mermaid": "^11.14.0"
+    "mermaid": "^11.15.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bump mermaid from `^11.14.0` to `^11.15.0` to match `crit/package.json`

## Review
- [x] Parity check: version now matches crit local

## Test plan
- npm install succeeds
- See also: tomasz-tomczyk/crit#565 — audit cleanup PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)