### PR TITLE
feat: replace homepage and mode page screenshots with autoplay demo videos

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -393,3 +393,11 @@ if (process.env.NODE_ENV === "development") {
   })
 }
 
+document.querySelectorAll("video[data-lazy-src]").forEach(video => {
+  new IntersectionObserver(([entry], obs) => {
+    if (!entry.isIntersecting) return
+    video.src = video.dataset.lazySrc
+    obs.disconnect()
+  }, {rootMargin: "200px"}).observe(video)
+})
+

--- a/lib/crit_web/controllers/page_controller.ex
+++ b/lib/crit_web/controllers/page_controller.ex
@@ -141,10 +141,11 @@ defmodule CritWeb.PageController do
     "plans-docs" => %{
       label: "Plans & docs",
       screenshot: "plan",
+      video: "https://assets.crit.md/plan-mode.mp4",
       eyebrow: "Mode · plans & docs",
       title: "Review the plan before the agent writes the code.",
       lead:
-        "Pass crit a markdown file, a source file, a docs page. It renders in the browser with the same inline-comment surface you'd use on a GitHub PR.",
+        "Pass crit a markdown file, a source file, or a docs page. It renders in the browser with the same inline-comment surface you'd use on a GitHub PR.",
       tags: [
         "Markdown render",
         "Syntax highlighting",
@@ -156,7 +157,7 @@ defmodule CritWeb.PageController do
         %{
           h: "Agent writes a plan",
           p:
-            "Tell your agent to draft a plan or spec. Run crit on the resulting file — the agent waits for your review."
+            "Tell your agent to draft a plan or spec. Run <code class=\"font-bold text-(--crit-brand)\">/crit</code> on the resulting file — the agent waits for your review."
         },
         %{
           h: "Crit renders it",
@@ -181,14 +182,14 @@ defmodule CritWeb.PageController do
             "Headings, tables, lists, blockquotes — all rendered. No more reading raw markdown to figure out the structure."
         },
         %{
-          h: "Suggestions, not paragraphs",
-          p:
-            "Select lines → Insert suggestion. The comment pre-fills with the original text. Edit to show the agent the exact replacement."
-        },
-        %{
           h: "Round-to-round diff",
           p:
             "When the agent edits the file, Crit shows a split or unified diff. Your previous comments stay attached to the right lines so you can verify they were addressed."
+        },
+        %{
+          h: "Suggestions, not paragraphs",
+          p:
+            "Select lines → Insert suggestion. The comment pre-fills with the original text. Edit to show the agent the exact replacement."
         },
         %{
           h: "Multiple files at once",
@@ -210,6 +211,7 @@ defmodule CritWeb.PageController do
     "code" => %{
       label: "Code",
       screenshot: "diff",
+      video: "https://assets.crit.md/diff-mode.mp4",
       eyebrow: "Mode · code",
       title: "Review the diff before you merge.",
       lead:
@@ -217,7 +219,6 @@ defmodule CritWeb.PageController do
       tags: [
         "Split / unified diff",
         "File tree",
-        "Comment counts",
         "Round-to-round diff",
         "PR sync"
       ],
@@ -225,7 +226,7 @@ defmodule CritWeb.PageController do
         %{
           h: "Agent makes changes",
           p:
-            "Your agent edits files across a branch. Run crit (no args) or crit --pr <number> to review."
+            "Your agent edits files across a branch. Run <code class=\"font-bold text-(--crit-brand)\">/crit</code> or <code class=\"font-bold text-(--crit-brand)\">/crit --pr &lt;number&gt;</code> to review."
         },
         %{
           h: "Crit shows the diff",
@@ -279,6 +280,7 @@ defmodule CritWeb.PageController do
     "live" => %{
       label: "Live",
       screenshot: "live",
+      video: "https://assets.crit.md/live-mode.mp4",
       eyebrow: "Mode · live",
       title: "Review the running app, not a screenshot.",
       lead:
@@ -286,8 +288,7 @@ defmodule CritWeb.PageController do
       tags: [
         "Click-to-pin DOM",
         "Selector anchoring",
-        "Live reload",
-        "Round comparisons"
+        "Live reload"
       ],
       steps: [
         %{
@@ -323,11 +324,6 @@ defmodule CritWeb.PageController do
             "Comments are anchored by CSS selector, not coordinates. Minor layout shifts don't break your feedback."
         },
         %{
-          h: "Round comparisons",
-          p:
-            "See how the page changed between rounds. Previous comments stay attached to their elements across reloads."
-        },
-        %{
           h: "Works with any dev server",
           p:
             "Vite, Next.js, Phoenix, Rails — anything serving HTTP on localhost. Crit proxies it transparently."
@@ -342,6 +338,7 @@ defmodule CritWeb.PageController do
     "preview" => %{
       label: "Preview",
       screenshot: "preview",
+      video: "https://assets.crit.md/preview-mode.mp4",
       eyebrow: "Mode · preview",
       title: "Review the HTML your agent generated.",
       lead:
@@ -350,8 +347,7 @@ defmodule CritWeb.PageController do
         "Static HTML iframe",
         "Click-to-comment",
         "Asset siblings served",
-        "No dev server",
-        "Round comparisons"
+        "No dev server"
       ],
       steps: [
         %{
@@ -390,11 +386,6 @@ defmodule CritWeb.PageController do
           h: "No server, no build step",
           p:
             "Point crit at an HTML file and it works. No dev server to start, no dependencies to install, no build pipeline."
-        },
-        %{
-          h: "Round comparisons",
-          p:
-            "When the agent regenerates the HTML, Crit shows what changed. Your previous comments stay attached to their elements."
         },
         %{
           h: "Works with any HTML artifact",

--- a/lib/crit_web/controllers/page_html.ex
+++ b/lib/crit_web/controllers/page_html.ex
@@ -15,9 +15,10 @@ defmodule CritWeb.PageHTML do
       nav_label: "Review plans & docs",
       cmd: "files / markdown",
       screenshot: "plan",
+      video: "https://assets.crit.md/plan-mode.mp4",
       blurb:
         "Your agent drafted a 300-line plan. In the terminal it's a wall of markdown. Crit renders it in the browser — comment on the section that's wrong, not the whole document.",
-      bullets: ["Markdown render", "Per-line comments", "Code-fence ranges", "Mermaid diagrams"]
+      bullets: ["Markdown render", "Per-line comments", "Diff every round"]
     },
     %{
       slug: "code",
@@ -25,6 +26,7 @@ defmodule CritWeb.PageHTML do
       nav_label: "Review code diffs",
       cmd: "branch / pr changes",
       screenshot: "diff",
+      video: "https://assets.crit.md/diff-mode.mp4",
       blurb:
         "Your agent touched 14 files across your branch. Crit auto-detects the changes, shows syntax-highlighted diffs, and lets you comment on any line — like a PR review, but instant and local.",
       bullets: ["Syntax highlighting", "Stacked PRs", "Git, jj, sapling"]
@@ -35,6 +37,7 @@ defmodule CritWeb.PageHTML do
       nav_label: "Review running apps",
       cmd: "running app / dev server",
       screenshot: "live",
+      video: "https://assets.crit.md/live-mode.mp4",
       blurb:
         "Your agent built a frontend and it's running on localhost. Crit proxies the page into a review surface — click the button that's misaligned, pin a comment to it.",
       bullets: ["Comment on DOM", "Automatic reload", "Interactive browser"]
@@ -45,12 +48,12 @@ defmodule CritWeb.PageHTML do
       nav_label: "Review HTML artifacts",
       cmd: "static html artifact",
       screenshot: "preview",
+      video: "https://assets.crit.md/preview-mode.mp4",
       blurb:
         "Your agent generated a landing page as a static HTML file. Crit renders it in an iframe so you can click elements and comment.",
       bullets: [
         "Static HTML iframe",
         "Asset siblings served",
-        "Pin to elements",
         "No dev server needed"
       ]
     }
@@ -153,7 +156,7 @@ defmodule CritWeb.PageHTML do
       <div class="max-w-[880px] mx-auto px-10 max-sm:px-4 w-full">
         <div class="text-center mb-10 max-sm:mb-8">
           <h2 class="text-5xl font-extrabold tracking-tight mb-4 max-sm:text-4xl">
-            30-second install<span class="text-(--crit-brand)">.</span>
+            5-second install<span class="text-(--crit-brand)">.</span>
           </h2>
           <p class="text-lg text-(--crit-fg-secondary) max-sm:text-base">
             Single binary. No account, no config, no dependencies.

--- a/lib/crit_web/controllers/page_html/home.html.heex
+++ b/lib/crit_web/controllers/page_html/home.html.heex
@@ -61,26 +61,18 @@
       </div>
     </div>
 
-    <CritWeb.PageHTML.browser_chrome url="localhost:4923/plan.md">
-      <img
-        src="/images/screenshots/ai-loop-dark@1x.png"
-        srcset="/images/screenshots/ai-loop-dark@1x.png 1x, /images/screenshots/ai-loop-dark@2x.png 2x"
-        alt="Crit reviewing a markdown plan with inline threaded comments"
-        class="logo-dark w-full"
-        loading="eager"
-        width="1200"
-        height="675"
-      />
-      <img
-        src="/images/screenshots/ai-loop-light@1x.png"
-        srcset="/images/screenshots/ai-loop-light@1x.png 1x, /images/screenshots/ai-loop-light@2x.png 2x"
-        alt="Crit reviewing a markdown plan with inline threaded comments"
-        class="logo-light w-full"
-        loading="eager"
-        width="1200"
-        height="675"
-      />
-    </CritWeb.PageHTML.browser_chrome>
+    <div class="rounded-xl overflow-hidden shadow-lg">
+      <video
+        autoplay
+        loop
+        muted
+        playsinline
+        class="w-full"
+        poster="https://assets.crit.md/crit-demo-poster.png"
+        src="https://assets.crit.md/crit-demo.mp4"
+      >
+      </video>
+    </div>
 
     <%!-- YouTube video modal --%>
     <div
@@ -117,7 +109,7 @@
     <div class="max-w-7xl mx-auto px-10 max-sm:px-4 w-full">
       <div class="max-w-2xl mb-16 max-sm:mb-10">
         <p class="font-mono text-xs tracking-widest uppercase text-(--crit-fg-muted) mb-4">
-          Four surfaces
+          Four review modes
         </p>
         <h2 class="text-4xl font-extrabold tracking-tight max-sm:text-3xl text-balance">
           Agents don't just write code<span class="text-(--crit-brand)">.</span>
@@ -130,9 +122,12 @@
       <div class="flex flex-col gap-20">
         <div
           :for={{mode, idx} <- Enum.with_index(CritWeb.PageHTML.modes())}
-          class="grid grid-cols-2 gap-12 items-center max-md:grid-cols-1"
+          class="grid grid-cols-5 gap-12 items-center max-md:grid-cols-1"
         >
-          <div class={["max-md:order-none", rem(idx, 2) == 1 && "order-2"]}>
+          <div class={[
+            "col-span-2 max-md:col-span-1 max-md:order-none",
+            rem(idx, 2) == 1 && "order-2"
+          ]}>
             <p class="font-mono text-xs tracking-widest uppercase text-(--crit-fg-muted) mb-3">
               {String.upcase(mode.cmd)}
             </p>
@@ -153,31 +148,49 @@
               {mode.nav_label} &rarr;
             </a>
           </div>
-          <div class={["max-md:order-none", rem(idx, 2) == 1 && "order-1"]}>
-            <CritWeb.PageHTML.browser_chrome url={"localhost:4923/#{mode.slug}"}>
-              <%= if mode.screenshot do %>
-                <img
-                  src={"/images/screenshots/#{mode.screenshot}-dark@1x.png"}
-                  srcset={"/images/screenshots/#{mode.screenshot}-dark@1x.png 1x, /images/screenshots/#{mode.screenshot}-dark@2x.png 2x"}
-                  alt={"Crit #{mode.label} mode"}
-                  class="logo-dark w-full"
-                  loading="lazy"
-                  width="1200"
-                  height="675"
-                />
-                <img
-                  src={"/images/screenshots/#{mode.screenshot}-light@1x.png"}
-                  srcset={"/images/screenshots/#{mode.screenshot}-light@1x.png 1x, /images/screenshots/#{mode.screenshot}-light@2x.png 2x"}
-                  alt={"Crit #{mode.label} mode"}
-                  class="logo-light w-full"
-                  loading="lazy"
-                  width="1200"
-                  height="675"
-                />
-              <% else %>
-                <CritWeb.PageHTML.browser_chrome_placeholder label={mode.label} />
-              <% end %>
-            </CritWeb.PageHTML.browser_chrome>
+          <div class={[
+            "col-span-3 max-md:col-span-1 max-md:order-none",
+            rem(idx, 2) == 1 && "order-1"
+          ]}>
+            <%= if mode[:video] do %>
+              <div class="rounded-xl overflow-hidden shadow-lg">
+                <video
+                  autoplay
+                  loop
+                  muted
+                  playsinline
+                  preload="none"
+                  class="w-full"
+                  data-lazy-src={mode.video}
+                >
+                </video>
+              </div>
+            <% else %>
+              <CritWeb.PageHTML.browser_chrome url={"localhost:4923/#{mode.slug}"}>
+                <%= if mode.screenshot do %>
+                  <img
+                    src={"/images/screenshots/#{mode.screenshot}-dark@1x.png"}
+                    srcset={"/images/screenshots/#{mode.screenshot}-dark@1x.png 1x, /images/screenshots/#{mode.screenshot}-dark@2x.png 2x"}
+                    alt={"Crit #{mode.label} mode"}
+                    class="logo-dark w-full"
+                    loading="lazy"
+                    width="1200"
+                    height="675"
+                  />
+                  <img
+                    src={"/images/screenshots/#{mode.screenshot}-light@1x.png"}
+                    srcset={"/images/screenshots/#{mode.screenshot}-light@1x.png 1x, /images/screenshots/#{mode.screenshot}-light@2x.png 2x"}
+                    alt={"Crit #{mode.label} mode"}
+                    class="logo-light w-full"
+                    loading="lazy"
+                    width="1200"
+                    height="675"
+                  />
+                <% else %>
+                  <CritWeb.PageHTML.browser_chrome_placeholder label={mode.label} />
+                <% end %>
+              </CritWeb.PageHTML.browser_chrome>
+            <% end %>
           </div>
         </div>
       </div>

--- a/lib/crit_web/controllers/page_html/mode.html.heex
+++ b/lib/crit_web/controllers/page_html/mode.html.heex
@@ -11,7 +11,7 @@
     <h1 class="text-5xl font-extrabold leading-tight tracking-tight mb-5 max-lg:text-4xl max-sm:text-3xl text-balance">
       {@mode.title}
     </h1>
-    <p class="text-xl text-(--crit-fg-secondary) leading-relaxed max-w-[640px] mb-8 max-sm:text-base">
+    <p class="text-xl text-(--crit-fg-secondary) leading-relaxed max-w-[640px] mb-8 max-sm:text-base text-balance">
       {@mode.lead}
     </p>
     <div class="flex flex-wrap gap-2 mb-12">
@@ -22,30 +22,44 @@
         {tag}
       </span>
     </div>
-    <CritWeb.PageHTML.browser_chrome url={"localhost:4923/#{@mode.label}"}>
-      <%= if @mode.screenshot do %>
-        <img
-          src={"/images/screenshots/#{@mode.screenshot}-dark@1x.png"}
-          srcset={"/images/screenshots/#{@mode.screenshot}-dark@1x.png 1x, /images/screenshots/#{@mode.screenshot}-dark@2x.png 2x"}
-          alt={"Crit #{@mode.label} mode"}
-          class="logo-dark w-full"
-          loading="eager"
-          width="1200"
-          height="675"
-        />
-        <img
-          src={"/images/screenshots/#{@mode.screenshot}-light@1x.png"}
-          srcset={"/images/screenshots/#{@mode.screenshot}-light@1x.png 1x, /images/screenshots/#{@mode.screenshot}-light@2x.png 2x"}
-          alt={"Crit #{@mode.label} mode"}
-          class="logo-light w-full"
-          loading="eager"
-          width="1200"
-          height="675"
-        />
-      <% else %>
-        <CritWeb.PageHTML.browser_chrome_placeholder label={@mode.label} />
-      <% end %>
-    </CritWeb.PageHTML.browser_chrome>
+    <%= if @mode[:video] do %>
+      <div class="rounded-xl overflow-hidden shadow-lg">
+        <video
+          autoplay
+          loop
+          muted
+          playsinline
+          class="w-full"
+          src={@mode.video}
+        >
+        </video>
+      </div>
+    <% else %>
+      <CritWeb.PageHTML.browser_chrome url={"localhost:4923/#{@mode.label}"}>
+        <%= if @mode.screenshot do %>
+          <img
+            src={"/images/screenshots/#{@mode.screenshot}-dark@1x.png"}
+            srcset={"/images/screenshots/#{@mode.screenshot}-dark@1x.png 1x, /images/screenshots/#{@mode.screenshot}-dark@2x.png 2x"}
+            alt={"Crit #{@mode.label} mode"}
+            class="logo-dark w-full"
+            loading="eager"
+            width="1200"
+            height="675"
+          />
+          <img
+            src={"/images/screenshots/#{@mode.screenshot}-light@1x.png"}
+            srcset={"/images/screenshots/#{@mode.screenshot}-light@1x.png 1x, /images/screenshots/#{@mode.screenshot}-light@2x.png 2x"}
+            alt={"Crit #{@mode.label} mode"}
+            class="logo-light w-full"
+            loading="eager"
+            width="1200"
+            height="675"
+          />
+        <% else %>
+          <CritWeb.PageHTML.browser_chrome_placeholder label={@mode.label} />
+        <% end %>
+      </CritWeb.PageHTML.browser_chrome>
+    <% end %>
   </section>
 
   <%!-- The loop steps --%>
@@ -59,7 +73,7 @@
           Step {String.pad_leading(Integer.to_string(idx + 1), 2, "0")}
         </div>
         <h3 class="text-lg font-bold tracking-tight">{step.h}</h3>
-        <p class="text-sm text-(--crit-fg-secondary) leading-relaxed">{step.p}</p>
+        <p class="text-sm text-(--crit-fg-secondary) leading-relaxed">{Phoenix.HTML.raw(step.p)}</p>
       </div>
     </div>
   </section>

--- a/lib/crit_web/controllers/page_html/mode.html.heex
+++ b/lib/crit_web/controllers/page_html/mode.html.heex
@@ -73,7 +73,9 @@
           Step {String.pad_leading(Integer.to_string(idx + 1), 2, "0")}
         </div>
         <h3 class="text-lg font-bold tracking-tight">{step.h}</h3>
-        <p class="text-sm text-(--crit-fg-secondary) leading-relaxed">{Phoenix.HTML.raw(step.p)}</p>
+        <p class="text-sm text-(--crit-fg-secondary) leading-relaxed">
+          {Phoenix.HTML.raw(step.p)}
+        </p>
       </div>
     </div>
   </section>

--- a/lib/crit_web/plugs/security_headers.ex
+++ b/lib/crit_web/plugs/security_headers.ex
@@ -44,8 +44,9 @@ defmodule CritWeb.Plugs.SecurityHeaders do
       "'sha256-wm8xHXfA9tIFK/7McvhnPMGVuF/ErxqxEM1Clij75ec=' " <>
       "'sha256-5M5rMNBzgt7ZyJO3HUsytrd8A0xED8wq015qtyeaFrw='; " <>
       "style-src 'self' 'unsafe-inline'; " <>
-      "img-src 'self' data: blob: https://i.ytimg.com https://avatars.githubusercontent.com; " <>
+      "img-src 'self' data: blob: https://i.ytimg.com https://avatars.githubusercontent.com https://assets.crit.md; " <>
       "font-src 'self'; " <>
+      "media-src 'self' https://assets.crit.md; " <>
       "connect-src 'self'#{sentry_origin}; " <>
       "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; " <>
       "object-src 'none'"


### PR DESCRIPTION
## Summary
- Replace static screenshots with autoplay looping videos from assets.crit.md (Cloudflare R2)
- Hero video has a poster frame for fast LCP; below-fold videos lazy-load via IntersectionObserver
- Widen mode sections to 60/40 media-to-text split
- Update mode page content: drop round-comparison features from live/preview, brand `/crit` commands, reorder plans-docs features
- Update CSP to allow media-src and img-src from assets.crit.md
- Change install section copy to "5-second install"

## Test plan
- [x] `mix precommit` passes (998 tests, 0 failures)
- [x] Verified videos autoplay on homepage and mode pages
- [x] Verified lazy loading via network tab (below-fold videos only load on scroll)
- [x] Poster frame renders instantly for hero LCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)