### PR TITLE
perf(ci): cache npm deps and Playwright browsers in E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
+          cache: "npm"
 
       - name: Restore Elixir dependencies cache
         uses: actions/cache@v5
@@ -72,8 +73,20 @@ jobs:
       - name: Install Playwright dependencies
         run: npm ci
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright browser OS deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Install asset dependencies
         run: npm install --prefix assets


### PR DESCRIPTION
## Summary
- Adds `cache: "npm"` to `setup-node` — npm global cache is preserved across runs
- Caches `~/.cache/ms-playwright` keyed on `package-lock.json` hash — on cache hit, skips the full Chromium download and only installs OS-level deps
- Expected ~1-2min savings per E2E run (from ~4min to ~2min)

## Test plan
- [ ] Watch this PR's E2E run — should pass and show cache-hit on subsequent runs
- [ ] First run will be a cache miss (establishes the cache); second run should be faster


🤖 Generated with [Claude Code](https://claude.com/claude-code)