### PR TITLE
fix: allow gateway.umami.is in CSP connect-src

### DIFF
--- a/lib/crit_web/plugs/security_headers.ex
+++ b/lib/crit_web/plugs/security_headers.ex
@@ -47,7 +47,7 @@ defmodule CritWeb.Plugs.SecurityHeaders do
     umami_connect =
       if Crit.Config.hosted?(),
         do:
-          " https://cloud.umami.is https://api-gateway.umami.dev https://api-gateway-eu.umami.dev",
+          " https://cloud.umami.is https://gateway.umami.is https://api-gateway.umami.dev https://api-gateway-eu.umami.dev",
         else: ""
 
     "default-src 'self'; " <>

--- a/test/crit_web/plugs/security_headers_test.exs
+++ b/test/crit_web/plugs/security_headers_test.exs
@@ -48,6 +48,7 @@ defmodule CritWeb.Plugs.SecurityHeadersTest do
       [csp] = get_resp_header(conn, "content-security-policy")
 
       assert csp =~ "https://cloud.umami.is"
+      assert csp =~ "https://gateway.umami.is"
       assert csp =~ "https://api-gateway.umami.dev"
     end
 


### PR DESCRIPTION
## Summary
- Add `https://gateway.umami.is` to the hosted-deployment CSP `connect-src` allowlist
- Umami's `cloud.umami.is/script.js` now posts analytics to `gateway.umami.is/api/send`, which was blocked and produced console CSP violations

## Test plan
- [x] `DB_PORT=5433 mise exec -- mix test test/crit_web/plugs/security_headers_test.exs` passes
- [ ] Verify no CSP errors in browser console on crit.md after deploy