### PR TITLE
feat: add Umami analytics for hosted deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
 ## Privacy
 
-Crit Web collects no analytics or tracking data. There is no telemetry, no usage stats, and no phone-home. If we ever add anonymous usage statistics in the future, they will be explicitly opt-in.
+Self-hosted Crit Web collects no analytics or tracking data. The public crit.md deployment uses [Umami](https://umami.is) for cookieless, aggregate website analytics (page views and traffic sources only — not linked to individual users or review content). See the [privacy policy](https://crit.md/privacy) for details.
 
 ## License
 

--- a/lib/crit/config.ex
+++ b/lib/crit/config.ex
@@ -18,6 +18,15 @@ defmodule Crit.Config do
   end
 
   @doc """
+  Returns true on the public crit.md deployment. Self-hosted instances opt out
+  of hosted-only integrations such as Umami analytics.
+  """
+  @spec hosted?() :: boolean()
+  def hosted? do
+    Application.get_env(:crit, :selfhosted) != true
+  end
+
+  @doc """
   Returns true when an OAuth provider is configured, regardless of selfhosted
   mode. Use this for sites that gate purely on OAuth presence (device flow,
   public-mode auth-required redirects). Distinct from `selfhosted_oauth?/0`,

--- a/lib/crit_web/components/layouts/root.html.heex
+++ b/lib/crit_web/components/layouts/root.html.heex
@@ -88,6 +88,14 @@
         }
       })();
     </script>
+    <%= if Crit.Config.hosted?() do %>
+      <script
+        defer
+        src="https://cloud.umami.is/script.js"
+        data-website-id="24d521a2-4440-4f90-9cbb-f0b2abcd67e2"
+      >
+      </script>
+    <% end %>
   </head>
   <body class="bg-(--crit-bg-page) text-(--crit-fg-primary)">
     {@inner_content}

--- a/lib/crit_web/controllers/page_html/privacy.html.heex
+++ b/lib/crit_web/controllers/page_html/privacy.html.heex
@@ -71,8 +71,7 @@
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Website analytics</h2>
       <p class="leading-relaxed text-(--crit-fg-secondary)">
-        On crit.md, we use
-        <a href="https://umami.is/privacy" class="crit-link">Umami</a>
+        On crit.md, we use <a href="https://umami.is/privacy" class="crit-link">Umami</a>
         to measure aggregate traffic (page views, referrers, browser and device
         types, and country). Umami does not use cookies, does not track you across
         sites, and does not collect personally identifiable information. Analytics

--- a/lib/crit_web/controllers/page_html/privacy.html.heex
+++ b/lib/crit_web/controllers/page_html/privacy.html.heex
@@ -69,9 +69,20 @@
         The identifier is not linked to any personal information and is not used for tracking.
       </p>
 
-      <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Tracking</h2>
+      <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Website analytics</h2>
       <p class="leading-relaxed text-(--crit-fg-secondary)">
-        We do not use analytics or advertising trackers on this site.
+        On crit.md, we use
+        <a href="https://umami.is/privacy" class="crit-link">Umami</a>
+        to measure aggregate traffic (page views, referrers, browser and device
+        types, and country). Umami does not use cookies, does not track you across
+        sites, and does not collect personally identifiable information. Analytics
+        data is not linked to your GitHub account, session cookie, or review content.
+        Self-hosted Crit Web deployments do not include this script.
+      </p>
+
+      <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Other third-party services</h2>
+      <p class="leading-relaxed text-(--crit-fg-secondary)">
+        We do not use advertising trackers.
       </p>
       <p class="leading-relaxed text-(--crit-fg-secondary) mt-2">
         The homepage includes an embedded YouTube video. If you visit the homepage,
@@ -90,8 +101,8 @@
           privacy policy
         </a>
         governs that interaction.
-        Aside from the YouTube embed, GitHub OAuth, and the error monitoring described below,
-        no other third parties receive data from this site.
+        Aside from Umami analytics, the YouTube embed, GitHub OAuth, and the error
+        monitoring described below, no other third parties receive data from this site.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Error monitoring</h2>

--- a/lib/crit_web/plugs/security_headers.ex
+++ b/lib/crit_web/plugs/security_headers.ex
@@ -39,15 +39,26 @@ defmodule CritWeb.Plugs.SecurityHeaders do
         _ -> ""
       end
 
+    umami_script =
+      if Crit.Config.hosted?(),
+        do: " https://cloud.umami.is",
+        else: ""
+
+    umami_connect =
+      if Crit.Config.hosted?(),
+        do:
+          " https://cloud.umami.is https://api-gateway.umami.dev https://api-gateway-eu.umami.dev",
+        else: ""
+
     "default-src 'self'; " <>
-      "script-src 'self' " <>
+      "script-src 'self'#{umami_script} " <>
       "'sha256-wm8xHXfA9tIFK/7McvhnPMGVuF/ErxqxEM1Clij75ec=' " <>
       "'sha256-5M5rMNBzgt7ZyJO3HUsytrd8A0xED8wq015qtyeaFrw='; " <>
       "style-src 'self' 'unsafe-inline'; " <>
       "img-src 'self' data: blob: https://i.ytimg.com https://avatars.githubusercontent.com https://assets.crit.md; " <>
       "font-src 'self'; " <>
       "media-src 'self' https://assets.crit.md; " <>
-      "connect-src 'self'#{sentry_origin}; " <>
+      "connect-src 'self'#{sentry_origin}#{umami_connect}; " <>
       "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; " <>
       "object-src 'none'"
   end

--- a/test/crit_web/controllers/page_controller_test.exs
+++ b/test/crit_web/controllers/page_controller_test.exs
@@ -19,6 +19,8 @@ defmodule CritWeb.PageControllerTest do
   test "GET /privacy", %{conn: conn} do
     conn = get(conn, ~p"/privacy")
     assert html_response(conn, 200) =~ "Privacy Policy"
+    assert html_response(conn, 200) =~ "Website analytics"
+    assert html_response(conn, 200) =~ "Umami"
   end
 
   test "GET /self-hosting", %{conn: conn} do

--- a/test/crit_web/plugs/security_headers_test.exs
+++ b/test/crit_web/plugs/security_headers_test.exs
@@ -39,5 +39,47 @@ defmodule CritWeb.Plugs.SecurityHeadersTest do
       [hsts] = get_resp_header(conn, "strict-transport-security")
       assert hsts == "max-age=31536000; includeSubDomains"
     end
+
+    test "includes Umami in CSP on hosted deployments", %{conn: conn} do
+      Application.put_env(:crit, :selfhosted, false)
+      on_exit(fn -> Application.delete_env(:crit, :selfhosted) end)
+
+      conn = get(conn, ~p"/")
+      [csp] = get_resp_header(conn, "content-security-policy")
+
+      assert csp =~ "https://cloud.umami.is"
+      assert csp =~ "https://api-gateway.umami.dev"
+    end
+
+    test "omits Umami from CSP on self-hosted deployments", %{conn: conn} do
+      Application.put_env(:crit, :selfhosted, true)
+      on_exit(fn -> Application.delete_env(:crit, :selfhosted) end)
+
+      conn = get(conn, ~p"/")
+      [csp] = get_resp_header(conn, "content-security-policy")
+
+      refute csp =~ "cloud.umami.is"
+    end
+  end
+
+  describe "Umami analytics script" do
+    test "renders on hosted deployments", %{conn: conn} do
+      Application.put_env(:crit, :selfhosted, false)
+      on_exit(fn -> Application.delete_env(:crit, :selfhosted) end)
+
+      html = get(conn, ~p"/") |> html_response(200)
+
+      assert html =~ "cloud.umami.is/script.js"
+      assert html =~ "24d521a2-4440-4f90-9cbb-f0b2abcd67e2"
+    end
+
+    test "omits on self-hosted deployments", %{conn: conn} do
+      Application.put_env(:crit, :selfhosted, true)
+      on_exit(fn -> Application.delete_env(:crit, :selfhosted) end)
+
+      html = get(conn, ~p"/privacy") |> html_response(200)
+
+      refute html =~ "cloud.umami.is"
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Load Umami on crit.md only (not self-hosted instances)
- Extend CSP for cloud.umami.is and Umami API gateways
- Update privacy policy and README for cookieless aggregate analytics

## Review
- [x] Code review: passed
- [x] Parity audit: N/A

## Test plan
- [x] mix precommit (1022 tests)
- [x] Security header + script presence tests for hosted vs self-hosted

🤖 Generated with Claude Code

Made with [Cursor](https://cursor.com)