### PR TITLE
chore: upload frontend source maps to Sentry during Docker build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,11 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: crit-md
-      - run: flyctl deploy --remote-only --env SENTRY_RELEASE=${{ github.sha }}
+      - run: |
+          flyctl deploy --remote-only \
+            --build-arg SENTRY_RELEASE=${{ github.sha }} \
+            --build-secret SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
+            --env SENTRY_RELEASE=${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@
 ARG ELIXIR_VERSION=1.19.5
 ARG OTP_VERSION=28.3.1
 ARG DEBIAN_VERSION=trixie-20260202-slim
+# Git SHA passed by deploy.yml; must match SENTRY_RELEASE in the running app.
+ARG SENTRY_RELEASE=""
 
 ARG BUILDER_IMAGE="docker.io/hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="docker.io/debian:${DEBIAN_VERSION}"
@@ -61,6 +63,21 @@ RUN npm ci --prefix assets
 
 # compile assets
 RUN mix assets.deploy
+
+# Upload frontend source maps from the same build that ships, then strip .map files
+# so they are not served publicly. Skipped when SENTRY_AUTH_TOKEN is absent (e.g.
+# local docker build, GHCR multi-arch job).
+RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,required=false \
+  if [ -f /run/secrets/SENTRY_AUTH_TOKEN ] && [ -n "${SENTRY_RELEASE}" ]; then \
+    export SENTRY_AUTH_TOKEN="$(cat /run/secrets/SENTRY_AUTH_TOKEN)" && \
+    npx --yes @sentry/cli@2 sourcemaps upload \
+      --org crit-md \
+      --project crit-web-frontend \
+      --release "${SENTRY_RELEASE}" \
+      --url-prefix '~/assets/js' \
+      priv/static/assets/js; \
+  fi && \
+  find priv/static/assets/js -name '*.map' -delete
 
 # Changes to config/runtime.exs don't require recompiling the code
 COPY config/runtime.exs config/

--- a/mix.exs
+++ b/mix.exs
@@ -97,8 +97,8 @@ defmodule Crit.MixProject do
       "assets.build": ["compile", "tailwind crit", "esbuild crit", "esbuild share_receiver"],
       "assets.deploy": [
         "tailwind crit --minify",
-        "esbuild crit --minify",
-        "esbuild share_receiver --minify",
+        "esbuild crit --minify --sourcemap",
+        "esbuild share_receiver --minify --sourcemap",
         "phx.digest"
       ],
       precommit: [


### PR DESCRIPTION
## Summary
- Enable external esbuild source maps in `mix assets.deploy`
- Upload maps to `crit-web-frontend` inside the Fly Docker build (same bytes that ship)
- Pass `SENTRY_RELEASE` and `SENTRY_AUTH_TOKEN` as build arg/secret from deploy workflow
- Strip `.map` files from the production image after upload

## Review
- [x] Code review: passed (infra-only change, no review-page parity)
- [x] Parity audit: N/A

## Test plan
- [x] `mix precommit` green
- [ ] After merge: confirm Sentry release artifacts for merge SHA on `crit-web-frontend`
- [ ] Next frontend error should symbolicate to `assets/js/…` paths


Made with [Cursor](https://cursor.com)