### PR TITLE
feat: isolate preview mode on a dedicated host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ SELFHOSTED=true
 
 # Host configuration
 PHX_HOST=localhost
+# Optional isolated preview host (recommended when using preview mode with
+# untrusted JS). Example: PREVIEW_HOST=preview.localhost
+# PREVIEW_HOST=
 PORT=4000
 
 # URL generation (for links in the app)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ export CRIT_SHARE_URL=https://reviews.yourdomain.com
 | `OAUTH_CLIENT_SECRET` | No | — | Generic OAuth2 client secret |
 | `OAUTH_BASE_URL` | No | — | OIDC discovery base URL, e.g. `https://accounts.google.com` |
 | `PHX_HOST` | No | `localhost` | Hostname for URL generation |
+| `PREVIEW_HOST` | No | — | Optional dedicated host for preview raw pages (e.g. `preview.example.com`). When set, this host serves only preview routes and can run a separate CSP for user-defined scripts |
 | `PORT` | No | `4000` | HTTP listening port |
 | `FORCE_SSL` | No | `false` | Set `true` if terminating TLS at the app (not behind a reverse proxy) |
 | `PHX_SCHEME` | No | `https` | URL scheme for link generation |

--- a/assets/js/preview-mode.js
+++ b/assets/js/preview-mode.js
@@ -96,7 +96,11 @@ function makeAgentSender(post) {
 export const PreviewMode = {
   mounted() {
     this.token = this.el.dataset.token
-    this.previewOrigin = (this.el.dataset.previewOrigin || window.location.origin).replace(/\/$/, "")
+    const configuredOrigin = (this.el.dataset.previewOrigin || "").replace(/\/$/, "")
+    // When PREVIEW_HOST is unset (dev/E2E), load the iframe root-relative so the
+    // browser uses whatever host the user opened (127.0.0.1 vs localhost).
+    this.previewIsolated = configuredOrigin !== ""
+    this.previewOrigin = configuredOrigin || window.location.origin
     this.canComment = this.el.dataset.canComment === "true"
     // Viewer identity (server-rendered, same as files mode's #document-renderer)
     // so the panel can gate edit/delete/resolve to the comment's author.
@@ -472,12 +476,9 @@ export const PreviewMode = {
     // the postMessage bridge explicit and strict.
     const firstHtml = this.files.find((f) => /\.html?$/i.test(f.path || ""))
     this.htmlFile = (firstHtml && firstHtml.path) || "index.html"
-    this.iframe.src =
-      this.previewOrigin +
-      "/r/" +
-      encodeURIComponent(this.token) +
-      "/raw/" +
-      this.htmlFile
+    const rawPath =
+      "/r/" + encodeURIComponent(this.token) + "/raw/" + this.htmlFile
+    this.iframe.src = this.previewIsolated ? this.previewOrigin + rawPath : rawPath
 
     this.applyViewport(this.viewport)
     this.afterCommentsChanged()

--- a/assets/js/preview-mode.js
+++ b/assets/js/preview-mode.js
@@ -96,7 +96,7 @@ function makeAgentSender(post) {
 export const PreviewMode = {
   mounted() {
     this.token = this.el.dataset.token
-    this.baseUrl = (this.el.dataset.baseUrl || "").replace(/\/$/, "")
+    this.previewOrigin = (this.el.dataset.previewOrigin || window.location.origin).replace(/\/$/, "")
     this.canComment = this.el.dataset.canComment === "true"
     // Viewer identity (server-rendered, same as files mode's #document-renderer)
     // so the panel can gate edit/delete/resolve to the comment's author.
@@ -186,7 +186,10 @@ export const PreviewMode = {
       '<div class="crit-preview-body">',
       '  <div class="crit-preview-iframe-pane">',
       '    <div class="crit-preview-iframe-frame" id="critPreviewFrame">',
-      '      <iframe id="critPreviewIframe" title="Preview" referrerpolicy="no-referrer"></iframe>',
+      // Sandbox runs on preview.crit.md (not crit.md). allow-same-origin restores the
+      // preview host origin for postMessage + relative assets; CSP on that host allows
+      // arbitrary CDNs (script-src *). No crit.md session crosses the host boundary.
+      '      <iframe id="critPreviewIframe" title="Preview" referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin allow-forms"></iframe>',
       "    </div>",
       "  </div>",
       '  <div class="sidebar-resize-handle" id="commentsPanelResizer" role="separator" tabindex="0" aria-orientation="vertical" aria-label="Resize comments panel"></div>',
@@ -464,14 +467,17 @@ export const PreviewMode = {
     this.isAdmin = !!payload.is_admin
     if (typeof payload.can_comment === "boolean") this.canComment = payload.can_comment
 
-    // iframe src is ROOT-RELATIVE so the iframe is always same-origin as the
-    // parent page. An absolute Endpoint.url() (data-base-url) makes the iframe
-    // cross-origin when browsed via a different host alias (e.g. 127.0.0.1 vs
-    // localhost); the agent<->hook postMessage channel enforces an exact origin
-    // match on both ends, so a mismatch silently blocks selection + comments.
+    // Preview loads from the dedicated preview origin when configured.
+    // This isolates user-authored JS/CSS from the main app origin while keeping
+    // the postMessage bridge explicit and strict.
     const firstHtml = this.files.find((f) => /\.html?$/i.test(f.path || ""))
     this.htmlFile = (firstHtml && firstHtml.path) || "index.html"
-    this.iframe.src = "/r/" + encodeURIComponent(this.token) + "/raw/" + this.htmlFile
+    this.iframe.src =
+      this.previewOrigin +
+      "/r/" +
+      encodeURIComponent(this.token) +
+      "/raw/" +
+      this.htmlFile
 
     this.applyViewport(this.viewport)
     this.afterCommentsChanged()
@@ -483,17 +489,17 @@ export const PreviewMode = {
     const iw = this.iframe && this.iframe.contentWindow
     if (!iw) return
     try {
-      iw.postMessage(msg, window.location.origin)
+      iw.postMessage(msg, this.previewOrigin)
     } catch (_) {
       /* noop */
     }
   },
 
   handleAgentMessage(event) {
-    // Accept only messages from our iframe's content window. Preview is served
-    // same-origin, so origin must match ours.
+    // Accept only messages from our iframe's content window and from the
+    // configured preview origin.
     if (!this.iframe || event.source !== this.iframe.contentWindow) return
-    if (event.origin !== window.location.origin) return
+    if (event.origin !== this.previewOrigin) return
     const msg = event.data
     if (!msg || typeof msg.type !== "string") return
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -302,8 +302,10 @@ if config_env() == :prod do
       """
 
   host = System.get_env("PHX_HOST") || "example.com"
+  preview_host = System.get_env("PREVIEW_HOST")
 
   config :crit, :canonical_host, host
+  config :crit, :preview_host, preview_host
   config :crit, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
   scheme = System.get_env("PHX_SCHEME", "https")

--- a/config/test.exs
+++ b/config/test.exs
@@ -58,6 +58,10 @@ config :crit, start_github_stars: false
 config :crit, CritWeb.Plugs.RateLimit, disabled: true
 config :crit, CritWeb.Plugs.AuthRateLimit, disabled: true
 
+# Preview isolation is prod-only (PREVIEW_HOST + PHX_HOST). Keep disabled in tests
+# unless a case opts in via Application.put_env/3.
+config :crit, :preview_host, nil
+
 config :crit, :oauth_provider,
   strategy: Assent.Strategy.Github,
   client_id: "test_github_client_id",

--- a/lib/crit_web/controllers/raw_controller.ex
+++ b/lib/crit_web/controllers/raw_controller.ex
@@ -49,16 +49,16 @@ defmodule CritWeb.RawController do
   # crit-agent can fetch its same-origin marker CSS without a CSP violation —
   # external egress is still blocked since only 'self' is allowed. (crit local
   # serves this with no CSP at all; this is still far stricter.)
-  @preview_csp Enum.join(
-                 [
-                   "default-src 'self' 'unsafe-inline' 'unsafe-eval'",
-                   "img-src 'self' data: blob:",
-                   "font-src 'self' data:",
-                   "connect-src 'self'",
-                   "frame-src 'none'"
-                 ],
-                 "; "
-               )
+  @preview_csp_restrictive Enum.join(
+                             [
+                               "default-src 'self' 'unsafe-inline' 'unsafe-eval'",
+                               "img-src 'self' data: blob:",
+                               "font-src 'self' data:",
+                               "connect-src 'self'",
+                               "frame-src 'none'"
+                             ],
+                             "; "
+                           )
 
   def show(conn, %{"token" => token, "file_path" => path_segments})
       when is_list(path_segments) do
@@ -66,9 +66,19 @@ defmodule CritWeb.RawController do
     scope = conn.assigns[:current_scope] || %Crit.Accounts.Scope{}
 
     with %Review{} = review <- Reviews.get_by_token(token),
-         :ok <- Reviews.check_org_access(review, scope),
-         %{} = file <-
-           Enum.find(review.files, fn f -> f.file_path == file_path end),
+         :ok <- Reviews.check_org_access(review, scope) do
+      if redirect_preview_raw_from_canonical?(conn, review) do
+        redirect_preview_raw_to_preview_host(conn)
+      else
+        serve_raw(conn, review, file_path)
+      end
+    else
+      _ -> conn |> put_status(404) |> text("not found")
+    end
+  end
+
+  defp serve_raw(conn, %Review{} = review, file_path) do
+    with %{} = file <- Enum.find(review.files, fn f -> f.file_path == file_path end),
          basename when basename != :unsafe <- safe_basename(file.file_path),
          {:ok, content} <- decode_content(file) do
       preview? = review.review_type == :preview
@@ -92,6 +102,27 @@ defmodule CritWeb.RawController do
     else
       _ -> conn |> put_status(404) |> text("not found")
     end
+  end
+
+  # Preview HTML/JS must not execute on the canonical app host when a dedicated
+  # preview host is configured — redirect to PREVIEW_HOST so session cookies
+  # for crit.md are never visible to user-authored scripts.
+  defp redirect_preview_raw_from_canonical?(conn, %Review{review_type: :preview}) do
+    CritWeb.Hosts.preview_host_enabled?() && conn.host == CritWeb.Hosts.canonical_host()
+  end
+
+  defp redirect_preview_raw_from_canonical?(_conn, _review), do: false
+
+  defp redirect_preview_raw_to_preview_host(conn) do
+    url =
+      CritWeb.Hosts.preview_origin() <>
+        conn.request_path <>
+        maybe_query(conn.query_string)
+
+    conn
+    |> put_resp_header("location", url)
+    |> send_resp(308, "")
+    |> halt()
   end
 
   # The injected crit-agent fetches its marker overlay CSS from
@@ -161,10 +192,29 @@ defmodule CritWeb.RawController do
   # reloader is enabled (dev only) so the dev console stays clean; prod keeps the
   # strict `frame-src 'none'`.
   defp preview_csp do
-    if CritWeb.Endpoint.config(:code_reloader) do
-      String.replace(@preview_csp, "frame-src 'none'", "frame-src 'self'")
+    if CritWeb.Hosts.preview_host_enabled?() do
+      frame_ancestors = "frame-ancestors 'self' #{CritWeb.Hosts.canonical_origin()}"
+
+      Enum.join(
+        [
+          "default-src * data: blob: 'unsafe-inline' 'unsafe-eval'",
+          "script-src * data: blob: 'unsafe-inline' 'unsafe-eval'",
+          "style-src * 'unsafe-inline'",
+          "img-src * data: blob:",
+          "font-src * data:",
+          "media-src * data: blob:",
+          "connect-src * data: blob:",
+          "frame-src *",
+          frame_ancestors
+        ],
+        "; "
+      )
     else
-      @preview_csp
+      if CritWeb.Endpoint.config(:code_reloader) do
+        String.replace(@preview_csp_restrictive, "frame-src 'none'", "frame-src 'self'")
+      else
+        @preview_csp_restrictive
+      end
     end
   end
 

--- a/lib/crit_web/endpoint.ex
+++ b/lib/crit_web/endpoint.ex
@@ -56,6 +56,7 @@ defmodule CritWeb.Endpoint do
   plug Plug.MethodOverride
   plug Plug.Head
   plug CritWeb.Plugs.CanonicalHost
+  plug CritWeb.Plugs.HostGate
   plug :session
 
   # Drop request body and cookies — review documents and comment bodies must

--- a/lib/crit_web/hosts.ex
+++ b/lib/crit_web/hosts.ex
@@ -1,0 +1,55 @@
+defmodule CritWeb.Hosts do
+  @moduledoc """
+  Host/origin helpers for app-vs-preview isolation.
+  """
+
+  @doc """
+  Canonical app host (`PHX_HOST`), if configured.
+  """
+  @spec canonical_host() :: String.t() | nil
+  def canonical_host do
+    Application.get_env(:crit, :canonical_host)
+  end
+
+  @doc """
+  Optional dedicated preview host (`PREVIEW_HOST`).
+  """
+  @spec preview_host() :: String.t() | nil
+  def preview_host do
+    case Application.get_env(:crit, :preview_host) do
+      host when is_binary(host) and host != "" -> host
+      _ -> nil
+    end
+  end
+
+  @doc """
+  True when a separate preview host is configured.
+  """
+  @spec preview_host_enabled?() :: boolean()
+  def preview_host_enabled? do
+    is_binary(preview_host())
+  end
+
+  @doc """
+  Canonical app origin.
+  """
+  @spec canonical_origin() :: String.t()
+  def canonical_origin do
+    endpoint_origin_for(canonical_host())
+  end
+
+  @doc """
+  Preview origin. Falls back to endpoint origin when PREVIEW_HOST is unset.
+  """
+  @spec preview_origin() :: String.t()
+  def preview_origin do
+    endpoint_origin_for(preview_host())
+  end
+
+  defp endpoint_origin_for(nil), do: CritWeb.Endpoint.url()
+
+  defp endpoint_origin_for(host) do
+    endpoint = URI.parse(CritWeb.Endpoint.url())
+    endpoint |> Map.put(:host, host) |> URI.to_string()
+  end
+end

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -597,7 +597,9 @@
       phx-hook="PreviewMode"
       phx-update="ignore"
       data-token={@review.token}
-      data-preview-origin={CritWeb.Hosts.preview_origin()}
+      data-preview-origin={
+        if CritWeb.Hosts.preview_host_enabled?(), do: CritWeb.Hosts.preview_origin()
+      }
       data-can-comment={to_string(@can_comment?)}
       data-identity={@current_scope.identity}
       data-user-id={Crit.Accounts.Scope.user_id(@current_scope)}

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -597,7 +597,7 @@
       phx-hook="PreviewMode"
       phx-update="ignore"
       data-token={@review.token}
-      data-base-url={CritWeb.Endpoint.url()}
+      data-preview-origin={CritWeb.Hosts.preview_origin()}
       data-can-comment={to_string(@can_comment?)}
       data-identity={@current_scope.identity}
       data-user-id={Crit.Accounts.Scope.user_id(@current_scope)}

--- a/lib/crit_web/plugs/host_gate.ex
+++ b/lib/crit_web/plugs/host_gate.ex
@@ -1,0 +1,53 @@
+defmodule CritWeb.Plugs.HostGate do
+  @moduledoc """
+  Restricts the route surface by host when PREVIEW_HOST is configured.
+  """
+  import Plug.Conn
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    preview_host = CritWeb.Hosts.preview_host()
+
+    canonical_host = CritWeb.Hosts.canonical_host()
+
+    cond do
+      not is_binary(preview_host) ->
+        conn
+
+      not is_binary(canonical_host) ->
+        conn
+
+      conn.host == preview_host ->
+        if preview_path_allowed?(conn) do
+          conn
+        else
+          conn |> send_resp(404, "not found") |> halt()
+        end
+
+      conn.host == canonical_host ->
+        conn
+
+      local_host?(conn.host) ->
+        conn
+
+      true ->
+        conn |> send_resp(404, "not found") |> halt()
+    end
+  end
+
+  defp preview_path_allowed?(%Plug.Conn{method: method, request_path: path}) do
+    method in ["GET", "HEAD"] and
+      (String.starts_with?(path, "/r/") or
+         String.starts_with?(path, "/preview-agent/") or
+         path == "/agent-marker.css" or
+         path == "/health" or
+         path == "/share-receiver")
+  end
+
+  defp local_host?(host), do: host in ["localhost", "127.0.0.1", "[::1]"]
+end

--- a/lib/crit_web/plugs/security_headers.ex
+++ b/lib/crit_web/plugs/security_headers.ex
@@ -19,9 +19,17 @@ defmodule CritWeb.Plugs.SecurityHeaders do
     conn
     |> put_resp_header("content-security-policy", csp())
     |> put_resp_header("x-content-type-options", "nosniff")
-    |> put_resp_header("x-frame-options", "SAMEORIGIN")
+    |> maybe_put_x_frame_options()
     |> put_resp_header("permissions-policy", Enum.join(@permissions_policy, ", "))
     |> maybe_put_hsts()
+  end
+
+  defp maybe_put_x_frame_options(conn) do
+    if conn.host == CritWeb.Hosts.preview_host() do
+      conn
+    else
+      put_resp_header(conn, "x-frame-options", "SAMEORIGIN")
+    end
   end
 
   defp maybe_put_hsts(conn) do

--- a/test/crit_web/controllers/raw_controller_test.exs
+++ b/test/crit_web/controllers/raw_controller_test.exs
@@ -148,6 +148,75 @@ defmodule CritWeb.RawControllerTest do
       refute csp =~ "http"
     end
 
+    test "redirects preview raw from canonical host to preview host", %{conn: conn} do
+      Application.put_env(:crit, :canonical_host, "app.example.test")
+      Application.put_env(:crit, :preview_host, "preview.example.test")
+
+      on_exit(fn ->
+        Application.delete_env(:crit, :canonical_host)
+        Application.delete_env(:crit, :preview_host)
+      end)
+
+      html = "<html><head></head><body><h1>Hi</h1></body></html>"
+      review = review_fixture(%{review_type: :preview, files: [file("index.html", html)]})
+
+      conn =
+        conn
+        |> Map.put(:host, "app.example.test")
+        |> get(~p"/r/#{review.token}/raw/index.html")
+
+      assert response(conn, 308) == ""
+
+      [location] = get_resp_header(conn, "location")
+      assert location =~ "http://preview.example.test"
+      assert location =~ "/r/#{review.token}/raw/index.html"
+    end
+
+    test "files-mode raw on canonical host is not redirected when preview host is set", %{
+      conn: conn
+    } do
+      Application.put_env(:crit, :canonical_host, "app.example.test")
+      Application.put_env(:crit, :preview_host, "preview.example.test")
+
+      on_exit(fn ->
+        Application.delete_env(:crit, :canonical_host)
+        Application.delete_env(:crit, :preview_host)
+      end)
+
+      review = review_fixture(%{files: [file("lib/foo.ex", "defmodule Foo, do: :ok\n")]})
+
+      conn =
+        conn
+        |> Map.put(:host, "app.example.test")
+        |> get(~p"/r/#{review.token}/raw/lib/foo.ex")
+
+      assert response(conn, 200) == "defmodule Foo, do: :ok\n"
+    end
+
+    test "uses permissive CSP for isolated preview host", %{conn: conn} do
+      Application.put_env(:crit, :canonical_host, "app.example.test")
+      Application.put_env(:crit, :preview_host, "preview.example.test")
+
+      on_exit(fn ->
+        Application.delete_env(:crit, :canonical_host)
+        Application.delete_env(:crit, :preview_host)
+      end)
+
+      html = "<html><head></head><body><h1>Hi</h1></body></html>"
+      review = review_fixture(%{review_type: :preview, files: [file("index.html", html)]})
+
+      conn =
+        conn
+        |> Map.put(:host, "preview.example.test")
+        |> get(~p"/r/#{review.token}/raw/index.html")
+
+      [csp] = get_resp_header(conn, "content-security-policy")
+      assert csp =~ "script-src *"
+      assert csp =~ "connect-src *"
+      assert csp =~ "frame-ancestors 'self'"
+      assert csp =~ "app.example.test"
+    end
+
     test "appends agent scripts when there is no </body> tag", %{conn: conn} do
       review =
         review_fixture(%{

--- a/test/crit_web/plugs/host_gate_test.exs
+++ b/test/crit_web/plugs/host_gate_test.exs
@@ -1,0 +1,68 @@
+defmodule CritWeb.Plugs.HostGateTest do
+  use CritWeb.ConnCase, async: false
+
+  import Crit.ReviewsFixtures
+
+  setup do
+    old_canonical = Application.get_env(:crit, :canonical_host)
+    old_preview = Application.get_env(:crit, :preview_host)
+
+    Application.put_env(:crit, :canonical_host, "app.example.test")
+    Application.put_env(:crit, :preview_host, "preview.example.test")
+
+    on_exit(fn ->
+      if is_nil(old_canonical),
+        do: Application.delete_env(:crit, :canonical_host),
+        else: Application.put_env(:crit, :canonical_host, old_canonical)
+
+      if is_nil(old_preview),
+        do: Application.delete_env(:crit, :preview_host),
+        else: Application.put_env(:crit, :preview_host, old_preview)
+    end)
+
+    :ok
+  end
+
+  test "preview host allows raw paths", %{conn: conn} do
+    review =
+      review_fixture(%{
+        review_type: :preview,
+        files: [%{"path" => "index.html", "content" => "<html></html>"}]
+      })
+
+    conn =
+      conn
+      |> Map.put(:host, "preview.example.test")
+      |> get(~p"/r/#{review.token}/raw/index.html")
+
+    assert response(conn, 200) =~ "<html>"
+  end
+
+  test "preview host allows preview-agent static scripts", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:host, "preview.example.test")
+      |> get("/preview-agent/agent-protocol.js")
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "content-type") |> hd() =~ "javascript"
+  end
+
+  test "preview host blocks app routes", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:host, "preview.example.test")
+      |> get(~p"/dashboard")
+
+    assert response(conn, 404)
+  end
+
+  test "canonical host keeps app routes reachable", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:host, "app.example.test")
+      |> get(~p"/")
+
+    assert html_response(conn, 200)
+  end
+end

--- a/test/crit_web/plugs/security_headers_test.exs
+++ b/test/crit_web/plugs/security_headers_test.exs
@@ -19,6 +19,24 @@ defmodule CritWeb.Plugs.SecurityHeadersTest do
       assert get_resp_header(conn, "x-frame-options") == ["SAMEORIGIN"]
     end
 
+    test "omits x-frame-options on preview host", %{conn: conn} do
+      Application.put_env(:crit, :canonical_host, "app.example.test")
+      Application.put_env(:crit, :preview_host, "preview.example.test")
+
+      on_exit(fn ->
+        Application.delete_env(:crit, :canonical_host)
+        Application.delete_env(:crit, :preview_host)
+      end)
+
+      conn =
+        conn
+        |> Map.put(:host, "preview.example.test")
+        |> get(~p"/agent-marker.css")
+
+      assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+      assert get_resp_header(conn, "x-frame-options") == []
+    end
+
     test "does not set HSTS when hsts_enabled is not configured", %{conn: conn} do
       Application.delete_env(:crit, :hsts_enabled)
 


### PR DESCRIPTION
## Summary

- Serve preview raw assets from `PREVIEW_HOST` (e.g. `preview.crit.md`) instead of the app origin, so user-authored HTML/JS cannot access `crit.md` session cookies
- Add `HostGate` to limit the preview host to preview routes (`/r/*/raw/*`, `/preview-agent/*`, `/agent-marker.css`, `/health`)
- 308-redirect preview raw requests off the canonical host when isolation is enabled
- Load preview iframes with `sandbox="allow-scripts allow-same-origin allow-forms"` and permissive CSP (`script-src *`, etc.) on the preview host only — arbitrary CDN JS/CSS without whitelisting
- Skip `X-Frame-Options` on the preview host so `crit.md` can frame preview content (`frame-ancestors` in preview CSP)

## Security context

Preview mode serves uploaded HTML as `text/html` (not plain text). Before this change, that executed on the `crit.md` origin; malicious preview JS could `fetch("/reviews", { credentials: "include" })` and ride the viewer's OAuth session.

## Test plan

- [x] `mix precommit`
- [ ] After merge/deploy: open a preview review on `crit.md` — iframe `src` should be `https://preview.crit.md/r/.../raw/...`
- [ ] `curl -I https://crit.md/r/{preview_token}/raw/index.html` → `308` to `preview.crit.md`
- [ ] `curl -I https://preview.crit.md/dashboard` → `404`
- [ ] Preview page with CDN `<script src="https://cdn.jsdelivr.net/...">` loads and runs
- [ ] Pin mode / agent postMessage still works


Made with [Cursor](https://cursor.com)