### PR TITLE
fix: sort review files to match GitHub order (crit#635 parity)

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -23,6 +23,17 @@ hljs.registerLanguage('heex', heex)
 
 // ---- Helpers ----------------------------------------------------------------
 
+// Byte-order path compare matching Go sort.Strings and GitHub PR file order.
+// localeCompare puts '_' before '.' (foo_test.go before foo.go).
+function pathCompare(a, b) {
+  const min = Math.min(a.length, b.length)
+  for (let i = 0; i < min; i++) {
+    const diff = a.charCodeAt(i) - b.charCodeAt(i)
+    if (diff !== 0) return diff
+  }
+  return a.length - b.length
+}
+
 const IDENTITY_HUES = [200, 140, 30, 260, 350, 90, 175, 315, 55, 220, 0, 160]
 
 function identityHue(identity) {
@@ -1382,7 +1393,7 @@ function renderTreeNode(ctx, container, node, depth, pathPrefix) {
   }
 
   // Render files
-  const sortedFiles = node.files.slice().sort(function(a, b) { return a.path.localeCompare(b.path) })
+  const sortedFiles = node.files.slice().sort(function(a, b) { return pathCompare(a.path, b.path) })
   for (const f of sortedFiles) {
     const fileName = f.path.split('/').pop()
     const fileEl = document.createElement('div')
@@ -4598,7 +4609,7 @@ export const DocumentRenderer = {
             status: f.status || 'modified',
             orphaned,
           }
-        })
+        }).sort((a, b) => pathCompare(a.path, b.path))
         restoreViewedState(ctx)
       } else if (files && files.length === 1) {
         const f = files[0]

--- a/e2e/viewed.spec.ts
+++ b/e2e/viewed.spec.ts
@@ -132,7 +132,7 @@ test.describe("Viewed Checkbox — Multi-File Review", () => {
     await loadReview(page, token);
 
     const filePath = "src/main.ts";
-    const section = page.locator(`#file-section-${filePath}`);
+    const section = page.locator(`[id="file-section-${filePath}"]`);
     const checkbox = section.locator(
       '.file-header-viewed input[type="checkbox"]'
     );

--- a/e2e/viewed.spec.ts
+++ b/e2e/viewed.spec.ts
@@ -132,7 +132,11 @@ test.describe("Viewed Checkbox — Multi-File Review", () => {
     await loadReview(page, token);
 
     const filePath = "src/main.ts";
-    const section = page.locator(`[id="file-section-${filePath}"]`);
+    const sectionId = await page.evaluate(
+      (p) => "file-section-" + CSS.escape(p),
+      filePath
+    );
+    const section = page.locator(`[id="${sectionId}"]`);
     const checkbox = section.locator(
       '.file-header-viewed input[type="checkbox"]'
     );

--- a/e2e/viewed.spec.ts
+++ b/e2e/viewed.spec.ts
@@ -132,20 +132,22 @@ test.describe("Viewed Checkbox — Multi-File Review", () => {
     await loadReview(page, token);
 
     const filePath = "src/main.ts";
-    const sectionId = await page.evaluate(
-      (p) => "file-section-" + CSS.escape(p),
-      filePath
-    );
-    const section = page.locator(`[id="${sectionId}"]`);
-    const checkbox = section.locator(
-      '.file-header-viewed input[type="checkbox"]'
-    );
 
     // No viewed indicator initially
     const treeFile = page.locator(`.tree-file[data-path="${filePath}"]`);
     await expect(treeFile.locator(".tree-viewed-check")).toHaveCount(0);
 
-    await checkbox.click();
+    // Click via getElementById + CSS.escape — ids escape '/' and '.' for CSS
+    await page.evaluate((path) => {
+      const section = document.getElementById(
+        "file-section-" + CSS.escape(path)
+      );
+      const cb = section?.querySelector(
+        '.file-header-viewed input[type="checkbox"]'
+      );
+      if (!cb) throw new Error("viewed checkbox not found for " + path);
+      (cb as HTMLInputElement).click();
+    }, filePath);
 
     // Tree file should have viewed class and checkmark
     await expect(treeFile).toHaveClass(/viewed/);

--- a/e2e/viewed.spec.ts
+++ b/e2e/viewed.spec.ts
@@ -131,13 +131,14 @@ test.describe("Viewed Checkbox — Multi-File Review", () => {
   test("viewed checkbox updates the tree indicator", async ({ page }) => {
     await loadReview(page, token);
 
-    const section = page.locator("details.file-section").first();
+    const filePath = "src/main.ts";
+    const section = page.locator(`#file-section-${filePath}`);
     const checkbox = section.locator(
       '.file-header-viewed input[type="checkbox"]'
     );
 
     // No viewed indicator initially
-    const treeFile = page.locator(".tree-file").first();
+    const treeFile = page.locator(`.tree-file[data-path="${filePath}"]`);
     await expect(treeFile.locator(".tree-viewed-check")).toHaveCount(0);
 
     await checkbox.click();


### PR DESCRIPTION
## Summary
- Add `pathCompare` helper (ASCII byte order) in `document-renderer.js`
- Sort multi-file reviews by path on init and in the file tree
- Parity with crit local fix for tomasz-tomczyk/crit#635

## Test plan
- [ ] Open a hosted review with paired `.go` / `_test.go` files — source file should appear first

Related: tomasz-tomczyk/crit#635

Made with [Cursor](https://cursor.com)