### PR TITLE
fix: allow preview host in CSP frame-src

### DIFF
--- a/lib/crit_web/plugs/security_headers.ex
+++ b/lib/crit_web/plugs/security_headers.ex
@@ -67,7 +67,17 @@ defmodule CritWeb.Plugs.SecurityHeaders do
       "font-src 'self'; " <>
       "media-src 'self' https://assets.crit.md; " <>
       "connect-src 'self'#{sentry_origin}#{umami_connect}; " <>
-      "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; " <>
+      "frame-src #{frame_src()}; " <>
       "object-src 'none'"
+  end
+
+  defp frame_src do
+    base = "'self' https://www.youtube.com https://www.youtube-nocookie.com"
+
+    if CritWeb.Hosts.preview_host_enabled?() do
+      base <> " " <> CritWeb.Hosts.preview_origin()
+    else
+      base
+    end
   end
 end

--- a/test/crit_web/plugs/security_headers_test.exs
+++ b/test/crit_web/plugs/security_headers_test.exs
@@ -79,6 +79,40 @@ defmodule CritWeb.Plugs.SecurityHeadersTest do
 
       refute csp =~ "cloud.umami.is"
     end
+
+    test "allows preview origin in frame-src when PREVIEW_HOST is set", %{conn: conn} do
+      Application.put_env(:crit, :canonical_host, "app.example.test")
+      Application.put_env(:crit, :preview_host, "preview.example.test")
+
+      on_exit(fn ->
+        Application.delete_env(:crit, :canonical_host)
+        Application.delete_env(:crit, :preview_host)
+      end)
+
+      conn =
+        conn
+        |> Map.put(:host, "app.example.test")
+        |> get(~p"/")
+
+      [csp] = get_resp_header(conn, "content-security-policy")
+
+      assert csp =~
+               "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com http://preview.example.test"
+
+      refute csp =~ "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com;"
+    end
+
+    test "omits preview origin from frame-src when PREVIEW_HOST is unset", %{conn: conn} do
+      Application.delete_env(:crit, :preview_host)
+
+      on_exit(fn -> :ok end)
+
+      conn = get(conn, ~p"/")
+      [csp] = get_resp_header(conn, "content-security-policy")
+
+      assert csp =~
+               "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com; object-src 'none'"
+    end
   end
 
   describe "Umami analytics script" do


### PR DESCRIPTION
## Summary

- Adds `CritWeb.Hosts.preview_origin()` to `frame-src` when `PREVIEW_HOST` is configured
- Fixes preview mode being blocked in production after #291 (`Framing 'https://preview.crit.md/' violates frame-src`)

## Test plan

- [x] `mix test test/crit_web/plugs/security_headers_test.exs`
- [ ] After deploy: open a preview review on crit.md and confirm the iframe loads (no CSP console error)
- [ ] Confirm PoC still cannot reach `/reviews` from `preview.crit.md`


Made with [Cursor](https://cursor.com)