### PR TITLE
fix: resolve relative markdown image paths in hosted reviews

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1350,6 +1350,30 @@ function processTaskLists(html) {
       liTag + (checked === "x" ? '<input type="checkbox" checked disabled>' : '<input type="checkbox" disabled>'))
 }
 
+function resolveImagePath(filePath, src) {
+  const fileDir = filePath.includes("/") ? filePath.replace(/\/[^/]*$/, "") : ""
+  const combined = fileDir ? fileDir + "/" + src : src
+  const parts = combined.split("/")
+  const stack = []
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i]
+    if (!p || p === ".") continue
+    if (p === "..") { if (stack.length) stack.pop() }
+    else stack.push(p)
+  }
+  return stack.join("/")
+}
+
+function rewriteImageSrcs(html, filePath, reviewToken) {
+  return html.replace(/(<img\s[^>]*src=")([^"]+)(")/gi, function(match, pre, src, post) {
+    if (/^https?:\/\/|^data:|^\//.test(src)) return match
+    const resolved = resolveImagePath(filePath || "", src)
+    const href = "/r/" + encodeURIComponent(reviewToken) + "/raw/" +
+      resolved.split("/").map(encodeURIComponent).join("/")
+    return pre + href + post
+  })
+}
+
 // ---- Viewed state (localStorage) --------------------------------------------
 
 function viewedStorageKey(ctx) {
@@ -1953,6 +1977,7 @@ function renderRoundDiffBlock(ctx, block, diffClass, file, commentable, blockInd
   contentEl.className = contentClasses
   let html = block.wordDiffHtml || block.html
   html = processTaskLists(html)
+  html = rewriteImageSrcs(html, file.path, ctx.reviewToken)
   contentEl.innerHTML = html
   lineBlockEl.appendChild(contentEl)
 
@@ -2539,6 +2564,7 @@ function renderBlock(ctx, block, index, commentsMap, commentedLineSet, filePath)
   content.className = contentClasses
   let html = block.html
   html = processTaskLists(html)
+  html = rewriteImageSrcs(html, filePath, ctx.reviewToken)
   content.innerHTML = html
 
   lineBlockEl.appendChild(gutter)


### PR DESCRIPTION
## Summary
- Resolve relative markdown image paths (e.g. `./screenshot.png`) against the document's directory before rendering
- Point rewritten image URLs at the review raw endpoint (`/r/:token/raw/...`) so co-located assets load on crit.md
- Keeps external and absolute URLs unchanged

## Review
- [x] Code review: passed
- [x] Parity audit: paired with tomasz-tomczyk/crit PR (CLI `/files/` route)

## Test plan
- [x] `mix precommit` (1029 tests, 0 failures)
- [ ] Manual: share a markdown doc with sibling PNGs and confirm images render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)