### PR TITLE
fix: load articles from release priv and add release smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,55 @@ jobs:
           files: cover/excoveralls.json
           flags: unit
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  release-smoke:
+    name: Release smoke
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: crit_release_smoke
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.19"
+          otp-version: "28"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: assets/package-lock.json
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            deps
+            _build/prod
+            assets/node_modules
+          key: ${{ runner.os }}-release-smoke-${{ hashFiles('**/mix.lock', 'assets/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-release-smoke-
+
+      - name: Smoke test prod release
+        run: ./scripts/release-smoke.sh
+        env:
+          RELEASE_SMOKE_PORT: "4001"
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/crit_release_smoke
+          SECRET_KEY_BASE: ci-release-smoke-secret-key-base-must-be-at-least-sixty-four-bytes-long

--- a/lib/crit/articles.ex
+++ b/lib/crit/articles.ex
@@ -6,16 +6,11 @@ defmodule Crit.Articles do
   with MDEx.
   """
 
-  @articles_root Path.expand("../../priv/articles", __DIR__)
-  @article_paths Path.wildcard(Path.join(@articles_root, "*/index.md"))
-
-  for path <- @article_paths do
-    @external_resource path
-  end
-
   @doc "All articles, newest first."
   def list do
-    @article_paths
+    articles_root()
+    |> Path.join("*/index.md")
+    |> Path.wildcard()
     |> Enum.map(&build_article/1)
     |> Enum.sort_by(& &1.published_at, {:desc, Date})
   end
@@ -32,6 +27,8 @@ defmodule Crit.Articles do
   end
 
   def format_date_iso(%Date{} = date), do: Date.to_iso8601(date)
+
+  defp articles_root, do: Path.join(:code.priv_dir(:crit), "articles")
 
   defp build_article(path) do
     {frontmatter, body} = path |> File.read!() |> parse_frontmatter()

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -15,6 +15,7 @@ mix local.hex --force >/dev/null
 mix local.rebar --force >/dev/null
 mix deps.get --only prod
 npm ci --prefix assets
+mix compile
 mix assets.deploy
 mix release --overwrite
 

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Build a prod release and smoke-test pages that read runtime priv files.
+# Catches bugs where compile-time priv paths work in dev/test but fail in releases.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export MIX_ENV=prod
+smoke_port="${RELEASE_SMOKE_PORT:-4001}"
+export PORT="$smoke_port"
+export DATABASE_URL="${DATABASE_URL:?DATABASE_URL is required}"
+export SECRET_KEY_BASE="${SECRET_KEY_BASE:-$(openssl rand -base64 64)}"
+
+mix local.hex --force >/dev/null
+mix local.rebar --force >/dev/null
+mix deps.get --only prod
+npm ci --prefix assets
+mix assets.deploy
+mix release --overwrite
+
+_build/prod/rel/crit/bin/migrate
+
+# In Docker/production only the release's lib/crit-*/priv tree exists — not the
+# source checkout's priv/. Hide source priv so runtime reads must use
+# :code.priv_dir/1, not compile-time Path.expand paths baked into the BEAM.
+release_priv=$(
+  find _build/prod/rel/crit/lib -maxdepth 3 -type d -path '*/priv/articles' -print -quit
+)
+if [ -z "$release_priv" ] || [ ! -d "$release_priv" ]; then
+  echo "release smoke: expected articles under release priv, found none" >&2
+  exit 1
+fi
+mv priv priv.source-hidden-for-smoke
+priv_hidden=1
+restore_priv() {
+  if [ "${priv_hidden:-0}" = "1" ] && [ -d priv.source-hidden-for-smoke ]; then
+    mv priv.source-hidden-for-smoke priv
+    priv_hidden=0
+  fi
+}
+
+PHX_SERVER=true _build/prod/rel/crit/bin/server &
+server_pid=$!
+cleanup() {
+  kill "$server_pid" 2>/dev/null || true
+  wait "$server_pid" 2>/dev/null || true
+  restore_priv
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+  if curl -sf "http://127.0.0.1:${smoke_port}/health" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+curl -sf "http://127.0.0.1:${smoke_port}/health" >/dev/null
+curl -sf "http://127.0.0.1:${smoke_port}/" >/dev/null
+curl -sf "http://127.0.0.1:${smoke_port}/articles" >/dev/null
+
+echo "release smoke OK"

--- a/test/crit/articles_test.exs
+++ b/test/crit/articles_test.exs
@@ -23,6 +23,15 @@ defmodule Crit.ArticlesTest do
     refute Articles.get("missing-slug")
   end
 
+  test "article markdown files live under :code.priv_dir/1 (release layout)" do
+    root = Path.join(:code.priv_dir(:crit), "articles")
+    assert File.dir?(root)
+
+    paths = Path.wildcard(Path.join(root, "*/index.md"))
+    assert paths != []
+    assert Enum.all?(paths, &File.regular?/1)
+  end
+
   test "renders markdown body as HTML" do
     article = Articles.get("how-to-plan-document-and-review")
     html = Phoenix.HTML.safe_to_string(article.body_html)


### PR DESCRIPTION
## Summary
- Resolve article loading in production releases by reading markdown from `:code.priv_dir(:crit)` instead of compile-time source paths.
- Add `scripts/release-smoke.sh` to build a prod release, hide source `priv/`, boot the release, and verify `/health`, `/`, and `/articles`.
- Add a `release-smoke` CI job in `.github/workflows/ci.yml` so release-layout regressions fail before deploy.
- Add article-path safety coverage in `test/crit/articles_test.exs`.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (crit-web-only backend/release behavior)

## Test plan
- `mise exec -- mix precommit`
- `DATABASE_URL=... SECRET_KEY_BASE=... mise exec -- ./scripts/release-smoke.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)