### PR TITLE
docs: fix global config path on self-hosting page

### DIFF
--- a/lib/crit_web/controllers/page_html/self_hosting.html.heex
+++ b/lib/crit_web/controllers/page_html/self_hosting.html.heex
@@ -701,7 +701,7 @@
           from the terminal — the proxy redirects to a login page. Set
           <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">proxy_auth: true</code>
           in your
-          <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">~/.config/crit/crit.json</code>
+          <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">~/.crit.config.json</code>
           to route Share, Pull, Re-share, and Unpublish through a browser popup
           that carries your existing proxy session cookie.
         </p>
@@ -715,7 +715,7 @@
             <div class="w-2.5 h-2.5 rounded-full bg-(--crit-fg-muted) opacity-40"></div>
           </div>
           <span class="font-mono text-xs text-(--crit-fg-muted) ml-2">
-            ~/.config/crit/crit.json
+            ~/.crit.config.json
           </span>
         </div>
         <div


### PR DESCRIPTION
## Summary
- Correct the SSO proxy_auth section on the self-hosting page: `~/.config/crit/crit.json` → `~/.crit.config.json` (matches crit CLI `GlobalConfigPath`)

## Review
- [x] Code review: passed (docs-only, 2-line path fix)
- [x] Parity audit: N/A

## Test plan
- [x] `mix precommit` (1052 tests, 0 failures)

🤖 Generated with Claude Code

Made with [Cursor](https://cursor.com)