### PR TITLE
fix: ensure Sentry sourcemap upload runs in Fly Docker build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,10 +33,11 @@ jobs:
       - run: |
           flyctl deploy --remote-only \
             --build-arg SENTRY_RELEASE=${{ github.sha }} \
-            --build-secret SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
+            --build-secret SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN}" \
             --env SENTRY_RELEASE=${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
   docker:
     name: Build and push Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ FROM ${BUILDER_IMAGE} AS builder
 # Git SHA from deploy.yml --build-arg; must match runtime SENTRY_RELEASE.
 # ARG must be declared inside the stage (pre-FROM ARGs are not in scope here).
 ARG SENTRY_RELEASE=""
+ENV SENTRY_RELEASE=${SENTRY_RELEASE}
 
 # install build dependencies
 RUN apt-get update \
@@ -69,16 +70,20 @@ RUN mix assets.deploy
 # Upload frontend source maps from the same build that ships, then strip .map files
 # so they are not served publicly. Skipped when SENTRY_AUTH_TOKEN is absent (e.g.
 # local docker build, GHCR multi-arch job).
-RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,required=false \
+RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
+  set -eu; \
   if [ -f /run/secrets/SENTRY_AUTH_TOKEN ] && [ -n "${SENTRY_RELEASE}" ]; then \
-    export SENTRY_AUTH_TOKEN="$(cat /run/secrets/SENTRY_AUTH_TOKEN)" && \
+    export SENTRY_AUTH_TOKEN="$(cat /run/secrets/SENTRY_AUTH_TOKEN)"; \
+    echo "Uploading source maps for release ${SENTRY_RELEASE}..."; \
     npx --yes @sentry/cli@2 sourcemaps upload \
       --org crit-md \
       --project crit-web-frontend \
       --release "${SENTRY_RELEASE}" \
       --url-prefix '~/assets/js' \
       priv/static/assets/js; \
-  fi && \
+  else \
+    echo "Skipping source map upload (secret=$([ -f /run/secrets/SENTRY_AUTH_TOKEN ] && echo present || echo absent), release=${SENTRY_RELEASE:-empty})"; \
+  fi; \
   find priv/static/assets/js -name '*.map' -delete
 
 # Changes to config/runtime.exs don't require recompiling the code


### PR DESCRIPTION
## Summary
- Add `ENV SENTRY_RELEASE=${SENTRY_RELEASE}` so the upload `RUN` layer rebuilds per deploy SHA
- Pass `SENTRY_AUTH_TOKEN` through step `env` for `--build-secret` (safer quoting)
- Remove unsupported `required=false` on secret mount; log upload vs skip in build output

Follow-up to #252 — ARG scope was fixed but upload still skipped (~0.1s) and release `2bca40c` has 0 artifacts.

## Test plan
- [ ] Deploy logs show `Uploading source maps for release …` (not skip message)
- [ ] Upload step takes several seconds, not 0.1s
- [ ] Sentry release for merge SHA lists source map artifacts on `crit-web-frontend`


Made with [Cursor](https://cursor.com)