### PR TITLE
fix: stabilize dark-theme contrast check via reduced-motion guard

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -568,6 +568,23 @@
   }
 }
 
+/* ===== Reduced motion ===== */
+/* Respect prefers-reduced-motion: near-instant transitions/animations.
+   Also makes theme switches apply instantly instead of cross-fading
+   color/background through low-contrast intermediate frames (the
+   transient state axe-core flagged on .crit-round-diff-btn — CRI-90).
+   0.01ms (not 0) keeps transitionend/animationend listeners firing. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* ===== Brand link ===== */
 .crit-link {
   color: var(--crit-brand);

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -49,6 +49,10 @@ test.describe("Accessibility", () => {
   test("should have no color contrast violations in dark theme", async ({
     page,
   }) => {
+    // Contrast is a settled-state property. Reduced motion zeroes the
+    // theme-switch transition so axe measures final colors, not the
+    // 150ms color/background cross-fade through low-contrast frames (CRI-90).
+    await page.emulateMedia({ reducedMotion: "reduce" });
     await loadReview(page, token);
 
     await page.evaluate(() =>
@@ -75,6 +79,7 @@ test.describe("Accessibility", () => {
   test("should have no color contrast violations in light theme", async ({
     page,
   }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
     await loadReview(page, token);
 
     await page.evaluate(() =>


### PR DESCRIPTION
## Summary

The accessibility e2e test "no color contrast violations in dark theme" failed locally (and flaked in CI) on `.crit-round-diff-btn` (the single-file "Raw" link). axe-core reported ~1–2.5:1 against the required 4.5:1.

**Root cause is not opacity or bad colors** — the issue's "opacity blend" hypothesis was off. The settled dark-theme state is fine: `--crit-editor-fg` `#c0caf5` on `--crit-editor-bg-elevated` `#262940` is ~8.6:1. The button carries `transition: background 0.15s, color 0.15s` (for hover). When the test flips `data-theme` to dark, the color and background **animate** from the light values through near-identical mid-grays over 150ms. The test only waits on `--crit-bg-page` (not transitioned), so axe samples mid-cross-fade — hence the render-timing dependence (CI slow = settled = pass; local fast = mid-transition = fail).

## Fix

- Add a `prefers-reduced-motion: reduce` guard to `app.css` that zeroes transition/animation durations. This is a genuine a11y improvement crit-web was missing (crit/ already has reduced-motion handling), and it makes theme switches apply instantly instead of cross-fading through low-contrast frames.
- Have the dark + light contrast tests emulate reduced motion, so axe measures the settled colors (contrast is a settled-state property).

**No colors changed.**

## Review
- [x] Code review (/crit-review): SHIP IT — 0 blockers, 0 warnings
- [x] Parity: N/A — global a11y guard, not a review-component style; crit/ already has reduced-motion handling and lacks the round-diff/Raw button

## Test plan
- `accessibility.spec.ts` full suite passes (3/3)
- Dark-theme contrast test passes 8/8 under `--repeat-each` (was deterministically failing before)
- Guard is gated behind `prefers-reduced-motion`; only the two contrast tests opt in, so other e2e projects are unaffected

Closes CRI-90

🤖 Generated with [Claude Code](https://claude.com/claude-code)