### PR TITLE
chore: make fresh worktrees run e2e out of the box

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,9 +84,13 @@ mise run up               # Install deps, setup DB, start server on :4000
 mix test                  # Run all tests
 mix test path/to/test.exs:42  # One test by line
 mix precommit             # compile --warnings-as-errors, deps.unlock --unused, format, sobelow --skip, deps.audit, test
+mise run e2e              # Run the full Playwright e2e suite (installs everything it needs first)
+mise run e2e e2e/accessibility.spec.ts  # Run a single e2e spec (args pass through to `npx playwright test`)
 ```
 
 Tests use `DataCase` (database) or `ConnCase` (HTTP). Test database: `crit_test`. Local Postgres listens on **5433** (host) → 5432 (container); `DB_PORT` defaults to 5433 via `mise.toml` and `.envrc`, so `mise exec -- mix test` / `mise run test` just work (an explicit `DB_PORT` still overrides). Start the DB first with `mise run db:start` (idempotent). Always run `mix precommit` when done with a change.
+
+**E2E** (Playwright): `mise run e2e` is the one command — idempotent and self-bootstrapping, so a fresh worktree runs the suite without any manual `npm install`. It runs `npm ci` (root Playwright deps, which `wt step copy-ignored` can't copy because the source checkout never installs them), `npx playwright install chromium`, `npm install --prefix assets`, `mix assets.build`, ensures the DB is up, then `npx playwright test`. `playwright.config.ts`'s managed `webServer` starts Phoenix and runs ecto.create/migrate itself. Mirrors `.github/workflows/e2e.yml`.
 
 CI runs the same sequence in `.github/workflows/ci.yml` (Postgres 17 service, Elixir 1.19 / OTP 28), with `mix coveralls.json` instead of plain `mix test` for Codecov upload.
 </important>

--- a/mise.toml
+++ b/mise.toml
@@ -63,3 +63,32 @@ run = "docker stop crit-web-postgres 2>/dev/null || true"
 [tasks.setup]
 description = "Install deps and setup DB (no server)"
 depends = ["deps", "db:setup"]
+
+[tasks.e2e]
+description = "Run the Playwright e2e suite (installs everything it needs first)"
+depends = ["deps", "db:start"]
+# Mirrors .github/workflows/e2e.yml so a fresh worktree runs the suite with one
+# command. Every step is idempotent — a no-op once installed, so reruns are
+# fast. The root `node_modules` (Playwright deps) is NOT copied into new
+# worktrees (the source checkout never installs it, so `wt step copy-ignored`
+# has nothing to copy), hence `npm ci` here. `playwright.config.ts`'s webServer
+# starts Phoenix and runs ecto.create/migrate itself, so we only prep deps,
+# browser, assets, and the DB container. DB_PORT defaults to 5433 (host →
+# container 5432) via mise.toml; the managed webServer forwards it.
+#
+# `mix deps.compile` runs before `mix compile` because a fresh worktree's
+# `_build/test` is copied from the source checkout by `wt step copy-ignored`
+# and can be stale (e.g. missing a dep's Erlang parser .beam). `mix compile`
+# alone never recompiles deps, so it would inherit the gap; `deps.compile` is
+# idempotent and only rebuilds stale deps. CI doesn't need this — it builds
+# `_build/test` fresh from cache, never copying a partial one.
+usage = 'arg "[args]" help="Extra args forwarded to npx playwright test (e.g. a spec path)" var=#true'
+run = """
+npm ci
+npx playwright install chromium
+npm install --prefix assets
+MIX_ENV=test E2E=true mix deps.compile
+MIX_ENV=test E2E=true mix compile
+mix assets.build
+npx playwright test ${usage_args:-}
+"""


### PR DESCRIPTION
## Summary

A freshly created `wt` worktree of crit-web couldn't run the Playwright e2e suite without manual setup:

- The `[post-start] copy = "wt step copy-ignored"` hook only copies git-ignored files that **exist in the source checkout**. The canonical `crit-web/` checkout has no root `node_modules` — the root `package.json` Playwright deps (`@playwright/test`, `@axe-core/playwright`, `@types/node`) were never installed there, so there was nothing to copy. A fresh worktree hit `Cannot find module '@playwright/test'`.
- crit-web had no local e2e runner. CI (`.github/workflows/e2e.yml`) installs deps inline, but a developer got nothing — manual `npm install` + asset build was required first.

This adds a single documented command, **`mise run e2e`**, that is idempotent and self-bootstrapping, mirroring `.github/workflows/e2e.yml`:

- `npm ci` (root Playwright deps — the robust fix, since copy-ignored can only copy what already exists in the source)
- `npx playwright install chromium`
- `npm install --prefix assets`
- `MIX_ENV=test E2E=true mix deps.compile` then `mix compile` (deps.compile guards against a stale copied `_build/test` — a fresh worktree's copied build can be missing a dep's Erlang parser `.beam`; CI never hits this since it builds the test tree fresh from cache)
- `mix assets.build`
- `depends = ["db:start"]` ensures the Postgres container is up (DB_PORT 5433 host → 5432 container, via `mise.toml`)
- `npx playwright test` — extra args forward through (e.g. `mise run e2e e2e/accessibility.spec.ts`)

`playwright.config.ts`'s managed `webServer` starts Phoenix and runs ecto.create/migrate itself.

Mirrors the intent of tomasz-tomczyk/crit#621 ("chore: make fresh worktrees and e2e work out of the box") for crit-web — an install step in the runner is the robust fix because `copy-ignored` can only copy what already exists in the source checkout.

## Review
- [x] Code review: N/A (config + docs only; no app/test/CSS code)
- [x] Parity audit: N/A

## Test plan
- Simulated a fresh worktree (no root `node_modules`) and ran `mise run e2e e2e/accessibility.spec.ts`. The task bootstrapped everything (npm ci, playwright install, asset deps, test-env compile, assets.build, DB), started Phoenix, and ran the suite with no manual `npm install`. 2 specs passed; the 1 dark-theme color-contrast failure is pre-existing on `main` (subject of a separate task) and unrelated to this diff (which touches only `mise.toml` + `AGENTS.md`).
- Confirmed the `usage` field replaces the deprecated `arg()` template function (no mise deprecation warning) and arg passthrough to a spec path works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)