### PR TITLE
fix: run npm ci before CI sourcemap upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,14 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: crit-md
+      - name: Restore dependencies cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            deps
+            _build
+            assets/node_modules
+          key: ${{ runner.os }}-deploy-${{ hashFiles('**/mix.lock', 'assets/package-lock.json') }}
       - name: Upload frontend source maps
         env:
           MIX_ENV: prod
@@ -46,8 +54,9 @@ jobs:
         run: |
           mix local.hex --force
           mix local.rebar --force
-          mix deps.get --only prod
+          mix deps.get --only "$MIX_ENV"
           mix assets.setup
+          npm ci --prefix assets
           mix compile
           mix assets.deploy
           npx --yes @sentry/cli@2 sourcemaps upload \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,10 @@ RUN mix assets.deploy
 # Upload frontend source maps from the same build that ships, then strip .map files
 # so they are not served publicly. Skipped when SENTRY_AUTH_TOKEN is absent (e.g.
 # local docker build, GHCR multi-arch job).
-RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
+RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
   set -eu; \
-  if [ -n "${SENTRY_AUTH_TOKEN:-}" ] && [ -n "${SENTRY_RELEASE}" ]; then \
+  if [ -f /run/secrets/SENTRY_AUTH_TOKEN ] && [ -n "${SENTRY_RELEASE}" ]; then \
+    export SENTRY_AUTH_TOKEN="$(cat /run/secrets/SENTRY_AUTH_TOKEN)"; \
     echo "Uploading source maps for release ${SENTRY_RELEASE}..."; \
     npx --yes @sentry/cli@2 sourcemaps upload \
       --org crit-md \
@@ -81,7 +82,7 @@ RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
       --url-prefix '~/assets/js' \
       priv/static/assets/js; \
   else \
-    echo "Skipping source map upload (token=${SENTRY_AUTH_TOKEN:+present}, release=${SENTRY_RELEASE:-empty})"; \
+    echo "Skipping source map upload (secret=$([ -f /run/secrets/SENTRY_AUTH_TOKEN ] && echo present || echo absent), release=${SENTRY_RELEASE:-empty})"; \
   fi; \
   find priv/static/assets/js -name '*.map' -delete
 


### PR DESCRIPTION
## Summary
- Add `npm ci --prefix assets` before `mix assets.deploy` in the deploy upload step (#254 missed this; Docker already had it)
- Add deps/_build/node_modules cache for deploy uploads
- Revert Docker `secret,env=` mount — likely broke Fly remote builds

## Test plan
- [ ] Deploy workflow succeeds
- [ ] Upload step reports ~178 source maps
- [ ] Sentry release has artifacts; production meta matches merge SHA


Made with [Cursor](https://cursor.com)