### PR TITLE
fix: declare SENTRY_RELEASE ARG inside Docker builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,15 @@
 ARG ELIXIR_VERSION=1.19.5
 ARG OTP_VERSION=28.3.1
 ARG DEBIAN_VERSION=trixie-20260202-slim
-# Git SHA passed by deploy.yml; must match SENTRY_RELEASE in the running app.
-ARG SENTRY_RELEASE=""
 
 ARG BUILDER_IMAGE="docker.io/hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="docker.io/debian:${DEBIAN_VERSION}"
 
 FROM ${BUILDER_IMAGE} AS builder
+
+# Git SHA from deploy.yml --build-arg; must match runtime SENTRY_RELEASE.
+# ARG must be declared inside the stage (pre-FROM ARGs are not in scope here).
+ARG SENTRY_RELEASE=""
 
 # install build dependencies
 RUN apt-get update \


### PR DESCRIPTION
## Summary
- Move `ARG SENTRY_RELEASE` into the `builder` stage so `--build-arg SENTRY_RELEASE=…` from deploy is visible to the sourcemap upload `RUN`
- Pre-FROM ARGs are out of scope inside build stages, which caused the upload step to finish in ~0.1s with zero artifacts

## Test plan
- [ ] Merge and watch Deploy workflow — builder step `#23` should take several seconds (real `sentry-cli` upload), not 0.1s
- [ ] Confirm Sentry release for merge SHA has source map artifacts on `crit-web-frontend`
- [ ] Confirm https://crit.md/ `<meta name="sentry-release">` matches merge SHA


Made with [Cursor](https://cursor.com)