### PR TITLE
fix: address release audit findings for preview and host gate

### DIFF
--- a/assets/js/article-mermaid.js
+++ b/assets/js/article-mermaid.js
@@ -3,8 +3,11 @@ export async function initArticleMermaid() {
   if (!blocks.length) return
 
   const { default: mermaid } = await import("mermaid")
-  const theme =
-    document.documentElement.dataset.theme === "light" ? "default" : "dark"
+  const attr = document.documentElement.dataset.theme
+  const isLight =
+    attr === "light" ||
+    (!attr && window.matchMedia("(prefers-color-scheme: light)").matches)
+  const theme = isLight ? "default" : "dark"
 
   mermaid.initialize({ startOnLoad: false, theme })
 

--- a/lib/crit_web/controllers/page_controller.ex
+++ b/lib/crit_web/controllers/page_controller.ex
@@ -748,17 +748,23 @@ defmodule CritWeb.PageController do
   end
 
   def articles(conn, _params) do
-    articles = Crit.Articles.list()
-    [featured | rest] = articles
+    case Crit.Articles.list() do
+      [] ->
+        conn
+        |> put_status(:not_found)
+        |> put_view(CritWeb.ErrorHTML)
+        |> render(:"404")
 
-    render(conn, :articles,
-      featured: featured,
-      rest: rest,
-      canonical_url: canonical_url(conn),
-      page_title: "Articles - Crit",
-      meta_description:
-        "Essays on reviewing AI agent output, structured feedback loops, and shipping with more control."
-    )
+      [featured | rest] ->
+        render(conn, :articles,
+          featured: featured,
+          rest: rest,
+          canonical_url: canonical_url(conn),
+          page_title: "Articles - Crit",
+          meta_description:
+            "Essays on reviewing AI agent output, structured feedback loops, and shipping with more control."
+        )
+    end
   end
 
   def article(conn, %{"slug" => slug}) do

--- a/lib/crit_web/controllers/raw_controller.ex
+++ b/lib/crit_web/controllers/raw_controller.ex
@@ -6,15 +6,16 @@ defmodule CritWeb.RawController do
 
   plug :require_review_scope
 
-  # The 7 transport-agnostic agent scripts crit injects into preview iframes,
+  # The 8 transport-agnostic agent scripts crit injects into preview iframes,
   # vendored verbatim into priv/static/preview-agent/. Order matters and must
-  # match crit's `agentScriptFiles` (server.go): protocol first, helpers next,
+  # match crit's `AgentScriptFiles` (server.go): protocol first, helpers next,
   # the main agent entry point last. Keeping the order identical preserves
   # DOM-anchor compatibility across the crit (Go) and crit-web (Phoenix)
   # renderers. `agent-marker.css` is served separately and is NOT injected.
   @agent_script_files [
     "agent-protocol.js",
     "agent-anchor-utils.js",
+    "agent-scroll-utils.js",
     "agent-marker-overlay.js",
     "agent-mutation-batcher.js",
     "agent-resolution.js",

--- a/lib/crit_web/plugs/host_gate.ex
+++ b/lib/crit_web/plugs/host_gate.ex
@@ -42,12 +42,16 @@ defmodule CritWeb.Plugs.HostGate do
 
   defp preview_path_allowed?(%Plug.Conn{method: method, request_path: path}) do
     method in ["GET", "HEAD"] and
-      (String.starts_with?(path, "/r/") or
+      (preview_raw_path?(path) or
          String.starts_with?(path, "/preview-agent/") or
          path == "/agent-marker.css" or
          path == "/health" or
          path == "/share-receiver")
   end
+
+  # Only sandboxed raw HTML belongs on the preview host — not the interactive
+  # ReviewLive at /r/:token (frameable there with no x-frame-options).
+  defp preview_raw_path?(path), do: String.match?(path, ~r{^/r/[^/]+/raw/})
 
   defp local_host?(host), do: host in ["localhost", "127.0.0.1", "[::1]"]
 end

--- a/priv/static/preview-agent/agent-scroll-utils.js
+++ b/priv/static/preview-agent/agent-scroll-utils.js
@@ -1,0 +1,211 @@
+'use strict';
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else {
+    root.crit = root.crit || {};
+    root.crit.agent = root.crit.agent || {};
+    root.crit.agent.scrollUtils = api;
+  }
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+
+  function isScrollableBox(el, win) {
+    if (!el || !el.style) return false;
+    try {
+      var style = win.getComputedStyle(el);
+      var oy = style.overflowY;
+      var ox = style.overflowX;
+      var scrollY = (oy === 'auto' || oy === 'scroll') && el.scrollHeight > el.clientHeight + 1;
+      var scrollX = (ox === 'auto' || ox === 'scroll') && el.scrollWidth > el.clientWidth + 1;
+      return scrollY || scrollX;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function isDocumentScrollRoot(el, doc) {
+    return el === doc.documentElement || el === doc.body || el === doc.scrollingElement;
+  }
+
+  // Nearest ancestor with overflow scroll/auto and scrollable overflow.
+  function findScrollContainer(el, doc) {
+    var node = el && el.parentElement;
+    while (node && node !== doc.documentElement) {
+      if (isScrollableBox(node, doc.defaultView || window)) return node;
+      node = node.parentElement;
+    }
+    return doc.scrollingElement || doc.documentElement;
+  }
+
+  // Every scrollable ancestor from innermost to outermost, terminated by the
+  // document scroll root. Nested scrollers (e.g. a list inside a horizontal
+  // carousel inside the page) each need adjusting, not just the closest one.
+  function findScrollContainerChain(el, doc) {
+    var win = doc.defaultView || (typeof window !== 'undefined' ? window : null);
+    var chain = [];
+    var node = el && el.parentElement;
+    while (node && node !== doc.documentElement) {
+      if (isScrollableBox(node, win)) chain.push(node);
+      node = node.parentElement;
+    }
+    chain.push(doc.scrollingElement || doc.documentElement);
+    return chain;
+  }
+
+  // Skip scroll when at least half the element area is visible within the
+  // relevant viewport (window for document root, container client rect otherwise).
+  function isMostlyVisible(el, win, container, doc) {
+    if (!el || !el.getBoundingClientRect) return true;
+    var r = el.getBoundingClientRect();
+    var bounds;
+    if (container && doc && !isDocumentScrollRoot(container, doc)) {
+      bounds = container.getBoundingClientRect();
+    } else {
+      bounds = {
+        top: 0,
+        left: 0,
+        bottom: win.innerHeight || 0,
+        right: win.innerWidth || 0,
+      };
+    }
+    var visibleH = Math.max(0, Math.min(r.bottom, bounds.bottom) - Math.max(r.top, bounds.top));
+    var visibleW = Math.max(0, Math.min(r.right, bounds.right) - Math.max(r.left, bounds.left));
+    var visibleArea = visibleH * visibleW;
+    var totalArea = Math.max(r.height, 1) * Math.max(r.width, 1);
+    return visibleArea >= totalArea * 0.5;
+  }
+
+  // True on-screen visibility: the viewport clipped by every non-root ancestor
+  // scroll container's rect. An element nested inside a scrolled-away container
+  // looks "visible relative to its container" yet is off-screen — that case must
+  // not short-circuit scrolling, so we intersect the whole chain instead.
+  function isMostlyVisibleInChain(el, win, chain, doc) {
+    if (!el || !el.getBoundingClientRect) return true;
+    var r = el.getBoundingClientRect();
+    var bounds = {
+      top: 0,
+      left: 0,
+      bottom: win.innerHeight || 0,
+      right: win.innerWidth || 0,
+    };
+    for (var i = 0; i < chain.length; i++) {
+      var c = chain[i];
+      if (isDocumentScrollRoot(c, doc) || !c.getBoundingClientRect) continue;
+      var cRect = c.getBoundingClientRect();
+      bounds.top = Math.max(bounds.top, cRect.top);
+      bounds.left = Math.max(bounds.left, cRect.left);
+      bounds.bottom = Math.min(bounds.bottom, cRect.bottom);
+      bounds.right = Math.min(bounds.right, cRect.right);
+    }
+    var visibleH = Math.max(0, Math.min(r.bottom, bounds.bottom) - Math.max(r.top, bounds.top));
+    var visibleW = Math.max(0, Math.min(r.right, bounds.right) - Math.max(r.left, bounds.left));
+    var visibleArea = visibleH * visibleW;
+    var totalArea = Math.max(r.height, 1) * Math.max(r.width, 1);
+    return visibleArea >= totalArea * 0.5;
+  }
+
+  function scrollWithinContainer(el, container, win, doc) {
+    var rect = el.getBoundingClientRect();
+    if (isDocumentScrollRoot(container, doc)) {
+      var scrollY = win.scrollY || win.pageYOffset || 0;
+      var scrollX = win.scrollX || win.pageXOffset || 0;
+      var targetY = scrollY + rect.top - (win.innerHeight / 2) + (rect.height / 2);
+      var targetX = scrollX + rect.left - (win.innerWidth / 2) + (rect.width / 2);
+      try {
+        win.scrollTo({ left: targetX, top: targetY, behavior: 'auto' });
+      } catch (_) {
+        try { win.scrollTo(targetX, targetY); } catch (_2) { /* noop */ }
+      }
+      return;
+    }
+    var cRect = container.getBoundingClientRect();
+    if (rect.top < cRect.top) {
+      container.scrollTop += rect.top - cRect.top;
+    } else if (rect.bottom > cRect.bottom) {
+      container.scrollTop += rect.bottom - cRect.bottom;
+    }
+    if (rect.left < cRect.left) {
+      container.scrollLeft += rect.left - cRect.left;
+    } else if (rect.right > cRect.right) {
+      container.scrollLeft += rect.right - cRect.right;
+    }
+  }
+
+  // Scroll anchored element into view without disturbing document-level scroll
+  // hijackers when possible. Walks every scrollable ancestor from innermost to
+  // outermost so deeply nested targets are revealed, not just the closest box.
+  // Returns true when at least one scroll was attempted.
+  function scrollIntoNearestContainer(el, opts) {
+    if (!el) return false;
+    var win = (opts && opts.win) || window;
+    var doc = (opts && opts.doc) || win.document;
+    var chain = findScrollContainerChain(el, doc);
+    if (isMostlyVisibleInChain(el, win, chain, doc)) return false;
+    var unsafe = !!(opts && opts.unsafeDocumentScroll);
+    var scrolled = false;
+    for (var i = 0; i < chain.length; i++) {
+      var container = chain[i];
+      // Re-measure each step: scrolling an inner container shifts the element,
+      // so the outer adjustment must read the updated position.
+      if (isDocumentScrollRoot(container, doc)) {
+        if (unsafe) continue;
+        // Only center on the document when the element is still off-screen
+        // after the inner containers have done their part.
+        if (isMostlyVisibleInChain(el, win, chain, doc)) continue;
+      }
+      scrollWithinContainer(el, container, win, doc);
+      scrolled = true;
+    }
+    return scrolled;
+  }
+
+  // Heuristics for pages that treat document scroll as navigation (slide decks,
+  // fullpage.js, smooth-scroll libs). Cached once at agent boot.
+  function detectUnsafeDocumentScroll(doc, win) {
+    var html = doc.documentElement;
+    var body = doc.body;
+    if (!html || !body) return false;
+
+    function overflowHidden(el) {
+      try {
+        var s = win.getComputedStyle(el);
+        return s.overflow === 'hidden' || s.overflowY === 'hidden';
+      } catch (_) {
+        return false;
+      }
+    }
+
+    if (overflowHidden(html) && overflowHidden(body)) {
+      var vh = win.innerHeight || html.clientHeight || 0;
+      var bodyH = body.scrollHeight || body.clientHeight || 0;
+      if (vh > 0 && bodyH <= vh * 1.1) return true;
+    }
+
+    function hasScrollSnap(el) {
+      try {
+        var snap = win.getComputedStyle(el).scrollSnapType || '';
+        return snap !== '' && snap !== 'none';
+      } catch (_) {
+        return false;
+      }
+    }
+    if (hasScrollSnap(html) || hasScrollSnap(body)) return true;
+
+    if (win.fullpage_api || win.Lenis || win.locomotiveScroll) return true;
+    if (doc.querySelector('#fullpage, .fullpage-wrapper, [data-fullpage]')) return true;
+
+    return false;
+  }
+
+  return {
+    isScrollableBox,
+    isDocumentScrollRoot,
+    findScrollContainer,
+    findScrollContainerChain,
+    isMostlyVisible,
+    isMostlyVisibleInChain,
+    scrollWithinContainer,
+    scrollIntoNearestContainer,
+    detectUnsafeDocumentScroll,
+  };
+});

--- a/scripts/sync-preview-agent.sh
+++ b/scripts/sync-preview-agent.sh
@@ -22,6 +22,7 @@ DST="$SCRIPT_DIR/../priv/static/preview-agent"
 FILES=(
   agent-protocol.js
   agent-anchor-utils.js
+  agent-scroll-utils.js
   agent-marker-overlay.js
   agent-mutation-batcher.js
   agent-resolution.js

--- a/test/crit_web/plugs/host_gate_test.exs
+++ b/test/crit_web/plugs/host_gate_test.exs
@@ -57,6 +57,59 @@ defmodule CritWeb.Plugs.HostGateTest do
     assert response(conn, 404)
   end
 
+  test "preview host blocks interactive review LiveView", %{conn: conn} do
+    review = review_fixture()
+
+    conn =
+      conn
+      |> Map.put(:host, "preview.example.test")
+      |> get(~p"/r/#{review.token}")
+
+    assert response(conn, 404)
+  end
+
+  test "preview host blocks non-GET to raw paths", %{conn: conn} do
+    review =
+      review_fixture(%{
+        review_type: :preview,
+        files: [%{"path" => "index.html", "content" => "<html></html>"}]
+      })
+
+    conn =
+      conn
+      |> Map.put(:host, "preview.example.test")
+      |> post(~p"/r/#{review.token}/raw/index.html")
+
+    assert response(conn, 404)
+  end
+
+  test "preview host allows /health", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:host, "preview.example.test")
+      |> get("/health")
+
+    assert conn.status == 200
+  end
+
+  test "unknown host returns 404", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:host, "evil.example.test")
+      |> get(~p"/")
+
+    assert response(conn, 404)
+  end
+
+  test "localhost bypasses host gate in dev/test", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:host, "127.0.0.1")
+      |> get(~p"/")
+
+    assert html_response(conn, 200)
+  end
+
   test "canonical host keeps app routes reachable", %{conn: conn} do
     conn =
       conn

--- a/test/crit_web/plugs/security_headers_test.exs
+++ b/test/crit_web/plugs/security_headers_test.exs
@@ -1,5 +1,5 @@
 defmodule CritWeb.Plugs.SecurityHeadersTest do
-  use CritWeb.ConnCase, async: true
+  use CritWeb.ConnCase, async: false
 
   describe "security headers" do
     test "sets permissions-policy on browser requests", %{conn: conn} do
@@ -103,9 +103,14 @@ defmodule CritWeb.Plugs.SecurityHeadersTest do
     end
 
     test "omits preview origin from frame-src when PREVIEW_HOST is unset", %{conn: conn} do
+      old_preview = Application.get_env(:crit, :preview_host)
       Application.delete_env(:crit, :preview_host)
 
-      on_exit(fn -> :ok end)
+      on_exit(fn ->
+        if is_nil(old_preview),
+          do: Application.delete_env(:crit, :preview_host),
+          else: Application.put_env(:crit, :preview_host, old_preview)
+      end)
 
       conn = get(conn, ~p"/")
       [csp] = get_resp_header(conn, "content-security-policy")

--- a/test/crit_web/preview_agent_sync_test.exs
+++ b/test/crit_web/preview_agent_sync_test.exs
@@ -19,6 +19,7 @@ defmodule CritWeb.PreviewAgentSyncTest do
   @files [
     "agent-protocol.js",
     "agent-anchor-utils.js",
+    "agent-scroll-utils.js",
     "agent-marker-overlay.js",
     "agent-mutation-batcher.js",
     "agent-resolution.js",


### PR DESCRIPTION
## Summary
- Vendor `agent-scroll-utils.js` so preview comment navigation scroll works (parity with crit CLI)
- Narrow preview-host HostGate allowlist to `/r/:token/raw/*` only — blocks frameable LiveView on preview host
- Fix Mermaid theme under system+light OS on article pages
- Fix `SecurityHeadersTest` async `Application.put_env` flakiness (308 redirect races in full suite)
- Add HostGate security-boundary tests; guard empty `/articles` catalog against MatchError

## Review
- [x] Code review: release audit + validation
- [x] Parity audit: scrollUtils ported from crit/web

## Test plan
- [x] `mix precommit` (1052 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)