### PR TITLE
docs: add Codex plugin docs to integrations page

### DIFF
--- a/lib/crit/integrations.ex
+++ b/lib/crit/integrations.ex
@@ -82,18 +82,27 @@ defmodule Crit.Integrations do
     %{
       id: "codex",
       name: "Codex",
-      tagline: "Crit as a Codex skill",
+      tagline: "The full Crit workflow for Codex",
       logo: %{
         light: "/images/integrations/codex-light.svg",
         dark: "/images/integrations/codex-dark.svg"
       },
-      page_title: "Crit + OpenAI Codex CLI — review AI plans inline",
+      page_title: "Crit + OpenAI Codex CLI — plan-mode review for AI agents",
       meta:
-        "Install crit's Codex skill. Drops .agents/skills/crit/ and .agents/skills/crit-cli/ so the OpenAI Codex CLI discovers the review workflow automatically.",
+        "Install crit's Codex plugin: a $crit skill, the crit-cli skill, and a proposed-plan Stop hook that opens every in-chat plan for inline review before the turn ends.",
       intro:
-        "Codex CLI walks up from cwd looking for .agents/skills/, with a global fallback at ~/.agents/skills/. The files follow the cross-tool Agent Skills spec, so any compatible agent loads them.",
+        "Codex is the only agent besides Claude Code with a plan hook: proposed plans in Plan mode go through Crit for inline review before the turn completes. Install the plugin for the hook; skills-only install works for on-demand $crit on files already on disk.",
       command: "crit install codex",
-      components: [:crit_command, :crit_cli_skill]
+      components: [:codex_crit_command, :crit_cli_skill, :codex_plan_hook],
+      marketplace: %{
+        intro:
+          "Installs the Crit Codex plugin globally: $crit and crit-cli skills, a local marketplace entry, and the proposed-plan Stop hook. Enables the plugin in ~/.codex/config.toml automatically.",
+        commands: [
+          "cd ~ && crit install codex-plugin"
+        ]
+      },
+      per_project_note:
+        "Run from the project root for skills only — $crit and crit-cli land in .agents/skills/. No plan hook. For the hook too, run crit install codex-plugin instead and commit plugins/crit/."
     },
     %{
       id: "gemini",
@@ -236,6 +245,19 @@ defmodule Crit.Integrations do
         }
       ]
     },
+    codex_crit_command: %{
+      label: "$crit skill",
+      summary:
+        "Starts the review loop when you type $crit in Codex chat. The agent launches Crit, waits for your inline comments, then revises until you approve.",
+      use_cases: [
+        %{
+          title: nil,
+          desc: nil,
+          example_label: "In your agent's chat:",
+          example: "$crit"
+        }
+      ]
+    },
     crit_cli_skill: %{
       label: "crit-cli skill",
       summary:
@@ -262,6 +284,19 @@ defmodule Crit.Integrations do
       label: "Plan-mode review hook",
       summary:
         "Intercepts Claude Code's ExitPlanMode and sends the plan to Crit for inline review. You comment line-by-line, the agent revises, and plan mode doesn't exit until you approve. Ships only with the marketplace plugin.",
+      use_cases: [
+        %{
+          title: nil,
+          desc: nil,
+          example_label: "Disable per-shell or globally:",
+          example: "export CRIT_PLAN_REVIEW=off"
+        }
+      ]
+    },
+    codex_plan_hook: %{
+      label: "Proposed-plan review hook",
+      summary:
+        "Intercepts Codex's Stop hook when the agent proposes a plan in Plan mode. Reads the in-chat <proposed_plan>, writes it to disk, and runs crit plan-hook --mode codex so you can comment inline before the turn ends. Ships only with crit install codex-plugin — bare $crit needs a file path and cannot review in-chat plans on its own.",
       use_cases: [
         %{
           title: nil,

--- a/lib/crit_web/controllers/page_html.ex
+++ b/lib/crit_web/controllers/page_html.ex
@@ -317,11 +317,12 @@ defmodule CritWeb.PageHTML do
     %{
       id: "codex",
       name: "Codex",
-      copy: "crit install codex",
+      copy: "cd ~ && crit install codex-plugin",
       lines: [
-        %{type: :cmd, prompt: "$ ", text: "crit install codex"},
+        %{type: :cmd, prompt: "$ ", text: "cd ~ && crit install codex-plugin"},
         %{type: :output, text: "Installed: .agents/skills/crit/SKILL.md"},
-        %{type: :output, text: "Installed: .agents/skills/crit-cli/SKILL.md"}
+        %{type: :output, text: "Installed: .codex/plugins/crit/hooks/hooks.json"},
+        %{type: :output, text: "Enabled: crit@local in ~/.codex/config.toml"}
       ]
     },
     %{

--- a/lib/crit_web/controllers/page_html/integration.html.heex
+++ b/lib/crit_web/controllers/page_html/integration.html.heex
@@ -78,9 +78,13 @@
               </div>
             </div>
             <p class="text-(--crit-fg-secondary) leading-relaxed" phx-no-format>
-              Run from the project root to add the <code class="text-(--crit-brand) bg-(--crit-bg-elevated) px-1.5 py-0.5 rounded">/crit</code>
-              and <code class="text-(--crit-brand) bg-(--crit-bg-elevated) px-1.5 py-0.5 rounded">crit-cli</code>
-              skills to the repo. The whole team gets them once pushed.
+              <%= if note = Map.get(@tool, :per_project_note) do %>
+                {note}
+              <% else %>
+                Run from the project root to add the <code class="text-(--crit-brand) bg-(--crit-bg-elevated) px-1.5 py-0.5 rounded">/crit</code>
+                and <code class="text-(--crit-brand) bg-(--crit-bg-elevated) px-1.5 py-0.5 rounded">crit-cli</code>
+                skills to the repo. The whole team gets them once pushed.
+              <% end %>
             </p>
           </div>
         <% nil -> %>

--- a/priv/static/llms.txt
+++ b/priv/static/llms.txt
@@ -30,6 +30,12 @@ claude plugin marketplace add tomasz-tomczyk/crit
 claude plugin install crit@crit
 ```
 
+For Codex, **`crit install codex-plugin` is the recommended path**. It installs the $crit skill, crit-cli, and a proposed-plan Stop hook that reviews in-chat plans before the turn ends:
+
+```
+cd ~ && crit install codex-plugin
+```
+
 For every other agent, `crit install <tool>` writes the integration files (skills, custom rules, or a slash command, depending on the tool).
 
 - [All integrations](https://crit.md/integrations): Index of every supported agent with install instructions.
@@ -37,7 +43,7 @@ For every other agent, `crit install <tool>` writes the integration files (skill
 - [Cursor](https://crit.md/integrations/cursor): `crit install cursor`. Drops the /crit slash command and crit-cli skill into `.cursor/skills/`.
 - [GitHub Copilot](https://crit.md/integrations/github-copilot): `crit install github-copilot`. Installs as Agent Skills under `.github/skills/`.
 - [OpenCode](https://crit.md/integrations/opencode): `crit install opencode`. Skill auto-activates on plan and review requests.
-- [Codex](https://crit.md/integrations/codex): `crit install codex`. Cross-tool Agent Skills format, project or global install.
+- [Codex](https://crit.md/integrations/codex): `crit install codex-plugin` globally (recommended, see above) or `crit install codex` per project for skills only.
 - [Windsurf](https://crit.md/integrations/windsurf): `crit install windsurf`. Single rule under `.windsurf/rules/`.
 - [Cline](https://crit.md/integrations/cline): `crit install cline`. Single rule under `.clinerules/`.
 - [Aider](https://crit.md/integrations/aider): Append the crit conventions to your `CONVENTIONS.md`.

--- a/test/crit_web/controllers/page_controller_test.exs
+++ b/test/crit_web/controllers/page_controller_test.exs
@@ -72,6 +72,16 @@ defmodule CritWeb.PageControllerTest do
       assert html =~ "Per-project alternative"
     end
 
+    test "renders the marketplace branch for codex", %{conn: conn} do
+      conn = get(conn, ~p"/integrations/codex")
+      html = html_response(conn, 200)
+      assert html =~ "Install the plugin (recommended)"
+      assert html =~ "crit install codex-plugin"
+      assert html =~ "Proposed-plan review hook"
+      assert html =~ "Per-project alternative"
+      assert html =~ "crit install codex"
+    end
+
     test "returns 404 for an unknown tool", %{conn: conn} do
       conn = get(conn, ~p"/integrations/does-not-exist")
       body = response(conn, 404)


### PR DESCRIPTION
## Summary
- Add Codex plugin as the recommended install path on `/integrations/codex`, mirroring Claude Code's marketplace flow
- Introduce `$crit` and proposed-plan hook component descriptions
- Update homepage terminal demo, `llms.txt`, and integration template `per_project_note` support

Related to tomasz-tomczyk/crit#685

## Review
- [x] Code review: passed (static)
- [x] Parity audit: N/A (docs only)

## Test plan
- [x] `mix precommit` (1029 tests)
- See also: tomasz-tomczyk/crit#687

🤖 Generated with [Claude Code](https://claude.com/claude-code)