### PR TITLE
fix: stack mini-toasts instead of overlapping

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2203,6 +2203,7 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   text-align: center;
   color: var(--crit-editor-fg-secondary);
   font-size: 14px;
+  line-height: 1.5;
 }
 
 /* File groups in comments panel */
@@ -2304,11 +2305,23 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
 }
 
 /* Toast notifications */
-.mini-toast {
+/* Host is a single fixed container; toasts stack inside (gap-separated
+   flex column). Toast-creation code finds-or-creates one shared host and
+   appends .mini-toast children so concurrent toasts stack, not overlap. */
+.mini-toast-host {
   position: fixed;
   bottom: 24px;
   left: 50%;
-  transform: translateX(-50%) translateY(20px);
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+  z-index: 10000;
+  pointer-events: none;
+}
+
+.mini-toast {
   padding: 10px 24px;
   border-radius: 8px;
   font-size: 14px;
@@ -2317,14 +2330,14 @@ body.dragging .line-block.drag-endpoint .line-gutter .line-add { display: flex; 
   border: 1px solid var(--crit-border);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   opacity: 0;
+  transform: translateY(20px);
   transition: opacity 0.3s, transform 0.3s;
-  z-index: 10000;
   pointer-events: none;
 }
 
 .mini-toast-visible {
   opacity: 1;
-  transform: translateX(-50%) translateY(0);
+  transform: translateY(0);
 }
 
 /* Comment template chips */

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -339,11 +339,21 @@ function renderSuggestionDiff(suggestionContent, originalLines) {
   }
 })()
 
+function ensureToastHost() {
+  let host = document.querySelector('.mini-toast-host')
+  if (host) return host
+  host = document.createElement('div')
+  host.className = 'mini-toast-host'
+  document.body.appendChild(host)
+  return host
+}
+
 function showToast(message, duration = 3000) {
+  const host = ensureToastHost()
   const toast = document.createElement('div')
   toast.className = 'mini-toast'
   toast.textContent = message
-  document.body.appendChild(toast)
+  host.appendChild(toast)
   requestAnimationFrame(() => toast.classList.add('mini-toast-visible'))
   trackedSetTimeout(__activeCtx, () => {
     toast.classList.remove('mini-toast-visible')


### PR DESCRIPTION
## Summary
- Parity port from crit local: crit moved its mini-toast to a `.mini-toast-host` flex container so concurrent toasts stack in a column instead of overlapping
- Splits the single positioned `.mini-toast` into a `.mini-toast-host` container + `.mini-toast` child in `app.css`; `showToast()` finds-or-creates one shared host
- crit-web's own toast cosmetics (box-shadow, font-size, bg vars) are preserved — only the host/stacking structure is ported
- Adds `line-height: 1.5` to `.comments-panel-empty`, matching a crit local refinement for multi-line empty-state text

## Review
- [x] release-audit post-fix review: passed
- [x] parity audit: passed

## Test plan
- Review-page custom CSS only — no Tailwind/daisyUI added; conventions followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)