### PR TITLE
perf: add video posters, controls and reduced-motion to marketing pages

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -393,11 +393,26 @@ if (process.env.NODE_ENV === "development") {
   })
 }
 
-document.querySelectorAll("video[data-lazy-src]").forEach(video => {
-  new IntersectionObserver(([entry], obs) => {
-    if (!entry.isIntersecting) return
-    video.src = video.dataset.lazySrc
-    obs.disconnect()
-  }, {rootMargin: "200px"}).observe(video)
-})
+const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+
+// Lazily load decorative videos as they scroll into view. Skipped under
+// reduced-motion — the poster stays visible and nothing autoplays.
+if (!prefersReducedMotion) {
+  document.querySelectorAll("video[data-lazy-src]").forEach(video => {
+    new IntersectionObserver(([entry], obs) => {
+      if (!entry.isIntersecting) return
+      video.src = video.dataset.lazySrc
+      obs.disconnect()
+    }, {rootMargin: "200px"}).observe(video)
+  })
+}
+
+// Under reduced-motion, pause autoplaying videos so only the poster shows.
+// The hero keeps its `controls`, so users can still play it on demand.
+if (prefersReducedMotion) {
+  document.querySelectorAll("video[autoplay]").forEach(video => {
+    video.removeAttribute("autoplay")
+    video.pause()
+  })
+}
 

--- a/lib/crit_web/controllers/page_controller.ex
+++ b/lib/crit_web/controllers/page_controller.ex
@@ -142,6 +142,7 @@ defmodule CritWeb.PageController do
       label: "Plans & docs",
       screenshot: "plan",
       video: "https://assets.crit.md/plan-mode.mp4",
+      poster: "https://assets.crit.md/plan-mode-poster.webp",
       eyebrow: "Mode · plans & docs",
       title: "Review the plan before the agent writes the code.",
       lead:
@@ -212,6 +213,7 @@ defmodule CritWeb.PageController do
       label: "Code",
       screenshot: "diff",
       video: "https://assets.crit.md/diff-mode.mp4",
+      poster: "https://assets.crit.md/diff-mode-poster.webp",
       eyebrow: "Mode · code",
       title: "Review the diff before you merge.",
       lead:
@@ -281,6 +283,7 @@ defmodule CritWeb.PageController do
       label: "Live",
       screenshot: "live",
       video: "https://assets.crit.md/live-mode.mp4",
+      poster: "https://assets.crit.md/live-mode-poster.webp",
       eyebrow: "Mode · live",
       title: "Review the running app, not a screenshot.",
       lead:
@@ -339,6 +342,7 @@ defmodule CritWeb.PageController do
       label: "Preview",
       screenshot: "preview",
       video: "https://assets.crit.md/preview-mode.mp4",
+      poster: "https://assets.crit.md/preview-mode-poster.webp",
       eyebrow: "Mode · preview",
       title: "Review the HTML your agent generated.",
       lead:

--- a/lib/crit_web/controllers/page_html.ex
+++ b/lib/crit_web/controllers/page_html.ex
@@ -16,6 +16,7 @@ defmodule CritWeb.PageHTML do
       cmd: "files / markdown",
       screenshot: "plan",
       video: "https://assets.crit.md/plan-mode.mp4",
+      poster: "https://assets.crit.md/plan-mode-poster.webp",
       blurb:
         "Your agent drafted a 300-line plan. In the terminal it's a wall of markdown. Crit renders it in the browser — comment on the section that's wrong, not the whole document.",
       bullets: ["Markdown render", "Per-line comments", "Diff every round"]
@@ -27,6 +28,7 @@ defmodule CritWeb.PageHTML do
       cmd: "branch / pr changes",
       screenshot: "diff",
       video: "https://assets.crit.md/diff-mode.mp4",
+      poster: "https://assets.crit.md/diff-mode-poster.webp",
       blurb:
         "Your agent touched 14 files across your branch. Crit auto-detects the changes, shows syntax-highlighted diffs, and lets you comment on any line — like a PR review, but instant and local.",
       bullets: ["Syntax highlighting", "Stacked PRs", "Git, jj, sapling"]
@@ -38,6 +40,7 @@ defmodule CritWeb.PageHTML do
       cmd: "running app / dev server",
       screenshot: "live",
       video: "https://assets.crit.md/live-mode.mp4",
+      poster: "https://assets.crit.md/live-mode-poster.webp",
       blurb:
         "Your agent built a frontend and it's running on localhost. Crit proxies the page into a review surface — click the button that's misaligned, pin a comment to it.",
       bullets: ["Comment on DOM", "Automatic reload", "Interactive browser"]
@@ -49,6 +52,7 @@ defmodule CritWeb.PageHTML do
       cmd: "static html artifact",
       screenshot: "preview",
       video: "https://assets.crit.md/preview-mode.mp4",
+      poster: "https://assets.crit.md/preview-mode-poster.webp",
       blurb:
         "Your agent generated a landing page as a static HTML file. Crit renders it in an iframe so you can click elements and comment.",
       bullets: [

--- a/lib/crit_web/controllers/page_html/home.html.heex
+++ b/lib/crit_web/controllers/page_html/home.html.heex
@@ -67,7 +67,10 @@
         loop
         muted
         playsinline
-        class="w-full"
+        controls
+        width="1920"
+        height="1080"
+        class="w-full h-auto"
         poster="https://assets.crit.md/crit-demo-poster.png"
         src="https://assets.crit.md/crit-demo.mp4"
       >
@@ -160,7 +163,10 @@
                   muted
                   playsinline
                   preload="none"
-                  class="w-full"
+                  width="1920"
+                  height="1080"
+                  class="w-full h-auto"
+                  poster={mode[:poster]}
                   data-lazy-src={mode.video}
                 >
                 </video>

--- a/lib/crit_web/controllers/page_html/mode.html.heex
+++ b/lib/crit_web/controllers/page_html/mode.html.heex
@@ -29,7 +29,11 @@
           loop
           muted
           playsinline
-          class="w-full"
+          controls
+          width="1920"
+          height="1080"
+          class="w-full h-auto"
+          poster={@mode[:poster]}
           src={@mode.video}
         >
         </video>


### PR DESCRIPTION
## Summary
- Mode-card / mode-page videos now show poster screencaps (`*-poster.webp`) instead of a black box before load
- Homepage hero + mode-page (`/modes/:slug`) hero videos gain `controls` (loop kept) — long clips can be paused/scrubbed; satisfies WCAG 2.2.2. Home-grid mode cards stay control-free (short ambient loops)
- All marketing videos get `width`/`height` + `h-auto`: reserves aspect-ratio space to prevent layout shift (CLS), no distortion
- `prefers-reduced-motion`: lazy-load skipped, autoplay paused — reduced-motion users see posters only
- `poster:` keys added to both mode data sources (`@modes` for the home grid, `@modes_data` for `/modes/:slug`)

## Review
- [x] Code review: passed (`/crit-review` — 2 blockers found & fixed)
- [x] Parity audit: N/A (marketing pages, no crit/ equivalent)
- [x] Intent audit: clean

## Test plan
- `mix precommit` — 998 tests, 0 failures
- Mode posters verified live on R2 (`*-poster.webp` → 200 image/webp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)