### PR TITLE
feat: add articles landing page and first tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ npm-debug.log
 mise.local.toml
 .env
 .envrc.local
+.wrangler/

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3517,6 +3517,156 @@ body.sidebar-resizing * {
   border-top: 1px solid var(--crit-border);
   margin: 1.5em 0;
 }
+
+/* ===== Article body (MDEx-rendered markdown) ===== */
+
+.article-body {
+  font-size: 1.05rem;
+  line-height: 1.75;
+}
+
+.article-body h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--crit-fg-primary);
+  margin: 2em 0 0.75em;
+  letter-spacing: -0.02em;
+}
+
+.article-body h2:first-child {
+  margin-top: 0;
+}
+
+.article-body h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--crit-fg-primary);
+  margin: 1.5em 0 0.5em;
+}
+
+.article-body p {
+  margin: 0.85em 0;
+}
+
+.article-body ul,
+.article-body ol {
+  padding-left: 1.35em;
+  margin: 0.85em 0;
+}
+
+.article-body ul {
+  list-style: disc;
+}
+
+.article-body ol {
+  list-style: decimal;
+}
+
+.article-body li {
+  margin: 0.35em 0;
+}
+
+.article-body a {
+  color: var(--crit-brand);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 1px;
+  transition: border-color var(--crit-dur-fast) var(--crit-ease);
+  overflow-wrap: anywhere;
+}
+
+.article-body a:hover {
+  border-bottom-color: var(--crit-brand);
+}
+
+.article-body code {
+  font-family: var(--crit-font-mono);
+  font-size: 0.875em;
+  background: var(--crit-bg-elevated);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+}
+
+.article-body pre {
+  background: var(--crit-bg-card);
+  border: 1px solid var(--crit-border);
+  border-radius: 8px;
+  padding: 0.85em 1em;
+  overflow-x: auto;
+  margin: 1em 0;
+  font-size: 0.9em;
+}
+
+.article-body pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
+
+.article-body strong {
+  color: var(--crit-fg-primary);
+  font-weight: 600;
+}
+
+.article-body hr {
+  border: none;
+  border-top: 1px solid var(--crit-border);
+  margin: 2em 0;
+}
+
+.article-body img {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  outline: none;
+  background: none;
+}
+
+.article-body p:has(> img) {
+  margin: 1.25em 0;
+  padding: 0;
+}
+
+.article-body p:has(> img) img {
+  margin: 0;
+}
+
+.article-body blockquote {
+  border-left: 3px solid var(--crit-brand);
+  margin: 1.25em 0;
+  padding: 0.25em 0 0.25em 1em;
+  color: var(--crit-fg-secondary);
+}
+
+.article-body pre.mermaid {
+  background: var(--crit-bg-card);
+  border: 1px solid var(--crit-border);
+  border-radius: 10px;
+  padding: 1.25em;
+  text-align: center;
+  min-height: 80px;
+}
+
+.article-body .mermaid-rendered {
+  margin: 1.5em 0;
+  padding: 1.25em;
+  background: var(--crit-bg-card);
+  border: 1px solid var(--crit-border);
+  border-radius: 10px;
+  text-align: center;
+  overflow-x: auto;
+}
+
+.article-body .mermaid-rendered svg {
+  max-width: 100%;
+  height: auto;
+}
+
 /* Integration logo theme swap (default site is dark) */
 .logo-light { display: none; }
 [data-theme="light"] .logo-light { display: inline-block; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -431,3 +431,7 @@ if (prefersReducedMotion) {
   })
 }
 
+if (/^\/articles\/[^/]+$/.test(window.location.pathname)) {
+  import("./article-mermaid").then(({ initArticleMermaid }) => initArticleMermaid())
+}
+

--- a/assets/js/article-mermaid.js
+++ b/assets/js/article-mermaid.js
@@ -1,0 +1,24 @@
+export async function initArticleMermaid() {
+  const blocks = document.querySelectorAll(".article-body pre.mermaid")
+  if (!blocks.length) return
+
+  const { default: mermaid } = await import("mermaid")
+  const theme =
+    document.documentElement.dataset.theme === "light" ? "default" : "dark"
+
+  mermaid.initialize({ startOnLoad: false, theme })
+
+  let counter = 0
+  for (const el of blocks) {
+    const id = `article-mermaid-${counter++}`
+    try {
+      const { svg } = await mermaid.render(id, el.textContent.trim())
+      const wrapper = document.createElement("div")
+      wrapper.className = "mermaid-rendered"
+      wrapper.innerHTML = svg
+      el.replaceWith(wrapper)
+    } catch {
+      // Leave the source block visible if rendering fails.
+    }
+  }
+}

--- a/lib/crit/articles.ex
+++ b/lib/crit/articles.ex
@@ -1,0 +1,107 @@
+defmodule Crit.Articles do
+  @moduledoc """
+  Static article catalog loaded from `priv/articles/*/index.md`.
+
+  Each file uses YAML frontmatter for metadata and a markdown body rendered
+  with MDEx.
+  """
+
+  @articles_root Path.expand("../../priv/articles", __DIR__)
+  @article_paths Path.wildcard(Path.join(@articles_root, "*/index.md"))
+
+  for path <- @article_paths do
+    @external_resource path
+  end
+
+  @doc "All articles, newest first."
+  def list do
+    @article_paths
+    |> Enum.map(&build_article/1)
+    |> Enum.sort_by(& &1.published_at, {:desc, Date})
+  end
+
+  @doc "The three most recent articles — for homepage highlights."
+  def recent(limit \\ 3), do: list() |> Enum.take(limit)
+
+  @doc "Lookup a single article by slug."
+  def get(slug), do: Enum.find(list(), &(&1.slug == slug))
+
+  @doc "Human-readable date for article cards and headers."
+  def format_date(%Date{} = date) do
+    Calendar.strftime(date, "%b %-d, %Y")
+  end
+
+  def format_date_iso(%Date{} = date), do: Date.to_iso8601(date)
+
+  defp build_article(path) do
+    {frontmatter, body} = path |> File.read!() |> parse_frontmatter()
+    slug = frontmatter["slug"] || Path.basename(Path.dirname(path))
+
+    body_html =
+      case MDEx.to_html(body) do
+        {:ok, html} -> postprocess_html(html)
+        _ -> "<p>Failed to render article.</p>"
+      end
+
+    %{
+      slug: slug,
+      title: frontmatter["title"],
+      excerpt: frontmatter["excerpt"],
+      category: frontmatter["category"],
+      published_at: parse_date!(frontmatter["published_at"]),
+      read_time: frontmatter["read_time"],
+      hero_image: frontmatter["hero_image"],
+      author: frontmatter["author"],
+      body_html: Phoenix.HTML.raw(body_html)
+    }
+  end
+
+  defp parse_frontmatter(content) do
+    case Regex.run(~r/\A---\r?\n(.*?)\r?\n---\r?\n(.*)\z/s, content) do
+      [_, yaml, body] -> {parse_yaml(yaml), String.trim_leading(body)}
+      _ -> {%{}, content}
+    end
+  end
+
+  defp parse_yaml(yaml) do
+    yaml
+    |> String.split("\n", trim: true)
+    |> Enum.reduce(%{}, fn line, acc ->
+      case String.split(line, ":", parts: 2) do
+        [key, value] -> Map.put(acc, String.trim(key), String.trim(value))
+        _ -> acc
+      end
+    end)
+  end
+
+  defp parse_date!(value) when is_binary(value) do
+    case Date.from_iso8601(value) do
+      {:ok, date} -> date
+      _ -> raise "invalid published_at: #{inspect(value)}"
+    end
+  end
+
+  defp postprocess_html(html) do
+    html
+    |> mermaid_blocks()
+    |> lazy_images()
+  end
+
+  defp mermaid_blocks(html) do
+    Regex.replace(~r/<pre><code class="language-mermaid">([\s\S]*?)<\/code><\/pre>/, html, fn _, src ->
+      decoded =
+        src
+        |> String.replace("&amp;", "&")
+        |> String.replace("&lt;", "<")
+        |> String.replace("&gt;", ">")
+        |> String.replace("&#39;", "'")
+        |> String.replace("&quot;", "\"")
+
+      ~s(<pre class="mermaid">#{decoded}</pre>)
+    end)
+  end
+
+  defp lazy_images(html) do
+    String.replace(html, "<img ", ~s(<img loading="lazy" decoding="async" ))
+  end
+end

--- a/lib/crit/articles.ex
+++ b/lib/crit/articles.ex
@@ -88,7 +88,8 @@ defmodule Crit.Articles do
   end
 
   defp mermaid_blocks(html) do
-    Regex.replace(~r/<pre><code class="language-mermaid">([\s\S]*?)<\/code><\/pre>/, html, fn _, src ->
+    Regex.replace(~r/<pre><code class="language-mermaid">([\s\S]*?)<\/code><\/pre>/, html, fn _,
+                                                                                              src ->
       decoded =
         src
         |> String.replace("&amp;", "&")

--- a/lib/crit_web/components/layouts.ex
+++ b/lib/crit_web/components/layouts.ex
@@ -71,7 +71,7 @@ defmodule CritWeb.Layouts do
 
   attr :current_page, :atom,
     default: nil,
-    doc: "one of :features, :changelog, :integrations"
+    doc: "one of :features, :articles, :changelog, :integrations"
 
   def site_header(assigns) do
     current_user = assigns.current_scope && assigns.current_scope.user
@@ -180,6 +180,9 @@ defmodule CritWeb.Layouts do
           </.nav_link>
           <.nav_link href={~p"/features"} active={@current_page == :features}>
             Features
+          </.nav_link>
+          <.nav_link href={~p"/articles"} active={@current_page == :articles}>
+            Articles
           </.nav_link>
           <.nav_link href={~p"/self-hosting"} active={@current_page == :self_hosting}>
             Self-Hosting
@@ -341,6 +344,9 @@ defmodule CritWeb.Layouts do
           </.nav_mobile_link>
           <.nav_mobile_link href={~p"/features"} active={@current_page == :features}>
             Features
+          </.nav_mobile_link>
+          <.nav_mobile_link href={~p"/articles"} active={@current_page == :articles}>
+            Articles
           </.nav_mobile_link>
           <.nav_mobile_link href={~p"/self-hosting"} active={@current_page == :self_hosting}>
             Self-Hosting
@@ -1183,6 +1189,12 @@ defmodule CritWeb.Layouts do
                 class="text-sm text-(--crit-fg-primary) hover:text-(--crit-brand) no-underline"
               >
                 Changelog
+              </a>
+              <a
+                href={~p"/articles"}
+                class="text-sm text-(--crit-fg-primary) hover:text-(--crit-brand) no-underline"
+              >
+                Articles
               </a>
             </div>
           </div>

--- a/lib/crit_web/controllers/page_controller.ex
+++ b/lib/crit_web/controllers/page_controller.ex
@@ -489,6 +489,7 @@ defmodule CritWeb.PageController do
     else
       render(conn, :home,
         demo_token: Application.get_env(:crit, :demo_review_token),
+        recent_articles: Crit.Articles.recent(),
         testimonials: @testimonials,
         faq: @faq,
         canonical_url: canonical_url(conn),
@@ -746,6 +747,56 @@ defmodule CritWeb.PageController do
     end
   end
 
+  def articles(conn, _params) do
+    articles = Crit.Articles.list()
+    [featured | rest] = articles
+
+    render(conn, :articles,
+      featured: featured,
+      rest: rest,
+      canonical_url: canonical_url(conn),
+      page_title: "Articles - Crit",
+      meta_description:
+        "Essays on reviewing AI agent output, structured feedback loops, and shipping with more control."
+    )
+  end
+
+  def article(conn, %{"slug" => slug}) do
+    case Crit.Articles.get(slug) do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> put_view(CritWeb.ErrorHTML)
+        |> render(:"404")
+
+      article ->
+        render(conn, :article,
+          article: article,
+          canonical_url: canonical_url(conn),
+          page_title: "#{article.title} - Crit",
+          meta_description: article.excerpt,
+          og_image: article.hero_image,
+          json_ld: %{
+            "@context" => "https://schema.org",
+            "@type" => "Article",
+            "headline" => article.title,
+            "description" => article.excerpt,
+            "datePublished" => Crit.Articles.format_date_iso(article.published_at),
+            "author" => %{
+              "@type" => "Person",
+              "name" => article.author
+            },
+            "image" => article.hero_image,
+            "publisher" => %{
+              "@type" => "Organization",
+              "name" => "Crit",
+              "url" => "https://crit.md"
+            }
+          }
+        )
+    end
+  end
+
   def changelog(conn, _params) do
     releases = Crit.Changelog.list_releases()
     cli_releases = Enum.filter(releases, &(&1.source == :cli))
@@ -795,6 +846,7 @@ defmodule CritWeb.PageController do
     {"/modes/preview", "monthly", "0.8"},
     {"/getting-started", "monthly", "0.9"},
     {"/self-hosting", "monthly", "0.7"},
+    {"/articles", "weekly", "0.8"},
     {"/changelog", "daily", "0.7"},
     {"/terms", "monthly", "0.3"},
     {"/privacy", "monthly", "0.3"}
@@ -831,6 +883,12 @@ defmodule CritWeb.PageController do
     static_entries =
       Enum.map(@sitemap_paths, fn {p, f, pr} -> sitemap_entry(base <> p, f, pr) end)
 
+    article_entries =
+      Crit.Articles.list()
+      |> Enum.map(fn article ->
+        sitemap_entry(base <> "/articles/#{article.slug}", "monthly", "0.6")
+      end)
+
     review_entries =
       Crit.Reviews.list_public_review_tokens()
       |> Enum.map(fn token -> sitemap_entry(base <> "/r/#{token}", "weekly", "0.5") end)
@@ -838,7 +896,7 @@ defmodule CritWeb.PageController do
     body = """
     <?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    #{Enum.join(static_entries ++ review_entries, "\n")}
+    #{Enum.join(static_entries ++ article_entries ++ review_entries, "\n")}
     </urlset>
     """
 

--- a/lib/crit_web/controllers/page_html.ex
+++ b/lib/crit_web/controllers/page_html.ex
@@ -65,6 +65,103 @@ defmodule CritWeb.PageHTML do
 
   def modes, do: @modes
 
+  attr :article, :map, required: true
+  attr :variant, :string, default: "default", values: ~w(default featured compact)
+
+  def article_card(assigns) do
+    ~H"""
+    <a
+      href={~p"/articles/#{@article.slug}"}
+      class={[
+        "group flex flex-col no-underline text-inherit overflow-hidden transition-all duration-200",
+        @variant == "featured" &&
+          "grid grid-cols-2 gap-0 rounded-2xl border border-(--crit-border) bg-(--crit-bg-card) hover:border-(--crit-fg-muted) hover:shadow-lg max-lg:grid-cols-1",
+        @variant == "default" &&
+          "rounded-xl border border-(--crit-border) bg-(--crit-bg-card) hover:border-(--crit-fg-muted) hover:-translate-y-0.5 hover:shadow-md",
+        @variant == "compact" &&
+          "rounded-xl border border-(--crit-border) bg-(--crit-bg-card) hover:border-(--crit-fg-muted)"
+      ]}
+    >
+      <div class={[
+        "relative overflow-hidden bg-(--crit-bg-elevated)",
+        @variant == "featured" && "min-h-[280px] max-lg:min-h-[200px]",
+        @variant == "default" && "aspect-[16/10]",
+        @variant == "compact" && "aspect-[16/10]"
+      ]}>
+        <img
+          src={@article.hero_image}
+          alt=""
+          class={[
+            "w-full h-full object-cover transition-transform duration-500",
+            "group-hover:scale-[1.03]"
+          ]}
+          loading="lazy"
+          width="640"
+          height="400"
+        />
+        <div class="absolute inset-0 bg-gradient-to-t from-black/50 via-black/10 to-transparent opacity-80" />
+        <span class="absolute top-3 left-3 inline-flex items-center rounded-full border border-white/20 bg-black/40 backdrop-blur-sm px-2.5 py-1 text-[11px] font-medium text-white/90">
+          {@article.category}
+        </span>
+      </div>
+
+      <div class={[
+        "flex flex-col flex-1",
+        @variant == "featured" && "justify-center p-8 max-sm:p-6",
+        @variant in ["default", "compact"] && "p-5"
+      ]}>
+        <div :if={@variant != "featured"} class="flex flex-wrap items-center gap-2 mb-3">
+          <span class="text-xs text-(--crit-fg-muted)">{@article.author}</span>
+          <span class="text-(--crit-fg-muted)" aria-hidden="true">·</span>
+          <time
+            datetime={Crit.Articles.format_date_iso(@article.published_at)}
+            class="text-[11px] text-(--crit-fg-muted)"
+          >
+            {Crit.Articles.format_date(@article.published_at)}
+          </time>
+          <span class="text-(--crit-fg-muted)" aria-hidden="true">·</span>
+          <span class="text-[11px] text-(--crit-fg-muted)">{@article.read_time}</span>
+        </div>
+
+        <h2 class={[
+          "font-bold tracking-tight text-(--crit-fg-primary) group-hover:text-(--crit-brand) transition-colors",
+          @variant == "featured" && "text-2xl leading-snug max-sm:text-xl",
+          @variant in ["default", "compact"] && "text-lg leading-snug"
+        ]}>
+          {@article.title}
+        </h2>
+
+        <p class={[
+          "text-(--crit-fg-secondary) leading-relaxed mt-2",
+          @variant == "featured" && "text-base mt-3",
+          @variant in ["default", "compact"] && "text-sm line-clamp-3"
+        ]}>
+          {@article.excerpt}
+        </p>
+
+        <div class={[
+          "flex flex-wrap items-center gap-x-3 gap-y-1 mt-auto text-xs text-(--crit-fg-muted)",
+          @variant == "featured" && "pt-6",
+          @variant in ["default", "compact"] && "pt-4"
+        ]}>
+          <span :if={@variant == "featured"}>{@article.author}</span>
+          <span :if={@variant == "featured"} class="text-(--crit-fg-muted)" aria-hidden="true">·</span>
+          <time
+            :if={@variant == "featured"}
+            datetime={Crit.Articles.format_date_iso(@article.published_at)}
+            class="text-xs"
+          >
+            {Crit.Articles.format_date(@article.published_at)}
+          </time>
+          <span class="text-sm font-semibold text-(--crit-brand) group-hover:underline ml-auto">
+            Read article &rarr;
+          </span>
+        </div>
+      </div>
+    </a>
+    """
+  end
+
   slot :inner_block, required: true
   attr :url, :string, required: true
   attr :tag, :string, default: nil

--- a/lib/crit_web/controllers/page_html/article.html.heex
+++ b/lib/crit_web/controllers/page_html/article.html.heex
@@ -1,0 +1,67 @@
+<Layouts.flash_group flash={@flash} />
+
+<div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
+  <Layouts.site_header current_scope={@current_scope} current_page={:articles} />
+
+  <article class="max-w-7xl mx-auto w-full px-10 mt-16 pb-20 max-sm:px-4 max-sm:mt-10 max-sm:pb-12">
+    <p class="mb-6">
+      <a
+        href={~p"/articles"}
+        class="inline-flex items-center gap-1.5 text-sm font-medium text-(--crit-fg-muted) hover:text-(--crit-brand) no-underline transition-colors"
+      >
+        <.icon name="hero-arrow-left-mini" class="size-3.5" />
+        All articles
+      </a>
+    </p>
+
+    <header class="mb-8">
+      <div class="flex flex-wrap items-center gap-3 mb-4 text-xs text-(--crit-fg-muted)">
+        <span class="inline-flex items-center rounded-full border border-(--crit-border) bg-(--crit-bg-elevated) px-3 py-1 font-medium text-(--crit-fg-secondary)">
+          {@article.category}
+        </span>
+        <time datetime={Crit.Articles.format_date_iso(@article.published_at)}>
+          {Crit.Articles.format_date(@article.published_at)}
+        </time>
+        <span aria-hidden="true">·</span>
+        <span>{@article.author}</span>
+        <span aria-hidden="true">·</span>
+        <span>{@article.read_time}</span>
+      </div>
+
+      <h1 class="text-4xl font-extrabold tracking-tight leading-tight max-sm:text-3xl text-balance">
+        {@article.title}
+      </h1>
+
+      <p class="text-lg text-(--crit-fg-secondary) leading-relaxed mt-4">
+        {@article.excerpt}
+      </p>
+    </header>
+
+    <div class="mb-10">
+      <img
+        src={@article.hero_image}
+        alt=""
+        class="w-full h-auto"
+        width="1200"
+        height="675"
+        loading="eager"
+        decoding="async"
+      />
+    </div>
+
+    <div class="article-body text-(--crit-fg-secondary)">
+      {@article.body_html}
+    </div>
+
+    <footer class="mt-12 pt-8 border-t border-(--crit-border)">
+      <a
+        href={~p"/articles"}
+        class="text-sm font-semibold text-(--crit-brand) no-underline hover:underline"
+      >
+        More articles &rarr;
+      </a>
+    </footer>
+  </article>
+
+  <Layouts.site_footer />
+</div>

--- a/lib/crit_web/controllers/page_html/article.html.heex
+++ b/lib/crit_web/controllers/page_html/article.html.heex
@@ -9,8 +9,7 @@
         href={~p"/articles"}
         class="inline-flex items-center gap-1.5 text-sm font-medium text-(--crit-fg-muted) hover:text-(--crit-brand) no-underline transition-colors"
       >
-        <.icon name="hero-arrow-left-mini" class="size-3.5" />
-        All articles
+        <.icon name="hero-arrow-left-mini" class="size-3.5" /> All articles
       </a>
     </p>
 

--- a/lib/crit_web/controllers/page_html/articles.html.heex
+++ b/lib/crit_web/controllers/page_html/articles.html.heex
@@ -1,0 +1,31 @@
+<Layouts.flash_group flash={@flash} />
+
+<div class="min-h-screen bg-(--crit-bg-page) text-(--crit-fg-primary) font-sans flex flex-col">
+  <Layouts.site_header current_scope={@current_scope} current_page={:articles} />
+
+  <section class="max-w-7xl mx-auto w-full px-10 mt-16 max-sm:px-4 max-sm:mt-10">
+    <header class="mb-14 max-sm:mb-10">
+      <p class="font-mono text-xs tracking-widest uppercase text-(--crit-fg-muted) mb-3">
+        Writing
+      </p>
+      <h1 class="text-5xl font-extrabold tracking-tight max-sm:text-4xl text-balance">
+        Articles<span class="text-(--crit-brand)">.</span>
+      </h1>
+      <p class="text-xl text-(--crit-fg-secondary) mt-4 leading-relaxed">
+        Notes on reviewing agent output, tightening feedback loops, and shipping with more control.
+      </p>
+    </header>
+
+    <%= if @featured do %>
+      <article class="mb-16 max-sm:mb-12">
+        <.article_card article={@featured} variant="featured" />
+      </article>
+    <% end %>
+
+    <div class="grid grid-cols-3 gap-8 max-lg:grid-cols-2 max-sm:grid-cols-1">
+      <.article_card :for={article <- @rest} article={article} variant="default" />
+    </div>
+  </section>
+
+  <Layouts.site_footer />
+</div>

--- a/lib/crit_web/controllers/page_html/home.html.heex
+++ b/lib/crit_web/controllers/page_html/home.html.heex
@@ -251,6 +251,36 @@
     </div>
   </section>
 
+  <%!-- ===== Recent articles ===== --%>
+  <section id="articles" class="py-16 max-sm:py-10">
+    <div class="max-w-7xl mx-auto px-10 max-sm:px-4 w-full">
+      <div class="flex flex-wrap items-end justify-between gap-6 mb-12 max-sm:mb-8">
+        <div class="max-w-2xl">
+          <p class="font-mono text-xs tracking-widest uppercase text-(--crit-fg-muted) mb-4">
+            Guides & articles
+          </p>
+          <h2 class="text-4xl font-extrabold tracking-tight max-sm:text-3xl text-balance">
+            Ideas for tighter agent loops<span class="text-(--crit-brand)">.</span>
+          </h2>
+        </div>
+        <a
+          href={~p"/articles"}
+          class="text-sm font-semibold text-(--crit-brand) no-underline hover:underline shrink-0"
+        >
+          View all articles &rarr;
+        </a>
+      </div>
+
+      <div class="grid grid-cols-3 gap-8 max-lg:grid-cols-2 max-sm:grid-cols-1">
+        <CritWeb.PageHTML.article_card
+          :for={article <- @recent_articles}
+          article={article}
+          variant="compact"
+        />
+      </div>
+    </div>
+  </section>
+
   <%!-- ===== Founder ===== --%>
   <section id="built-by" class="py-16 max-sm:py-10">
     <div class="max-w-3xl mx-auto px-10 max-sm:px-4 w-full">

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -58,6 +58,8 @@ defmodule CritWeb.Router do
     get "/privacy", PageController, :privacy
     get "/getting-started", PageController, :getting_started
     get "/self-hosting", PageController, :self_hosting
+    get "/articles", PageController, :articles
+    get "/articles/:slug", PageController, :article
     get "/changelog", PageController, :changelog
     get "/modes/:mode", PageController, :mode
     get "/sitemap.xml", PageController, :sitemap_xml

--- a/mise.toml
+++ b/mise.toml
@@ -50,6 +50,10 @@ description = "Run database seeds"
 depends = ["deps", "db:start"]
 run = "mix run priv/repo/seeds.exs"
 
+[tasks."assets:upload-article"]
+description = "Upload article images to Cloudflare R2 (requires wrangler login + CRIT_ASSETS_BUCKET)"
+run = "./scripts/upload-article-assets.sh"
+
 [tasks.up]
 description = "Start everything"
 depends = ["deps", "db:setup"]

--- a/priv/articles/how-to-plan-document-and-review/index.md
+++ b/priv/articles/how-to-plan-document-and-review/index.md
@@ -1,0 +1,356 @@
+---
+slug: how-to-plan-document-and-review
+title: How to Plan, Document and Review Code with Open Source Tools
+excerpt: Build a human-in-the-loop agentic coding workflow using Superpowers, Crit, and OpenCode — the ultimate open source stack for AI-assisted development.
+category: Tutorial
+published_at: 2026-07-03
+read_time: 18 min read
+hero_image: https://assets.crit.md/articles/how-to-plan-document-and-review/02_questions.png
+author: Valeria Viana Gusmao
+---
+
+AI can generate code faster than you could ever imagine. And it mostly works!
+
+Let's say you ask your favourite agent to build a feature. Five minutes later, you have 500 lines of code that compiles, passes tests and looks about right. Except you start digging into it and notice that the architecture is questionable, error handling is inconsistent, and you're not sure that the edge cases that agent swore it had taken into consideration are actually handled at all.
+
+It's natural to jump to a conclusion that that's the best AI can do, but, just like it is with humans, workflow quite often turns out to be less than optimal. One-shot prompt-and-forget is tempting, but AI isn't a magic wand. And if you go straight from "prompt" to "code" with no structured review in between you tend to end up with a pumpkin rather than a chariot.
+
+This tutorial walks through a different approach using an open source, local-first stack that brings structured planning, document review, and code review into your AI coding workflow.
+
+We'll be using OpenCode in this tutorial, but you can easily swap it for your favourite agentic harness instead be it ClaudeCode, Cursor, Aider, Pi or anything else. The real magic comes from these two tools:
+
+- **[Superpowers](https://github.com/obra/superpowers)** — An agentic skills framework (236K+ GitHub stars) that enforces a complete software development methodology: brainstorm, plan, TDD, review, ship.
+- **[Crit](https://github.com/tomasz-tomczyk/crit)** — UI for reviewing AI-generated plans, code and even web apps and pages with inline comments. The **code and document review open source tool** with over 500 stars on GitHub that makes the feedback loop between agent and human much more pleasant for both.
+
+By the end of this tutorial, you'll have a complete human-in-the-loop workflow that allows you to confidently develop and ship features with the assistance of AI.
+
+---
+
+## Step 1: Install the Stack
+
+### Install OpenCode
+
+To install OpenCode run:
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+If you run into troubles — please refer to the documentation for [OpenCode](https://opencode.ai).
+
+### Install Superpowers
+
+Superpowers are available as a plugin for multiple platforms. There are multiple ways to configure OpenCode — for this tutorial we will use the project level configuration. Create an `opencode.json` file at the root with the following configuration:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["superpowers@git+https://github.com/obra/superpowers.git"]
+}
+```
+
+For other agents, e.g. Claude Code, you can install from the official marketplace:
+
+```bash
+/plugin install superpowers@claude-plugins-official
+```
+
+### Install Crit
+
+Crit is distributed as a single binary.
+
+**For Mac:**
+
+```bash
+brew install crit
+```
+
+**For Windows:**
+
+```powershell
+iwr https://github.com/tomasz-tomczyk/crit/releases/latest/download/crit-windows-amd64.exe -OutFile crit.exe
+```
+
+**For Linux:**
+
+```bash
+nix profile install github:tomasz-tomczyk/crit
+```
+
+If you have Go installed on your machine you can also install Crit with:
+
+```bash
+go install github.com/tomasz-tomczyk/crit@latest
+```
+
+And then simply run:
+
+```bash
+crit install opencode
+```
+
+See [Crit integration](https://crit.md/integrations) for ways to use Crit with other agents.
+
+You should see a message indicating that the plugin was installed successfully:
+
+```
+Installed: .opencode/commands/crit.md
+  Installed: .opencode/skills/crit/SKILL.md
+  Installed: .opencode/plugins/crit.ts
+  Installed: opencode.jsonc
+  Run /crit in OpenCode to start a review loop
+  The crit skill is available to OpenCode agents when needed
+  Crit's opencode plugin gates sharing instructions on share_url being set
+```
+
+You might be prompted to add a plugin manually if you already had an existing `opencode.json` configuration. In this case, do so, then restart OpenCode.
+
+### Verify the Installation
+
+```bash
+# Check Crit is available
+crit --help
+```
+
+```bash
+# Check OpenCode can find Superpowers
+opencode
+# Then type: "List the skills you have available"
+```
+
+You should see both Superpowers skills listed: such as `brainstorming`, `writing-plans`, `test-driven-development`, `requesting-code-review`, `crit` and `crit-cli`:
+![IDE showing opencode.json plugin configuration for Superpowers and Crit, with a terminal panel listing the installed Superpowers skills including requesting-code-review, crit, and crit-cli](https://assets.crit.md/articles/how-to-plan-document-and-review/01_installed.png)
+
+---
+
+## Step 2: Understand the Workflow
+
+Before we dive into the commands, here's the big picture. The full loop looks like this:
+
+```mermaid
+flowchart TD
+    A[💡 Idea] --> B[🧠 Brainstorming<br/>Superpowers]
+    B --> C[📝 Write Plan<br/>Superpowers]
+    C --> D[🔍 Review Plan<br/>Crit]
+    D --> E{Approved?}
+    E -->|No| C
+    E -->|Yes| F[⚙️ Execute Plan<br/>Superpowers]
+    F --> V[🧪 Verify it yourself]
+    V -->|Bug found| F
+    V -->|Looks good| G[🔍 Review Code<br/>Crit]
+    G --> H{Approved?}
+    H -->|No| F
+    H -->|Yes| I[🚀 Ship<br/>Superpowers]
+    I --> A
+```
+
+Every feature goes through this loop. It's slower than "vibe coding" initially, but since you're reviewing every step of the way, you can catch AI slop before it pollutes your codebase.
+
+---
+
+## Step 3: Start a Session and Brainstorm
+
+Start your coding agent and describe what you want to build.
+Instead of jumping straight into code, the agent activates its **brainstorming** skill.
+
+**Try this prompt:**
+
+> "I want to build a REST API that would allow users to create short links"
+
+Instead of writing code, the agent will ask clarifying questions to refine the requirements and present design options with trade-offs.
+
+You'll see something like:
+
+![IDE showing OpenCode asking a clarifying question about which language/runtime to use for the project, with multiple choice options for Node.js, Go, Python, and a field to type a custom answer](https://assets.crit.md/articles/how-to-plan-document-and-review/02_questions.png)
+
+This is the first key difference from a _normal_ AI coding session. So put on your tech lead hat and start reviewing the **design** document.
+
+---
+
+## Step 4: Review the Plan with Crit
+
+Once the brainstorming is done, the agent writes an implementation plan.
+
+The plan gets saved to something like `docs/superpowers/specs/2026-06-26-shortlink-api-design.md`.
+
+Now open it in Crit for review using slash command within the agent:
+
+```bash
+/crit docs/superpowers/specs/2026-06-26-shortlink-api-design.md
+```
+
+Or, you can simply run `/crit` without specifying a file to review the changes made during current session. Crit will automatically detect what you're reviewing documentation and will show markdown reviewer interface.
+
+Crit opens a browser window with the plan loaded and waits for you to review it.
+
+Walk through the plan line by line. Leave comments on anything that needs changing: point at the line and nitpick away.
+
+![Crit web interface showing an inline review comment on line 111 of a markdown file, with the reviewer suggesting to rename "code" parameter to "alias" for clarity](https://assets.crit.md/articles/how-to-plan-document-and-review/03_nitpick.png)
+
+When you're done, press `Finish review` to save your comments and exit. Crit stores your comments as JSON in `.crit/`:
+
+```json
+{
+  "file": "docs/superpowers/specs/2026-06-26-shortlink-api-design.md",
+  "comments": [
+    {
+      "line": 45,
+      "body": "Auto-generated aliases need a collision check — a 6-char base62 code will clash at scale",
+      "timestamp": "2026-06-26T10:30:00Z"
+    }
+  ]
+}
+```
+
+If you started the review process from a terminal outside your agent - you can copy and paste the feedback and your coding agent will take it from there.
+
+---
+
+## Step 5: Agent Addresses Your Feedback
+
+Once the agents gets the feedback, it revises the plan, responds to comments and presents the updated version. You can re-review with Crit to verify the changes.
+
+You might go through 2-3 rounds of this. That's normal and is the whole point of this process. As tedious as it is to review the document - it's best to catch design issues **before** any code is written.
+
+When you're satisfied with the plan, click "Approve" to move on to the next step.
+
+![Crit web interface showing the review complete state with a green checkmark and "Approved" modal overlay, indicating the review session is finished and the document is now read-only](https://assets.crit.md/articles/how-to-plan-document-and-review/04_approved.png)
+
+---
+
+## Step 6: Execute the Plan
+
+Once the plan is approved, start a fresh conversation for implementation by typing `/new`.
+
+> Note: You can also use this trick if agent gets stuck. OpenCode is a good open source tool, but sometimes it can get a little moody and need some extra help. If it won't work seamlessly for you, you can always switch to another harness. Superpowers are _just_ a collection of markdown skills and Crit works with pretty much any agent you can think of the same way.
+
+Starting new conversation is deliberate as the planning session can get long, and a clean context window allows the agent to focus on execution and since the documented plan persists between the sessions, the agent can pick up where it left off.
+
+If the agent nods off without creating a plan, tell it something like:
+
+```
+"The spec at docs/superpowers/specs/2026-06-26-shortlink-api-design.md is approved. Move to the next step."
+```
+
+After that you should have a document in the plans directory.
+You can review it with Crit again:
+
+```
+/crit docs/superpowers/plans/2026-06-26-shortlink-api.md
+```
+
+> Tip: It's better to go through many rounds of smaller comments, especially if the plan is long and complex than reviewing the plan all at once. Agents tend to perform better when they can focus on one thing at a time.
+
+Once you're ready with the plan, you'll see something like:
+
+```
+Review approved — all comments resolved, no changes needed. Plan is finalized at docs/superpowers/plans/2026-06-26-shortlink-api.md.
+Two execution options:
+1. Subagent-Driven (recommended) — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. Inline Execution — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+Which approach?
+```
+
+Unless you have a reason not to, you can safely go with the subagent-driven approach.
+
+By default, this is where Superpowers' **executing-plans** skill takes over. The agent works through the plan task by task:
+
+1. Creates a git worktree for isolated development
+2. Runs baseline tests to confirm a clean starting point
+3. Works through each task with TDD (RED → GREEN → REFACTOR)
+4. Self-reviews the code.
+
+We would like to intercept that and ask the agent to use crit skill so that we can review the code in between tasks instead of only self-review. A simple prompt like this one would do the trick:
+
+```
+Use the crit skill so that I can review the code in between tasks.
+```
+
+You don't need to watch over its shoulder. The agent knows what to build, what patterns to follow, and what trade-offs you agreed on. Go make coffee ☕. It'll wait for your review before proceeding to the next task.
+
+![IDE showing OpenCode executing Task 5 from the plan, with terminal output showing the subagent completed the implementation and started the review process, and the todo list tracking progress through 8 tasks](https://assets.crit.md/articles/how-to-plan-document-and-review/05_working.png)
+
+![Crit web interface showing a code review of Go source files (links.go and links_test.go) with the file tree on the left, code viewer in the center, and an Approve button in the top right](https://assets.crit.md/articles/how-to-plan-document-and-review/06_crit_review.png)
+
+---
+
+## Step 7: Final review
+
+Once the agent is done with all the tasks, it'll request your final review on the README file with the instructions on how to run the server:
+![Crit web interface showing the final review of README.md with session complete banner, displaying the project title, run instructions with JWT_SECRET export and go run command, and API section referencing the design document](https://assets.crit.md/articles/how-to-plan-document-and-review/07_final_review.png)
+
+When you're happy with the README file, the agent will do a final review on the whole branch, don't worry, you wouldn't have to review it all.
+
+And when it's done - it's finally time kick the tyres. Run the freshly written shortlink server, following the instructions in the README file, e.g.:
+
+```bash
+export JWT_SECRET=changeme
+go run ./cmd/server
+```
+
+Now try it out it end to end.
+
+Sign up through the API:
+![API client showing a POST request to /signup endpoint with email and password in the request body, returning 201 Created with a JWT token in the response body](https://assets.crit.md/articles/how-to-plan-document-and-review/08_signup.png)
+
+Create a short link:
+![API client showing a POST request to /links endpoint with Bearer token authentication, sending alias and URL in the request body, and receiving 201 Created with the short URL response including code, clicks, created_at timestamp, and short_url](https://assets.crit.md/articles/how-to-plan-document-and-review/09_create_link.png)
+
+And watch it redirect in the browser or in the terminal, for posterity:
+![Terminal showing curl command testing the short link redirect: `curl -I -X GET http://localhost:8080/crt` returns HTTP 302 Found with Location header pointing to https://github.com/tomasz-tomczyk/crit](https://assets.crit.md/articles/how-to-plan-document-and-review/10_redirect.png)
+
+## Step 8: Next Cycle: UI
+
+Hopefully your API is also verified and is in good shape. But there isn't much fun in just a bare API. Besides, it wouldn't be a real workflow if you could run it only once. So how about we do another cycle and see how easy it would be to maintain the project using the same open source tools and the same loop of planning, documenting and reviewing?
+
+Open a fresh session (clean context, same as before) and ask:
+
+> "Add a simple, but premium web UI to the link shortener. Complete with user signup, login, link management and analytics features."
+
+You'll go through the same flow as before, but hopefully notice that it goes a little faster this time. Superpowers scales the same flow down to fit the size of the task: a short brainstorm, a small plan, a quick review of that plan in Crit — nothing you haven't already done up until the point where the UI is ready for you to test.
+
+Something along the lines of:
+
+```
+# Todos
+[•] Write design spec to docs/superpowers/specs/2026-06-26-web-ui-design.md
+[ ] Self-review spec for placeholders/contradictions/ambiguity/scope
+[ ] Commit spec to git
+[ ] Ask user to review the written spec
+```
+
+Next, you'll repeat the same process of reviewing the plan and code for every implementation task as before.
+
+## Step 9: Review the Running App with Crit Live Mode
+
+Once the agent is done with the frontend it's time to look at it with a *Crit*ical eye. As fun as reading HTML and CSS is - being able to comment on the actual rendered app is a much more natural way to review it:
+
+```bash
+/crit live http://localhost:8080
+```
+
+Crit proxies your running dev server and overlays its review UI on the live page. Here is your chance to point to the agent anything that you don't like. Drop a comment right on an element and send the feedback using the same `Finish review` loop as the plan and code reviews.
+
+It's also a good idea to implement tasks vertically, so that you're not exhausting yourself by reviewing document after document and diff after diff. And if you do get to a state where you are tempted to just approve everything without reading, it's better to take a break and come back later than to redo all the work.
+
+To start reviewing the running app, run the following slash command in your agent:
+
+```
+/crit live http://localhost:8080
+```
+
+![Crit live mode showing a visual review of a sign-in page with email and password fields, with the comments panel on the right showing feedback about button styling and the agent's response about making it full-width](https://assets.crit.md/articles/how-to-plan-document-and-review/11_ui_review.png)
+
+The agent reads you comments and makes changes, fires the review again and keeps iterating with you until you approve. And often it takes more than a few rounds to get there.
+
+This view took 13 rounds to get to the approved state:
+
+![Crit live mode showing the final review of the linkz dashboard with analytics (total clicks, last 24h, last 7d stats and 14-day chart), with the comments panel on the right showing 8 resolved review comments](https://assets.crit.md/articles/how-to-plan-document-and-review/12_final.png)
+
+## That's the loop, folks!
+
+In this tutorial we've implemented a full-stack application from scratch using only open source tools and went through two cycles of planning, documenting, and reviewing AI-generated output.
+
+And because you have reviewed every decision the agent made and every bit of code it generated - you can keep iterating on the same codebase without losing your sanity.
+
+Just like us humans, the AI agents love structure and work best in smaller scopes with a shorter feedback cycle. And the fact that you can do every step of the AI workflow - plan, document and review AI-generated code efficiently - with nothing but open source tools is definitely a cherry on top.

--- a/priv/static/preview-agent/agent-protocol.js
+++ b/priv/static/preview-agent/agent-protocol.js
@@ -141,6 +141,9 @@
         if (!isString(msg.selector) || msg.selector.length === 0) {
           return { ok: false, reason: 'keep-highlight.selector' };
         }
+        if (msg.scroll !== undefined && !isBool(msg.scroll)) {
+          return { ok: false, reason: 'keep-highlight.scroll' };
+        }
         return { ok: true };
       case C2A.CLEAR_HIGHLIGHT:
         return { ok: true };

--- a/priv/static/preview-agent/crit-agent.js
+++ b/priv/static/preview-agent/crit-agent.js
@@ -16,6 +16,7 @@
   var validateMessage = protocol.validateMessage;
 
   var utils = window.crit && window.crit.agent && window.crit.agent.anchorUtils;
+  var scrollUtils = window.crit && window.crit.agent && window.crit.agent.scrollUtils;
   var markersAPI = window.crit && window.crit.agent && window.crit.agent.markers;
   var batcherAPI = window.crit && window.crit.agent && window.crit.agent.batcher;
   var resolutionAPI = window.crit && window.crit.agent && window.crit.agent.resolution;
@@ -51,6 +52,9 @@
     observer: null,           // MutationObserver
     reanchor: ReanchorStateCtor ? new ReanchorStateCtor() : null,
     routePathname: typeof location !== 'undefined' ? location.pathname : '',
+    unsafeDocumentScroll: scrollUtils
+      ? scrollUtils.detectUnsafeDocumentScroll(document, window)
+      : false,
   };
   window.__critAgentState = state;
 
@@ -234,7 +238,7 @@
       case C2A.FLASH_MARKER: onFlashMarker(msg.pin_id); break;
       case C2A.CANCEL_REANCHOR: onCancelReanchor(); break;
       case C2A.SET_MARKER_TABINDEX: onSetMarkerTabindex(msg.value); break;
-      case C2A.KEEP_HIGHLIGHT: onKeepHighlight(msg.selector); break;
+      case C2A.KEEP_HIGHLIGHT: onKeepHighlight(msg.selector, msg.scroll); break;
       case C2A.CLEAR_HIGHLIGHT: onClearHighlight(); break;
       default: break;
     }
@@ -244,7 +248,7 @@
   // is open so the user can see what they're commenting on. Auto-clears on
   // route change (the element is gone) and on explicit CLEAR_HIGHLIGHT
   // (Save/Cancel/Esc/dismiss).
-  function onKeepHighlight(selector) {
+  function onKeepHighlight(selector, scroll) {
     onClearHighlight(); // ensure only one element highlighted at a time
     if (!selector) return;
     try {
@@ -252,6 +256,21 @@
       if (!el) return;
       el.classList.add('crit-live-pending-highlight');
       state._pendingHighlightEl = el;
+      // When chrome navigates to a comment (clicking its card / a deep-link)
+      // it asks us to scroll the anchored element into view. The compose
+      // path leaves scroll falsy — that element was just clicked and is
+      // already on screen, so re-centring it would be jarring.
+      // Navigation scroll uses container-aware scrolling + a visibility gate
+      // so we don't disturb scroll-hijacking pages (see PR #590).
+      if (scroll && scrollUtils) {
+        try {
+          scrollUtils.scrollIntoNearestContainer(el, {
+            win: window,
+            doc: document,
+            unsafeDocumentScroll: state.unsafeDocumentScroll,
+          });
+        } catch (_) { /* noop */ }
+      }
       // Suppress the dashed hover overlay while the user is composing —
       // chasing the cursor at this point is just visual noise. Overlay
       // resumes on CLEAR_HIGHLIGHT (Save / Cancel / Esc / dismiss).

--- a/scripts/upload-article-assets.sh
+++ b/scripts/upload-article-assets.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Upload article images to Cloudflare R2 (served at https://assets.crit.md).
+#
+# Prerequisites:
+#   npx wrangler login
+#   export CRIT_ASSETS_BUCKET=<your-r2-bucket-name>
+#
+# Usage:
+#   ./scripts/upload-article-assets.sh [slug] [source-dir]
+#
+# Example:
+#   ./scripts/upload-article-assets.sh how-to-plan-document-and-review \
+#     ../crit-articles/how_to_plan_document_and_review
+
+set -euo pipefail
+
+slug="${1:-how-to-plan-document-and-review}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+default_src="${repo_root}/../crit-articles/how_to_plan_document_and_review"
+src_dir="${2:-$default_src}"
+bucket="${CRIT_ASSETS_BUCKET:-}"
+
+if [[ -z "$bucket" ]]; then
+  echo "Set CRIT_ASSETS_BUCKET to your R2 bucket name." >&2
+  echo "List buckets after login: npx wrangler r2 bucket list" >&2
+  exit 1
+fi
+
+if [[ ! -d "$src_dir" ]]; then
+  echo "Source directory not found: $src_dir" >&2
+  exit 1
+fi
+
+prefix="articles/${slug}"
+shopt -s nullglob
+files=("$src_dir"/*.{png,jpg,jpeg,webp,gif})
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No image files found in $src_dir" >&2
+  exit 1
+fi
+
+echo "Uploading ${#files[@]} file(s) to ${bucket}/${prefix}/"
+echo
+
+for file in "${files[@]}"; do
+  name="$(basename "$file")"
+  key="${prefix}/${name}"
+  case "$name" in
+    *.png) content_type="image/png" ;;
+    *.jpg|*.jpeg) content_type="image/jpeg" ;;
+    *.webp) content_type="image/webp" ;;
+    *.gif) content_type="image/gif" ;;
+    *) content_type="application/octet-stream" ;;
+  esac
+
+  npx wrangler r2 object put "${bucket}/${key}" \
+    --file="$file" \
+    --content-type="$content_type" \
+    --remote
+
+  echo "https://assets.crit.md/${key}"
+done
+
+echo
+echo "Done. Images are available at https://assets.crit.md/${prefix}/"

--- a/test/crit/articles_test.exs
+++ b/test/crit/articles_test.exs
@@ -1,0 +1,33 @@
+defmodule Crit.ArticlesTest do
+  use ExUnit.Case, async: true
+
+  alias Crit.Articles
+
+  test "list/0 returns articles newest first" do
+    articles = Articles.list()
+    assert length(articles) >= 1
+
+    dates = Enum.map(articles, & &1.published_at)
+    assert dates == Enum.sort(dates, {:desc, Date})
+  end
+
+  test "recent/1 returns the newest articles" do
+    recent = Articles.recent(2)
+    assert recent == Enum.take(Articles.list(), 2)
+  end
+
+  test "get/1 finds by slug" do
+    assert %{slug: "how-to-plan-document-and-review"} =
+             Articles.get("how-to-plan-document-and-review")
+
+    refute Articles.get("missing-slug")
+  end
+
+  test "renders markdown body as HTML" do
+    article = Articles.get("how-to-plan-document-and-review")
+    html = Phoenix.HTML.safe_to_string(article.body_html)
+    assert html =~ "Superpowers"
+    assert html =~ "assets.crit.md/articles/how-to-plan-document-and-review/01_installed.png"
+    assert html =~ ~s(<pre class="mermaid">)
+  end
+end

--- a/test/crit_web/controllers/page_controller_seo_test.exs
+++ b/test/crit_web/controllers/page_controller_seo_test.exs
@@ -51,6 +51,8 @@ defmodule CritWeb.PageControllerSeoTest do
       assert body =~ "<loc>#{base}/</loc>"
       assert body =~ "<loc>#{base}/features</loc>"
       assert body =~ "<loc>#{base}/changelog</loc>"
+      assert body =~ "<loc>#{base}/articles</loc>"
+      assert body =~ "<loc>#{base}/articles/how-to-plan-document-and-review</loc>"
     end
 
     test "includes public reviews and excludes unlisted", %{conn: conn} do

--- a/test/crit_web/controllers/page_controller_test.exs
+++ b/test/crit_web/controllers/page_controller_test.exs
@@ -33,7 +33,7 @@ defmodule CritWeb.PageControllerTest do
     html = html_response(conn, 200)
     assert html =~ "Point at the line."
     assert html =~ "Every agent reads files"
-      assert html =~ "Guides & articles"
+    assert html =~ "Guides & articles"
     assert html =~ "Frequently asked questions"
   end
 

--- a/test/crit_web/controllers/page_controller_test.exs
+++ b/test/crit_web/controllers/page_controller_test.exs
@@ -33,7 +33,7 @@ defmodule CritWeb.PageControllerTest do
     html = html_response(conn, 200)
     assert html =~ "Point at the line."
     assert html =~ "Every agent reads files"
-    assert html =~ "From the blog"
+      assert html =~ "Guides & articles"
     assert html =~ "Frequently asked questions"
   end
 

--- a/test/crit_web/controllers/page_controller_test.exs
+++ b/test/crit_web/controllers/page_controller_test.exs
@@ -33,7 +33,32 @@ defmodule CritWeb.PageControllerTest do
     html = html_response(conn, 200)
     assert html =~ "Point at the line."
     assert html =~ "Every agent reads files"
+    assert html =~ "From the blog"
     assert html =~ "Frequently asked questions"
+  end
+
+  describe "GET /articles" do
+    test "renders the articles landing page", %{conn: conn} do
+      conn = get(conn, ~p"/articles")
+      html = html_response(conn, 200)
+      assert html =~ "Articles"
+      assert html =~ "How to Plan, Document and Review Code with Open Source Tools"
+    end
+  end
+
+  describe "GET /articles/:slug" do
+    test "renders an article", %{conn: conn} do
+      conn = get(conn, ~p"/articles/how-to-plan-document-and-review")
+      html = html_response(conn, 200)
+      assert html =~ "How to Plan, Document and Review Code with Open Source Tools"
+      assert html =~ "All articles"
+    end
+
+    test "returns 404 for unknown slug", %{conn: conn} do
+      conn = get(conn, ~p"/articles/does-not-exist")
+      body = response(conn, 404)
+      assert body =~ "not found"
+    end
   end
 
   describe "GET /integrations" do


### PR DESCRIPTION
## Summary
- Add `/articles` index and `/articles/:slug` pages with MDEx-rendered markdown from `priv/articles`
- Publish first tutorial (Superpowers + Crit + OpenCode workflow) with mermaid diagrams and `assets.crit.md` screenshots
- Add `scripts/upload-article-assets.sh` + `mise run assets:upload-article` for R2 uploads, nav/homepage integration, and sitemap entries

## Review
- [x] Code review: crit branch diff approved
- [x] Parity audit: N/A (marketing site only)

## Test plan
- [x] `mix precommit` (1036 tests)
- [x] Crit live review of `/articles` pages
- [x] Crit branch diff review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)