### PR TITLE
docs: document PREVIEW_HOST self-hosting and ICO registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,12 @@ SELFHOSTED=true
 
 # Host configuration
 PHX_HOST=localhost
-# Optional isolated preview host (recommended when using preview mode with
-# untrusted JS). Example: PREVIEW_HOST=preview.localhost
-# PREVIEW_HOST=
+# Optional: separate hostname for preview-mode iframes (user-authored HTML/JS).
+# When set, preview raw assets load from this host so session cookies on PHX_HOST
+# are never visible to scripts in a shared preview. Point it at the same
+# crit-web instance (reverse proxy both hostnames). Recommended for production
+# when untrusted viewers can open preview links; leave unset for local dev.
+# PREVIEW_HOST=preview.localhost
 PORT=4000
 
 # URL generation (for links in the app)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ export CRIT_SHARE_URL=https://reviews.yourdomain.com
 | `OAUTH_CLIENT_SECRET` | No | — | Generic OAuth2 client secret |
 | `OAUTH_BASE_URL` | No | — | OIDC discovery base URL, e.g. `https://accounts.google.com` |
 | `PHX_HOST` | No | `localhost` | Hostname for URL generation |
-| `PREVIEW_HOST` | No | — | Optional dedicated host for preview raw pages (e.g. `preview.example.com`). When set, this host serves only preview routes and can run a separate CSP for user-defined scripts |
+| `PREVIEW_HOST` | No | — | Dedicated host for preview-mode iframes (e.g. `preview.example.com`). See [Preview mode isolation](#preview-mode-isolation) |
 | `PORT` | No | `4000` | HTTP listening port |
 | `FORCE_SSL` | No | `false` | Set `true` if terminating TLS at the app (not behind a reverse proxy) |
 | `PHX_SCHEME` | No | `https` | URL scheme for link generation |
@@ -110,6 +110,29 @@ The app listens on HTTP. Your reverse proxy (nginx, Caddy, Traefik) handles TLS.
 PHX_HOST=reviews.yourdomain.com
 PHX_SCHEME=https
 PHX_URL_PORT=443
+```
+
+### Preview mode isolation
+
+Preview reviews embed user-authored HTML, CSS, and JavaScript in an iframe so you can click around a live page while commenting. By default that iframe loads from the same origin as the review page (`PHX_HOST`). User scripts in a shared preview could then read your session cookies and act as you on the main app.
+
+Set `PREVIEW_HOST` to a separate hostname that points at the same crit-web container (via your reverse proxy). Preview raw assets are redirected there; the preview host only serves preview routes (`/r/.../raw/...`, agent scripts, health). Your login session stays on `PHX_HOST` and is not sent to the preview origin.
+
+Recommended for any self-hosted instance where untrusted people can open shared preview links. Leave unset for local dev — the iframe loads root-relative and works on a single host.
+
+```env
+PHX_HOST=reviews.yourdomain.com
+PREVIEW_HOST=preview.yourdomain.com
+PHX_SCHEME=https
+PHX_URL_PORT=443
+```
+
+Both hostnames must resolve to crit-web. Example Caddy snippet:
+
+```caddy
+reviews.yourdomain.com, preview.yourdomain.com {
+    reverse_proxy localhost:4000
+}
 ```
 
 ### Updating

--- a/contrib/docker-compose.example.yml
+++ b/contrib/docker-compose.example.yml
@@ -38,6 +38,7 @@ services:
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
       SELFHOSTED: "true"
       PHX_HOST: ${PHX_HOST:-localhost}
+      # PREVIEW_HOST: ${PREVIEW_HOST}  # optional — isolate preview iframes on a separate host
       PORT: ${PORT:-4000}
       PHX_SERVER: "true"
     healthcheck:

--- a/lib/crit_web/controllers/page_html/privacy.html.heex
+++ b/lib/crit_web/controllers/page_html/privacy.html.heex
@@ -3,11 +3,14 @@
   <div class="max-w-[900px] mx-auto px-10 pb-15 max-sm:px-4 max-sm:pb-10">
     <main class="mt-12">
       <h1 class="text-4xl font-extrabold tracking-tight mb-2">Privacy Policy</h1>
-      <p class="text-sm text-(--crit-fg-muted) mb-10">Last updated: March 2026</p>
+      <p class="text-sm text-(--crit-fg-muted) mb-10">Last updated: July 2026</p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Who operates this</h2>
       <p class="leading-relaxed text-(--crit-fg-secondary)">
-        Crit is operated by Tomasz Tomczyk as an independent open-source project.
+        Crit (crit.md) is operated by Tomasz Tomczyk, who is the data controller for personal
+        data processed through the hosted service. We are registered with the UK Information
+        Commissioner's Office. Registration reference: ZC149123. For privacy enquiries, email
+        <a href="mailto:tomasz@crit.md" class="crit-link">tomasz@crit.md</a>.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Local use</h2>

--- a/lib/crit_web/controllers/page_html/privacy.html.heex
+++ b/lib/crit_web/controllers/page_html/privacy.html.heex
@@ -9,8 +9,10 @@
       <p class="leading-relaxed text-(--crit-fg-secondary)">
         Crit (crit.md) is operated by Tomasz Tomczyk, who is the data controller for personal
         data processed through the hosted service. We are registered with the UK Information
-        Commissioner's Office. Registration reference: ZC149123. For privacy enquiries, email
-        <a href="mailto:tomasz@crit.md" class="crit-link">tomasz@crit.md</a>.
+        Commissioner's Office. Registration reference: ZC149123. For privacy enquiries, email <a
+          href="mailto:tomasz@crit.md"
+          class="crit-link"
+        >tomasz@crit.md</a>.
       </p>
 
       <h2 class="text-2xl font-extrabold tracking-tight mt-8 mb-2">Local use</h2>

--- a/lib/crit_web/controllers/page_html/self_hosting.html.heex
+++ b/lib/crit_web/controllers/page_html/self_hosting.html.heex
@@ -298,6 +298,17 @@
             <span class="text-xs font-mono text-(--crit-brand) sm:text-right">required</span>
           </div>
           <div class="grid grid-cols-[minmax(160px,320px)_1fr_80px] gap-x-4 items-baseline px-4 py-3 bg-(--crit-bg-card) max-sm:grid-cols-1 max-sm:gap-y-1">
+            <code class="text-sm font-mono text-(--crit-fg-primary)">PREVIEW_HOST</code>
+            <p phx-no-format class="text-sm text-(--crit-fg-secondary)">
+              Optional separate hostname for preview-mode iframes, e.g.
+              <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">preview.crit.example.com</code>.
+              Keeps user-authored scripts in shared previews away from your login session on
+              <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">PHX_HOST</code>.
+              See <a href="#preview-mode-isolation" class="crit-link">Preview mode isolation</a> below.
+            </p>
+            <span class="text-xs font-mono text-(--crit-fg-muted) sm:text-right">optional</span>
+          </div>
+          <div class="grid grid-cols-[minmax(160px,320px)_1fr_80px] gap-x-4 items-baseline px-4 py-3 bg-(--crit-bg-card) max-sm:grid-cols-1 max-sm:gap-y-1">
             <code class="text-sm font-mono text-(--crit-fg-primary)">PHX_SERVER</code>
             <p class="text-sm text-(--crit-fg-secondary)">
               Set to <code class="text-xs bg-(--crit-bg-elevated) px-1 rounded">true</code>
@@ -616,6 +627,67 @@
           </p>
         </div>
       </div>
+    </section>
+
+    <%!-- Preview mode isolation --%>
+    <section id="preview-mode-isolation" class="mb-16 max-sm:mb-12">
+      <div phx-no-format class="mb-5 border-t border-(--crit-border) pt-10">
+        <h2 class="text-2xl font-extrabold tracking-tight mb-2">
+          Preview mode isolation<span class="text-(--crit-brand)">.</span>
+        </h2>
+        <p class="text-sm text-(--crit-fg-secondary) leading-relaxed mb-3">
+          Preview reviews render a live page inside an iframe so reviewers can click around
+          while commenting. That page is built from HTML, CSS, and JavaScript you (or an agent)
+          authored — and anyone with the share link can open it.
+        </p>
+        <p class="text-sm text-(--crit-fg-secondary) leading-relaxed mb-3">
+          Without <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">PREVIEW_HOST</code>,
+          the iframe loads from the same origin as the review UI
+          (<code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">PHX_HOST</code>).
+          Scripts in a shared preview could read your session cookies and perform actions as you
+          on the main app.
+        </p>
+        <p class="text-sm text-(--crit-fg-secondary) leading-relaxed">
+          Set <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">PREVIEW_HOST</code>
+          to a second hostname that reverse-proxies to the same crit-web container. Preview raw
+          assets are served only from that host; it accepts preview routes and nothing else. Your
+          login session stays on <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">PHX_HOST</code>
+          and is never sent to the preview origin. Recommended for production when untrusted
+          viewers can open preview links; leave unset for local dev.
+        </p>
+      </div>
+
+      <div class="border border-(--crit-border) rounded-lg overflow-hidden">
+        <div class="flex items-center gap-2 px-4 py-2.5 bg-(--crit-bg-elevated) border-b border-(--crit-border)">
+          <div class="flex gap-1.5">
+            <div class="w-2.5 h-2.5 rounded-full bg-(--crit-fg-muted) opacity-40"></div>
+            <div class="w-2.5 h-2.5 rounded-full bg-(--crit-fg-muted) opacity-40"></div>
+            <div class="w-2.5 h-2.5 rounded-full bg-(--crit-fg-muted) opacity-40"></div>
+          </div>
+          <span class="font-mono text-xs text-(--crit-fg-muted) ml-2">.env</span>
+        </div>
+        <div class="bg-(--crit-code-bg) p-6 font-mono text-sm leading-7 text-(--crit-fg-secondary)">
+          <div>
+            <span class="text-(--crit-fg-primary)">PHX_HOST</span>=<span class="text-(--crit-fg-muted)">crit.example.com</span>
+          </div>
+          <div>
+            <span class="text-(--crit-fg-primary)">PREVIEW_HOST</span>=<span class="text-(--crit-fg-muted)">preview.crit.example.com</span>
+          </div>
+          <div>
+            <span class="text-(--crit-fg-primary)">PHX_SCHEME</span>=<span class="text-(--crit-fg-muted)">https</span>
+          </div>
+          <div>
+            <span class="text-(--crit-fg-primary)">PHX_URL_PORT</span>=<span class="text-(--crit-fg-muted)">443</span>
+          </div>
+        </div>
+      </div>
+
+      <p phx-no-format class="text-sm text-(--crit-fg-secondary) mt-3 leading-relaxed">
+        Both hostnames must resolve to crit-web. With Caddy, add the preview host to the same
+        <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">reverse_proxy</code>
+        block as <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">PHX_HOST</code>.
+        No second container is needed.
+      </p>
     </section>
 
     <%!-- Behind an SSO reverse proxy --%>


### PR DESCRIPTION
## Summary
- Document `PREVIEW_HOST` for self-hosters: why to set it (preview iframe isolation from session cookies), env examples, and reverse-proxy setup in README and `/self-hosting`
- Update `.env.example` and `docker-compose.example.yml` with commented `PREVIEW_HOST` guidance
- Privacy policy: identify data controller, add ICO registration reference ZC149123, bump last-updated to July 2026

## Review
- [x] Code review: passed
- [x] Parity audit: N/A (docs only)

## Test plan
- [x] `mix test test/crit_web/controllers/page_controller_test.exs`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)