### PR TITLE
chore: skip GitHub stars/changelog pollers on self-hosted

### DIFF
--- a/lib/crit/application.ex
+++ b/lib/crit/application.ex
@@ -58,19 +58,18 @@ defmodule Crit.Application do
   end
 
   defp changelog do
-    if Application.get_env(:crit, :start_changelog, true) do
-      [Crit.Changelog]
-    else
-      []
-    end
+    if hosted_only_child?(:start_changelog), do: [Crit.Changelog], else: []
   end
 
   defp github_stars do
-    if Application.get_env(:crit, :start_github_stars, true) do
-      [Crit.GithubStars]
-    else
-      []
-    end
+    if hosted_only_child?(:start_github_stars), do: [Crit.GithubStars], else: []
+  end
+
+  # GitHub stars/changelog poll api.github.com for the public marketing site.
+  # Self-hosted instances don't expose that UI, so skip the background fetchers.
+  defp hosted_only_child?(key) do
+    Application.get_env(:crit, :selfhosted) != true &&
+      Application.get_env(:crit, key, true)
   end
 
   # Tell Phoenix to update the endpoint configuration


### PR DESCRIPTION
## Summary
- Don't start `Crit.GithubStars` or `Crit.Changelog` GenServers when `SELFHOSTED=true`
- Eliminates hourly `api.github.com` calls on self-hosted deployments that never show that UI
- Test overrides (`start_changelog` / `start_github_stars` in `config/test.exs`) still work on hosted builds

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit-web only)

## Test plan
- [x] `mix precommit` (1028 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)