### PR TITLE
feat: show GitHub star count on Star on GitHub CTA

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -51,6 +51,7 @@ config :phoenix,
 config :crit, start_review_cleaner: false
 config :crit, start_device_code_cleaner: false
 config :crit, start_changelog: false
+config :crit, start_github_stars: false
 
 # Disable global rate limit in tests — shared 127.0.0.1 + persistent ETS would
 # trip the limiter across the suite. Plug-specific tests opt back in locally.

--- a/lib/crit/application.ex
+++ b/lib/crit/application.ex
@@ -20,6 +20,7 @@ defmodule Crit.Application do
         review_cleaner() ++
         device_code_cleaner() ++
         changelog() ++
+        github_stars() ++
         [
           CritWeb.Endpoint
         ]
@@ -59,6 +60,14 @@ defmodule Crit.Application do
   defp changelog do
     if Application.get_env(:crit, :start_changelog, true) do
       [Crit.Changelog]
+    else
+      []
+    end
+  end
+
+  defp github_stars do
+    if Application.get_env(:crit, :start_github_stars, true) do
+      [Crit.GithubStars]
     else
       []
     end

--- a/lib/crit/github_stars.ex
+++ b/lib/crit/github_stars.ex
@@ -1,0 +1,85 @@
+defmodule Crit.GithubStars do
+  @moduledoc """
+  Fetches and caches the GitHub star count for the Crit CLI repo.
+
+  Refreshes every hour. Reads from an ETS table for fast access.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @table :github_stars
+  @refresh_interval :timer.hours(1)
+  @repo "tomasz-tomczyk/crit"
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc "Returns the cached star count, or nil if unavailable."
+  def count do
+    case :ets.lookup(@table, :count) do
+      [{:count, count}] -> count
+      [] -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  @doc "Formats a star count for display in the UI."
+  def format_count(count) when is_integer(count) and count >= 0 do
+    count
+    |> Integer.to_string()
+    |> add_thousands_separator()
+  end
+
+  @impl true
+  def init(_opts) do
+    table = :ets.new(@table, [:set, :named_table, :protected, read_concurrency: true])
+    count = fetch_star_count()
+    :ets.insert(table, {:count, count})
+    schedule_refresh()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:refresh, state) do
+    count = fetch_star_count()
+    :ets.insert(@table, {:count, count})
+    schedule_refresh()
+    {:noreply, state}
+  end
+
+  defp fetch_star_count do
+    url = "https://api.github.com/repos/#{@repo}"
+
+    case Req.get(url, headers: [{"accept", "application/vnd.github+json"}]) do
+      {:ok, %{status: 200, body: %{"stargazers_count" => count}}} when is_integer(count) ->
+        count
+
+      {:ok, %{status: status}} ->
+        Logger.warning("[GithubStars] GitHub API returned #{status} for #{@repo}")
+        nil
+
+      {:error, reason} ->
+        Logger.warning("[GithubStars] Failed to fetch stars for #{@repo}: #{inspect(reason)}")
+        nil
+    end
+  end
+
+  defp add_thousands_separator(digits) do
+    digits
+    |> String.graphemes()
+    |> Enum.reverse()
+    |> Enum.chunk_every(3)
+    |> Enum.map(&Enum.reverse/1)
+    |> Enum.reverse()
+    |> Enum.join(",")
+  end
+
+  defp schedule_refresh do
+    interval = Application.get_env(:crit, :github_stars_refresh_interval_ms, @refresh_interval)
+    Process.send_after(self(), :refresh, interval)
+  end
+end

--- a/lib/crit_web/controllers/page_html.ex
+++ b/lib/crit_web/controllers/page_html.ex
@@ -483,4 +483,58 @@ defmodule CritWeb.PageHTML do
     </div>
     """
   end
+
+  attr :variant, :string, default: "hero", values: ~w(hero cta)
+
+  def github_star_link(assigns) do
+    star_count = Crit.GithubStars.count()
+    formatted = if star_count, do: Crit.GithubStars.format_count(star_count)
+
+    assigns =
+      assigns
+      |> assign(:star_count, star_count)
+      |> assign(:formatted_count, formatted)
+
+    ~H"""
+    <a
+      href="https://github.com/tomasz-tomczyk/crit"
+      class={[
+        "inline-flex items-center justify-center gap-2 text-sm font-semibold no-underline transition-all",
+        @variant == "hero" &&
+          "group/star px-5 py-2.5 border border-(--crit-border) text-(--crit-fg-secondary) rounded-lg hover:bg-(--crit-yellow-subtle) hover:border-(--crit-yellow) hover:text-(--crit-yellow) max-sm:w-full",
+        @variant == "cta" &&
+          "px-6 py-2.5 border border-(--crit-border) text-(--crit-fg-secondary) rounded-md hover:border-(--crit-fg-muted) hover:text-(--crit-fg-primary)"
+      ]}
+      aria-label={
+        if @star_count,
+          do: "Star Crit on GitHub — #{@formatted_count} stars",
+          else: "Star Crit on GitHub"
+      }
+    >
+      <svg
+        viewBox="0 0 16 16"
+        class={[
+          "fill-current",
+          @variant == "hero" &&
+            "size-4 opacity-60 group-hover/star:opacity-100 group-hover/star:text-(--crit-yellow) group-hover/star:scale-110 transition-all duration-200",
+          @variant == "cta" && "size-3.5 opacity-70"
+        ]}
+        aria-hidden="true"
+      >
+        <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+      </svg>
+      <span>Star on GitHub</span>
+      <span
+        :if={@formatted_count}
+        class={[
+          "tabular-nums font-medium",
+          @variant == "hero" && "text-(--crit-fg-muted) group-hover/star:text-(--crit-yellow)",
+          @variant == "cta" && "text-(--crit-fg-muted)"
+        ]}
+      >
+        {@formatted_count}
+      </span>
+    </a>
+    """
+  end
 end

--- a/lib/crit_web/controllers/page_html/feature.html.heex
+++ b/lib/crit_web/controllers/page_html/feature.html.heex
@@ -484,15 +484,7 @@
             See live demo
           </a>
         <% end %>
-        <a
-          href="https://github.com/tomasz-tomczyk/crit"
-          class="inline-flex items-center gap-2 px-6 py-2.5 border border-(--crit-border) text-(--crit-fg-secondary) rounded-md text-sm font-semibold no-underline hover:border-(--crit-fg-muted) hover:text-(--crit-fg-primary) transition-colors"
-        >
-          <svg viewBox="0 0 16 16" class="size-3.5 fill-current opacity-70" aria-hidden="true">
-            <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
-          </svg>
-          Star on GitHub
-        </a>
+        <.github_star_link variant="cta" />
       </div>
 
       <CritWeb.PageHTML.install_widget />

--- a/lib/crit_web/controllers/page_html/home.html.heex
+++ b/lib/crit_web/controllers/page_html/home.html.heex
@@ -25,19 +25,7 @@
           <CritWeb.PageHTML.install_widget id="hero-install" />
         </div>
         <div class="flex flex-col gap-3 shrink-0 pt-10 max-lg:pt-0 max-sm:w-full max-sm:items-center">
-          <a
-            href="https://github.com/tomasz-tomczyk/crit"
-            class="group/star inline-flex items-center justify-center gap-2 px-5 py-2.5 border border-(--crit-border) text-(--crit-fg-secondary) rounded-lg text-sm font-semibold no-underline hover:bg-(--crit-yellow-subtle) hover:border-(--crit-yellow) hover:text-(--crit-yellow) transition-all max-sm:w-full"
-          >
-            <svg
-              viewBox="0 0 16 16"
-              class="size-4 fill-current opacity-60 group-hover/star:opacity-100 group-hover/star:text-(--crit-yellow) group-hover/star:scale-110 transition-all duration-200"
-              aria-hidden="true"
-            >
-              <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
-            </svg>
-            Star on GitHub
-          </a>
+          <.github_star_link variant="hero" />
           <div class="flex items-center gap-3 max-sm:justify-center">
             <button
               type="button"

--- a/test/crit/github_stars_test.exs
+++ b/test/crit/github_stars_test.exs
@@ -1,0 +1,16 @@
+defmodule Crit.GithubStarsTest do
+  use ExUnit.Case, async: true
+
+  alias Crit.GithubStars
+
+  describe "format_count/1" do
+    test "formats small counts without separators" do
+      assert GithubStars.format_count(42) == "42"
+    end
+
+    test "adds thousands separators" do
+      assert GithubStars.format_count(1234) == "1,234"
+      assert GithubStars.format_count(1_234_567) == "1,234,567"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Crit.GithubStars` GenServer that fetches and caches `stargazers_count` for `tomasz-tomczyk/crit` (hourly refresh, same pattern as changelog)
- Extract a shared `<.github_star_link>` component used on the homepage hero and feature page CTA
- Show the formatted count next to "Star on GitHub" when the API is available; label-only fallback on failure

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (marketing pages only)

## Test plan
- [x] `mix test test/crit/github_stars_test.exs`
- [x] Full test suite (1024 tests, 1 flaky retry passed)
- [x] Rebased onto latest `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)