### PR TITLE
fix(preview): preserve comment DOM anchors across fetch + re-share

### DIFF
--- a/lib/crit/output.ex
+++ b/lib/crit/output.ex
@@ -136,6 +136,7 @@ defmodule Crit.Output do
       quote: c.quote,
       scope: c.scope || "line",
       author: c.author_display_name,
+      dom_anchor: c.dom_anchor,
       review_round: c.review_round,
       resolved: c.resolved,
       resolved_round: c.resolved_round,

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -559,7 +559,8 @@ defmodule Crit.Reviews do
         "resolved" => attrs["resolved"] || false,
         "resolved_round" => attrs["resolved_round"],
         "scope" => scope,
-        "external_id" => external_id
+        "external_id" => external_id,
+        "dom_anchor" => attrs["dom_anchor"] || (existing && existing.dom_anchor)
       })
       |> Ecto.Changeset.put_change(:review_id, review.id)
       |> Ecto.Changeset.put_change(:author_identity, resolved_identity)

--- a/lib/crit_web/controllers/page_controller.ex
+++ b/lib/crit_web/controllers/page_controller.ex
@@ -491,7 +491,6 @@ defmodule CritWeb.PageController do
         demo_token: Application.get_env(:crit, :demo_review_token),
         testimonials: @testimonials,
         faq: @faq,
-        stats: Crit.Statistics.totals(),
         canonical_url: canonical_url(conn),
         page_title: "Crit - Point at the line. Tell the agent.",
         meta_description:

--- a/test/crit/reviews_test.exs
+++ b/test/crit/reviews_test.exs
@@ -1173,6 +1173,76 @@ defmodule Crit.ReviewsTest do
       assert comment.resolved == true
     end
 
+    test "preserves dom_anchor from payload across re-share" do
+      scope = anon_scope()
+      anchor = %{"pathname" => "/preview-content", "css_selector" => "body > main > h1"}
+
+      {:ok, review} =
+        Reviews.create_review(scope, [%{"path" => "index.html", "content" => "v1"}], 1, [], [])
+
+      Reviews.upsert_review(scope, review.token, review.delete_token, %{
+        "files" => [%{"path" => "index.html", "content" => "v2"}],
+        "comments" => [
+          %{
+            "file" => "index.html",
+            "start_line" => 1,
+            "end_line" => 1,
+            "body" => "anchored",
+            "external_id" => "local-c1",
+            "dom_anchor" => anchor
+          }
+        ],
+        "review_round" => 1
+      })
+
+      updated = Reviews.get_by_token(review.token)
+      [comment] = updated.comments
+      assert comment.dom_anchor == anchor
+    end
+
+    test "carries forward existing dom_anchor when payload omits it (matched by external_id)" do
+      scope = anon_scope()
+      anchor = %{"pathname" => "/preview-content", "css_selector" => "body > main > h1"}
+
+      {:ok, review} =
+        Reviews.create_review(scope, [%{"path" => "index.html", "content" => "v1"}], 1, [], [])
+
+      # First re-share carries the anchor.
+      Reviews.upsert_review(scope, review.token, review.delete_token, %{
+        "files" => [%{"path" => "index.html", "content" => "v2"}],
+        "comments" => [
+          %{
+            "file" => "index.html",
+            "start_line" => 1,
+            "end_line" => 1,
+            "body" => "anchored",
+            "external_id" => "local-c1",
+            "dom_anchor" => anchor
+          }
+        ],
+        "review_round" => 1
+      })
+
+      # Second re-share via a payload that lost dom_anchor (e.g. CLI fetch path).
+      Reviews.upsert_review(scope, review.token, review.delete_token, %{
+        "files" => [%{"path" => "index.html", "content" => "v3"}],
+        "comments" => [
+          %{
+            "file" => "index.html",
+            "start_line" => 1,
+            "end_line" => 1,
+            "body" => "anchored",
+            "external_id" => "local-c1"
+          }
+        ],
+        "review_round" => 1
+      })
+
+      updated = Reviews.get_by_token(review.token)
+      [comment] = updated.comments
+      assert comment.dom_anchor == anchor
+    end
+
     test "preserves author_display_name from payload" do
       scope = anon_scope()
 

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -301,6 +301,34 @@ defmodule CritWeb.ApiControllerTest do
       refute Map.has_key?(comment, "file_path")
     end
 
+    test "includes dom_anchor so CLI fetch can round-trip preview anchors", %{conn: conn} do
+      anchor = %{"pathname" => "/preview-content", "css_selector" => "body > main > h1"}
+
+      {:ok, review} =
+        Reviews.create_review(
+          anon_scope(),
+          [%{"path" => "index.html", "content" => "<h1>hi</h1>"}],
+          1,
+          [
+            %{
+              "file" => "index.html",
+              "start_line" => 1,
+              "end_line" => 1,
+              "body" => "anchored",
+              "external_id" => "c1",
+              "dom_anchor" => anchor
+            }
+          ],
+          []
+        )
+
+      conn = get(conn, ~p"/api/export/#{review.token}/comments")
+      body = json_response(conn, 200)
+
+      [comment] = body["files"]["index.html"]["comments"]
+      assert comment["dom_anchor"] == anchor
+    end
+
     test "returns 404 for unknown token", %{conn: conn} do
       conn = get(conn, ~p"/api/export/nonexistent_token/comments")
       assert json_response(conn, 404)


### PR DESCRIPTION
## Summary
Preview comments are DOM pins, but `dom_anchor` was being dropped on two round-trip legs (found in the pre-release audit of v0.9.0..main):

- **Export leg** — `output.ex` `serialize_comment_for_export/1` (the `crit fetch` export at `GET /api/export/:token/comments`) omitted `dom_anchor`, so the CLI couldn't read anchors back. Now aligned with the live serializer `Reviews.serialize_comment/1`.
- **Persist leg** — `reviews.ex` `replace_comments/3` hand-built its attrs map without `dom_anchor`, so re-sharing/upserting a review stripped every anchor. Now carries it forward (prefer payload, else the existing row matched by `external_id`, mirroring the `user_id` attribution carry-forward).

Also removes a dead `stats: Crit.Statistics.totals()` assign from the homepage controller — no `page_html` template consumes `@stats` since the marketing revamp removed the stats band; it was an unused DB aggregate on every homepage load.

## Review
- [x] Code review: passed (fresh expert review; fix lines reverted to confirm tests are non-vacuous)
- [x] Parity audit: N/A (backend)

## Test plan
- `mix precommit` (compile --warnings-as-errors, format, sobelow, tests): **1018 tests, 0 failures**
- New tests: `dom_anchor` survives re-share (payload + carry-forward via `external_id`); export JSON includes `dom_anchor`
- See also: tomasz-tomczyk/crit-web#245 (heading-anchor + reduced-motion fixes from the same audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)