### PR TITLE
fix: dedup heading-anchor IDs and add controls to reduced-motion demo videos

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -896,6 +896,10 @@ async function renderMermaidBlocks(container) {
 // ---- Markdown parsing & line-block building ---------------------------------
 
 function buildLineBlocks(md, rawContent) {
+  // Reset per-render heading-slug dedup state (see heading_open rule). Scoping
+  // the counter to one buildLineBlocks() call prevents collisions accumulating
+  // across renders and keeps prev/current diff renders independent.
+  md.__headingSlugCounter = new Map()
   const tokens = md.parse(rawContent, {})
   const sourceLines = rawContent.split("\n")
   const totalLines = sourceLines.length
@@ -4362,8 +4366,21 @@ export const DocumentRenderer = {
       const token = tokens[idx]
       const inline = tokens[idx + 1]
       if (inline && inline.type === "inline") {
-        const slug = slugifyHeading(inline.content)
-        if (slug) token.attrSet("id", slug)
+        const baseSlug = slugifyHeading(inline.content)
+        if (baseSlug) {
+          // Dedup duplicate heading slugs per render pass (GitHub-style:
+          // examples, examples-1, examples-2). The counter is reset at the
+          // start of buildLineBlocks() — each heading is rendered in its own
+          // md.renderer.render() call (fresh env), so the counter must live on
+          // the md instance, not the env, to accumulate across blocks. Keep
+          // this algorithm identical to crit local (crit/frontend/app.js) so
+          // generated ids match between the two frontends (parity contract).
+          const counter = md.__headingSlugCounter || (md.__headingSlugCounter = new Map())
+          const count = counter.get(baseSlug) || 0
+          const slug = count === 0 ? baseSlug : baseSlug + "-" + count
+          counter.set(baseSlug, count + 1)
+          token.attrSet("id", slug)
+        }
       }
       return self.renderToken(tokens, idx, options)
     }

--- a/lib/crit_web/controllers/page_html/home.html.heex
+++ b/lib/crit_web/controllers/page_html/home.html.heex
@@ -162,6 +162,7 @@
                   loop
                   muted
                   playsinline
+                  controls
                   preload="none"
                   width="1920"
                   height="1080"


### PR DESCRIPTION
## Summary
Two review-page / marketing fixes found in the pre-release audit of v0.9.0..main:

- **Duplicate heading IDs** — `document-renderer.js` `heading_open` set `id=slug` with no de-duplication, so a doc with two headings slugifying to the same value emitted duplicate `id`s and anchor clicks (hashchange nav and the in-page `heading_close` link) always scrolled to the first match. Ports crit local's GitHub-style dedup (`baseSlug`, `baseSlug-1`, …) via a counter on the `md` instance, reset once per `buildLineBlocks` render so it doesn't leak across re-renders. IDs now match crit local exactly (parity contract).
- **Reduced-motion demo videos** — the homepage mode-grid videos had only `data-lazy-src` (no `src`) and no `controls`; under `prefers-reduced-motion` `app.js` skips loading them, leaving a poster with no way to play. Adds `controls` to match the hero and mode-page videos.

## Review
- [x] Code review: passed (fresh frontend review; dedup reset semantics + both anchor consumers verified)
- [x] Parity audit: passed (id scheme byte-identical to crit local; per-file reset matches `parseMarkdown` clear)

## Test plan
- `mix precommit`: **1015 tests, 0 failures**
- Playwright chromium E2E: **131 passed**
- See also: tomasz-tomczyk/crit-web#244 (DOM-anchor round-trip fix from the same audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)