### PR TITLE
chore: update preview agent sync path for crit web/ layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,12 +257,12 @@ Use `:req` (`Req`) for HTTP requests. **Avoid** `:httpoison`, `:tesla`, `:httpc`
 
 <important if="you are changing any agent-*.js or crit-agent.js in crit/">
 
-The preview-agent scripts in `crit-web/priv/static/preview-agent/` are vendored **verbatim** from `crit/frontend/` — they are the exact set + order crit injects into preview iframes (`agentScriptFiles` in `crit/server.go`), plus `agent-marker.css` (served at `/agent-marker.css` locally). crit-web must serve byte-identical copies so DOM anchoring stays compatible across both renderers.
+The preview-agent scripts in `crit-web/priv/static/preview-agent/` are vendored **verbatim** from `crit/web/` — they are the exact set + order crit injects into preview iframes (`agentScriptFiles` in `crit/server.go`), plus `agent-marker.css` (served at `/agent-marker.css` locally). crit-web must serve byte-identical copies so DOM anchoring stays compatible across both renderers.
 
 When you change any `agent-*.js`, `crit-agent.js`, or `agent-marker.css` in `crit/`:
 
-1. Re-sync: run `crit-web/scripts/sync-preview-agent.sh` (copies the 8 files from `../crit/frontend/`).
+1. Re-sync: run `crit-web/scripts/sync-preview-agent.sh` (copies the 8 files from `../crit/web/`).
 2. Commit the re-synced files in **both** repos.
 
-The drift-guard test `test/crit_web/preview_agent_sync_test.exs` fails loudly when the vendored copies diverge from `crit/frontend/` (and skips gracefully when the sibling `crit/` checkout is absent, e.g. CI). Do not edit `priv/static/preview-agent/*` by hand — always re-sync from crit.
+The drift-guard test `test/crit_web/preview_agent_sync_test.exs` fails loudly when the vendored copies diverge from `crit/web/` (and skips gracefully when the sibling `crit/` checkout is absent, e.g. CI). Do not edit `priv/static/preview-agent/*` by hand — always re-sync from crit.
 </important>

--- a/scripts/sync-preview-agent.sh
+++ b/scripts/sync-preview-agent.sh
@@ -10,11 +10,11 @@
 # re-run this script and commit the result in both repos.
 #
 # Usage: scripts/sync-preview-agent.sh [SRC_DIR]
-#   SRC_DIR defaults to <repo>/../crit/frontend
+#   SRC_DIR defaults to <repo>/../crit/web
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SRC="${1:-$SCRIPT_DIR/../../crit/frontend}"
+SRC="${1:-$SCRIPT_DIR/../../crit/web}"
 DST="$SCRIPT_DIR/../priv/static/preview-agent"
 
 # Keep in sync with `agentScriptFiles` in crit/server.go (order matters:

--- a/test/crit_web/preview_agent_sync_test.exs
+++ b/test/crit_web/preview_agent_sync_test.exs
@@ -28,7 +28,7 @@ defmodule CritWeb.PreviewAgentSyncTest do
   ]
 
   @vendored_dir Path.join([File.cwd!(), "priv", "static", "preview-agent"])
-  @crit_frontend Path.join([File.cwd!(), "..", "crit", "frontend"])
+  @crit_frontend Path.join([File.cwd!(), "..", "crit", "web"])
 
   defp sha256(path), do: :crypto.hash(:sha256, File.read!(path)) |> Base.encode16(case: :lower)
 
@@ -42,7 +42,7 @@ defmodule CritWeb.PreviewAgentSyncTest do
     end
   end
 
-  test "vendored preview-agent files match the crit/frontend sources by content hash" do
+  test "vendored preview-agent files match the crit/web sources by content hash" do
     if File.dir?(@crit_frontend) do
       for f <- @files do
         vendored = Path.join(@vendored_dir, f)


### PR DESCRIPTION
## Summary

Updates crit-web preview-agent sync tooling to read from `crit/web/` instead of the removed `crit/frontend/` directory after the crit Go layout refactor.

## Changes

- `scripts/sync-preview-agent.sh` — default source path `../crit/web`
- `test/crit_web/preview_agent_sync_test.exs` — drift test path + docs
- `AGENTS.md` — documentation path

## Review

- [x] Code review: passed (path-only chore, no review-page parity impact)
- [x] Parity audit: N/A (sync script/docs only)

## Test plan

- [x] `DB_PORT=5433 mise exec -- mix test test/crit_web/preview_agent_sync_test.exs`
- [x] `./scripts/sync-preview-agent.sh` against updated crit checkout
- [x] `DB_PORT=5433 mise exec -- mix precommit`