### PR TITLE
fix: handle expired OAuth sessions and reduce Sentry noise

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -72,6 +72,8 @@ function initSentry(liveSocket) {
     const socket = liveSocket?.getSocket?.()
     if (socket) {
       const PERSISTENCE_MS = 5000
+      const STALE_TAB_MS = 30 * 60 * 1000
+      const MIN_CONSECUTIVE_ERRORS = 3
       let pendingTimer = null
       let consecutiveErrors = 0
       let firstErrorAt = null
@@ -86,13 +88,16 @@ function initSentry(liveSocket) {
         const errSnapshot = err
         pendingTimer = setTimeout(() => {
           pendingTimer = null
+          const msSinceOpen = lastOpenAt ? Date.now() - lastOpenAt : null
+          if (msSinceOpen !== null && msSinceOpen > STALE_TAB_MS) return
+          if (consecutiveErrors < MIN_CONSECUTIVE_ERRORS) return
           Sentry.captureMessage("LiveSocket transport error (persistent)", {
             level: "warning",
             extra: {
               type: errSnapshot?.type,
               message: String(errSnapshot?.message ?? errSnapshot),
               consecutive_errors: consecutiveErrors,
-              ms_since_last_open: lastOpenAt ? Date.now() - lastOpenAt : null,
+              ms_since_last_open: msSinceOpen,
               transport: socket.transport?.name || socket.transport?.constructor?.name || null,
             },
           })

--- a/lib/crit/sentry_filter.ex
+++ b/lib/crit/sentry_filter.ex
@@ -17,9 +17,27 @@ defmodule Crit.SentryFilter do
 
   def before_send(%Sentry.Event{} = event) do
     event
+    |> drop_noise()
     |> scrub_extra()
     |> scrub_query_params()
   end
+
+  # Bot scanners and expired OAuth sessions — not actionable product bugs.
+  defp drop_noise(%{exception: exceptions} = event) when is_list(exceptions) do
+    if Enum.any?(exceptions, &noise_exception?/1), do: :ignore, else: event
+  end
+
+  defp drop_noise(event), do: event
+
+  defp noise_exception?(%{type: "Bandit.HTTPError", value: value}) when is_binary(value) do
+    String.contains?(value, "Header too long")
+  end
+
+  defp noise_exception?(%{type: "KeyError", value: value}) when is_binary(value) do
+    String.contains?(value, "key :state not found")
+  end
+
+  defp noise_exception?(_), do: false
 
   defp scrub_extra(%{extra: extra} = event) when is_map(extra) do
     %{event | extra: Map.drop(extra, @sensitive_keys)}

--- a/lib/crit/sentry_filter.ex
+++ b/lib/crit/sentry_filter.ex
@@ -22,7 +22,7 @@ defmodule Crit.SentryFilter do
     |> scrub_query_params()
   end
 
-  # Bot scanners and expired OAuth sessions — not actionable product bugs.
+  # Bot scanners — not actionable product bugs.
   defp drop_noise(%{exception: exceptions} = event) when is_list(exceptions) do
     if Enum.any?(exceptions, &noise_exception?/1), do: :ignore, else: event
   end
@@ -31,10 +31,6 @@ defmodule Crit.SentryFilter do
 
   defp noise_exception?(%{type: "Bandit.HTTPError", value: value}) when is_binary(value) do
     String.contains?(value, "Header too long")
-  end
-
-  defp noise_exception?(%{type: "KeyError", value: value}) when is_binary(value) do
-    String.contains?(value, "key :state not found")
   end
 
   defp noise_exception?(_), do: false

--- a/lib/crit_web/controllers/oauth_controller.ex
+++ b/lib/crit_web/controllers/oauth_controller.ex
@@ -24,9 +24,19 @@ defmodule CritWeb.OAuthController do
 
   @doc "Handles the OAuth callback: exchanges code for token, finds/creates user, logs in."
   def callback(conn, params) do
-    session_params = get_session(conn, :oauth_session_params) || %{}
     config = build_config()
+    session_params = get_session(conn, :oauth_session_params) || %{}
 
+    if oauth_session_expired?(config, session_params) do
+      conn
+      |> put_flash(:error, "OAuth session expired. Please try signing in again.")
+      |> redirect(to: ~p"/")
+    else
+      complete_callback(conn, params, config, session_params)
+    end
+  end
+
+  defp complete_callback(conn, params, config, session_params) do
     case config
          |> Keyword.put(:session_params, session_params)
          |> config[:strategy].callback(params) do
@@ -91,4 +101,17 @@ defmodule CritWeb.OAuthController do
       _ -> "custom"
     end
   end
+
+  # Assent's OAuth2 verify_state/3 raises KeyError when session_params lacks :state
+  # (expired session, bookmarked callback URL, or cross-browser flow). Fail gracefully.
+  defp oauth_session_expired?(config, session_params) do
+    state_required? = Keyword.get(config, :state, true) != false
+    state_required? and not has_oauth_state?(session_params)
+  end
+
+  defp has_oauth_state?(params) when is_map(params) do
+    Map.has_key?(params, :state) or Map.has_key?(params, "state")
+  end
+
+  defp has_oauth_state?(_), do: false
 end

--- a/test/crit/sentry_filter_test.exs
+++ b/test/crit/sentry_filter_test.exs
@@ -28,20 +28,6 @@ defmodule Crit.SentryFilterTest do
       assert :ignore = SentryFilter.before_send(event)
     end
 
-    test "drops OAuth state KeyError when session expired" do
-      event =
-        event(%{
-          exception: [
-            %{
-              type: "KeyError",
-              value: "key :state not found in:\n\n    %{}\n"
-            }
-          ]
-        })
-
-      assert :ignore = SentryFilter.before_send(event)
-    end
-
     test "passes through unrelated exceptions" do
       event =
         event(%{

--- a/test/crit/sentry_filter_test.exs
+++ b/test/crit/sentry_filter_test.exs
@@ -1,0 +1,55 @@
+defmodule Crit.SentryFilterTest do
+  use ExUnit.Case, async: true
+
+  alias Crit.SentryFilter
+
+  defp event(overrides) do
+    Map.merge(
+      %Sentry.Event{
+        event_id: "a" <> String.duplicate("0", 31),
+        timestamp: 1_700_000_000
+      },
+      Map.new(overrides)
+    )
+  end
+
+  describe "before_send/1" do
+    test "drops Bandit header-too-long scanner noise" do
+      event =
+        event(%{
+          exception: [
+            %{
+              type: "Bandit.HTTPError",
+              value: "Header too long"
+            }
+          ]
+        })
+
+      assert :ignore = SentryFilter.before_send(event)
+    end
+
+    test "drops OAuth state KeyError when session expired" do
+      event =
+        event(%{
+          exception: [
+            %{
+              type: "KeyError",
+              value: "key :state not found in:\n\n    %{}\n"
+            }
+          ]
+        })
+
+      assert :ignore = SentryFilter.before_send(event)
+    end
+
+    test "passes through unrelated exceptions" do
+      event =
+        event(%{
+          exception: [%{type: "RuntimeError", value: "boom"}],
+          extra: %{document: "secret", safe: "ok"}
+        })
+
+      assert %Sentry.Event{extra: %{safe: "ok"}} = SentryFilter.before_send(event)
+    end
+  end
+end

--- a/test/crit_web/controllers/oauth_controller_test.exs
+++ b/test/crit_web/controllers/oauth_controller_test.exs
@@ -45,7 +45,7 @@ defmodule CritWeb.OAuthControllerTest do
     test "logs in user, sets session user_id, and redirects to dashboard" do
       conn =
         build_conn()
-        |> init_test_session(%{oauth_session_params: %{}})
+        |> init_test_session(%{oauth_session_params: %{state: "test_state"}})
         |> get(~p"/auth/login/callback", %{"code" => "test_code"})
 
       assert redirected_to(conn) == ~p"/dashboard"
@@ -58,7 +58,7 @@ defmodule CritWeb.OAuthControllerTest do
       conn =
         build_conn()
         |> init_test_session(%{
-          oauth_session_params: %{},
+          oauth_session_params: %{state: "test_state"},
           device_code_id: device_code.id
         })
         |> get(~p"/auth/login/callback", %{"code" => "test_code"})
@@ -119,11 +119,29 @@ defmodule CritWeb.OAuthControllerTest do
     test "callback redirects to / (default) when no return_to was stored" do
       conn =
         build_conn()
-        |> init_test_session(%{oauth_session_params: %{}})
+        |> init_test_session(%{oauth_session_params: %{state: "test_state"}})
         |> get(~p"/auth/login/callback", %{"code" => "test_code"})
 
       # No oauth_return_to in session → callback falls back to /dashboard.
       assert redirected_to(conn) == ~p"/dashboard"
+    end
+
+    test "redirects with flash when oauth session params are missing state" do
+      conn =
+        build_conn()
+        |> init_test_session(%{oauth_session_params: %{}})
+        |> get(~p"/auth/login/callback", %{"code" => "test_code"})
+
+      assert redirected_to(conn) == ~p"/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "OAuth session expired"
+      assert get_session(conn, "user_id") == nil
+    end
+
+    test "redirects with flash when oauth session params are absent" do
+      conn = get(build_conn(), ~p"/auth/login/callback", %{"code" => "test_code"})
+
+      assert redirected_to(conn) == ~p"/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "OAuth session expired"
     end
   end
 


### PR DESCRIPTION
## Summary
- Redirect OAuth callbacks with missing session state instead of raising KeyError (CRIT-WEB-BACKEND-2)
- Drop Bandit header-too-long scanner noise in backend Sentry filter (CRIT-WEB-BACKEND-4)
- Tighten LiveSocket transport Sentry reporting for stale tabs and brief blips

## Review
- [x] Code review: passed (Crit)
- [x] Parity audit: N/A (crit-web only)

## Test plan
- [x] OAuth controller tests (expired session + happy path)
- [x] SentryFilter tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)