### PR TITLE
fix: upload frontend source maps in deploy CI job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,15 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.19"
+          otp-version: "28"
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Register Sentry release
         uses: getsentry/action-release@v3
@@ -30,6 +39,23 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: crit-md
+      - name: Upload frontend source maps
+        env:
+          MIX_ENV: prod
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get --only prod
+          mix assets.setup
+          mix compile
+          mix assets.deploy
+          npx --yes @sentry/cli@2 sourcemaps upload \
+            --org crit-md \
+            --project crit-web-frontend \
+            --release "${{ github.sha }}" \
+            --url-prefix '~/assets/js' \
+            priv/static/assets/js
       - run: |
           flyctl deploy --remote-only \
             --build-arg SENTRY_RELEASE=${{ github.sha }} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,10 +70,9 @@ RUN mix assets.deploy
 # Upload frontend source maps from the same build that ships, then strip .map files
 # so they are not served publicly. Skipped when SENTRY_AUTH_TOKEN is absent (e.g.
 # local docker build, GHCR multi-arch job).
-RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
+RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
   set -eu; \
-  if [ -f /run/secrets/SENTRY_AUTH_TOKEN ] && [ -n "${SENTRY_RELEASE}" ]; then \
-    export SENTRY_AUTH_TOKEN="$(cat /run/secrets/SENTRY_AUTH_TOKEN)"; \
+  if [ -n "${SENTRY_AUTH_TOKEN:-}" ] && [ -n "${SENTRY_RELEASE}" ]; then \
     echo "Uploading source maps for release ${SENTRY_RELEASE}..."; \
     npx --yes @sentry/cli@2 sourcemaps upload \
       --org crit-md \
@@ -82,7 +81,7 @@ RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
       --url-prefix '~/assets/js' \
       priv/static/assets/js; \
   else \
-    echo "Skipping source map upload (secret=$([ -f /run/secrets/SENTRY_AUTH_TOKEN ] && echo present || echo absent), release=${SENTRY_RELEASE:-empty})"; \
+    echo "Skipping source map upload (token=${SENTRY_AUTH_TOKEN:+present}, release=${SENTRY_RELEASE:-empty})"; \
   fi; \
   find priv/static/assets/js -name '*.map' -delete
 


### PR DESCRIPTION
## Summary
- Upload source maps in the deploy job (prod `mix assets.deploy` + `sentry-cli`) so every release gets artifacts even when Fly Docker build secrets skip
- Switch Docker upload to `--mount=type=secret,env=SENTRY_AUTH_TOKEN` as a best-effort duplicate from the same maps

## Test plan
- [ ] Deploy workflow upload step lists ~178 `.map` files
- [ ] Sentry release for merge SHA has artifacts on `crit-web-frontend`
- [ ] Production `<meta name="sentry-release">` matches merge SHA


Made with [Cursor](https://cursor.com)