### PR TITLE
test: add DAST suite for preview-origin session isolation

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -23,13 +23,20 @@ config :crit, Crit.Repo,
 config :crit, CritWeb.Endpoint,
   http: [ip: {127, 0, 0, 1}, port: 4002],
   secret_key_base: "Sg3AbYy0ombvmL33BiB7bfASWI/y6HNgUzvV1JFennme5U8HK2EJBDouMeFYehBc",
-  # The endpoint :url host is "localhost" (config.exs), but the E2E Playwright
-  # harness loads the server over http://127.0.0.1 (avoids macOS resolving
-  # localhost to IPv6 ::1 while Bandit binds IPv4). With the default
+  # The endpoint :url host is "localhost" by default (config.exs), but the E2E
+  # Playwright harness loads the server over http://127.0.0.1 (avoids macOS
+  # resolving localhost to IPv6 ::1 while Bandit binds IPv4). With the default
   # check_origin: true, that origin mismatch 403s the LiveView socket (WS AND
   # longpoll) → the LiveView never connects and the review page never renders.
   # Disabling the origin check is safe in test (no real cross-origin risk) and
   # lets the socket accept both 127.0.0.1 and localhost.
+  #
+  # PHX_HOST opts the host in for the dedicated security/isolation E2E project
+  # (playwright.config.ts webServer #2 on port 4004) so the app builds
+  # canonical-host-aware URLs and HostGate can compare against conn.host. When
+  # unset (default for dev + the regular E2E suite),.Endpoint.url() host stays
+  # "localhost" — identical to the previous behavior.
+  url: [host: System.get_env("PHX_HOST") || "localhost"],
   check_origin: false,
   server: false
 
@@ -58,9 +65,13 @@ config :crit, start_github_stars: false
 config :crit, CritWeb.Plugs.RateLimit, disabled: true
 config :crit, CritWeb.Plugs.AuthRateLimit, disabled: true
 
-# Preview isolation is prod-only (PREVIEW_HOST + PHX_HOST). Keep disabled in tests
-# unless a case opts in via Application.put_env/3.
-config :crit, :preview_host, nil
+# Preview isolation is prod-only (PREVIEW_HOST + PHX_HOST) by default. The
+# dedicated security/isolation E2E project opts the test env in via env vars so
+# it can bring up a second Phoenix instance with isolation active; nothing
+# else exercises this path. When the env vars are unset (default), both stay
+# nil → HostGate no-ops and production tests behave identically.
+config :crit, :canonical_host, System.get_env("PHX_HOST")
+config :crit, :preview_host, System.get_env("PREVIEW_HOST")
 
 config :crit, :oauth_provider,
   strategy: Assent.Strategy.Github,

--- a/e2e/security.spec.ts
+++ b/e2e/security.spec.ts
@@ -1,0 +1,251 @@
+/**
+ * Security/isolation E2E suite.
+ *
+ * Drives a *second* Playwright webServer (playwright.config.ts webServer #2)
+ * that boots Phoenix on port 4004 with `PREVIEW_HOST=preview.127.0.0.1.nip.io`
+ * and `PHX_HOST=127.0.0.1.nip.io`. nip.io resolves both names to 127.0.0.1, so
+ * they share the loopback but the browser treats them as separate origins →
+ * the app's canonical vs. preview split surfaces the same way it does in prod.
+ *
+ * Property asserted:
+ *   Logged-in victim's session cookies on the canonical host must not be
+ *   readable — not even addressable — by JS the victim did not author,
+ *   running inside a preview iframe the victim opens.
+ *
+ * The suite tests the *property*, not the fix's implementation. A regression
+ * that re-introduces the #291 vuln (e.g. iframe served same-origin again, or a
+ * fresh sink that bypasses HostGate) should fail this spec without anyone
+ * having to extend it.
+ *
+ * Run locally:
+ *   npx playwright test security.spec.ts
+ * The full `mise run e2e` also runs this spec. It uses port 4004 + the second
+ * webServer in playwright.config.ts.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import {
+  AUTHED_DASHBOARD_MARKER,
+  previewOriginBeaconPayload,
+  previewSessionRidePayload,
+  type SecProbe,
+} from "./security/payloads";
+
+// nip.io wildcards to 127.0.0.1 — same loopback as Bandit, but the browser
+// treats the two hostnames as distinct origins and gates cookies per origin
+// (matching the canonical/preview split the app uses in prod). Both env
+// vars below must match playwright.config.ts's second webServer so the app
+// side and the spec side agree on what "isolated" means.
+const PORT = "4004";
+const CANONICAL_HOST = "127.0.0.1.nip.io";
+const PREVIEW_HOST = "preview.127.0.0.1.nip.io";
+const CANONICAL_ORIGIN = `http://${CANONICAL_HOST}:${PORT}`;
+const PREVIEW_ORIGIN = `http://${PREVIEW_HOST}:${PORT}`;
+
+/**
+ * Install a window.postMessage listener that buffers CRIT_SEC_PROBE messages
+ * from any child iframe. MUST be called before any iframe that emits a probe
+ * navigates — i.e. before page.goto to the review route.
+ */
+async function installProbeListener(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    (window as unknown as { __critSecProbes?: SecProbe[] }).__critSecProbes =
+      [];
+    window.addEventListener("message", (event) => {
+      if (
+        typeof event.data === "object" &&
+        event.data !== null &&
+        (event.data as { type?: unknown }).type === "CRIT_SEC_PROBE"
+      ) {
+        (
+          window as unknown as { __critSecProbes: SecProbe[] }
+        ).__critSecProbes.push(event.data);
+      }
+    });
+  });
+}
+
+async function waitForProbe(
+  page: Page,
+  variant: string,
+  timeoutMs = 10_000,
+): Promise<SecProbe> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const found = await page.evaluate((variant) => {
+      const probes = (window as unknown as { __critSecProbes?: SecProbe[] })
+        .__critSecProbes;
+      return (probes ?? []).find((p) => p.variant === variant) ?? null;
+    }, variant);
+    if (found) return found as SecProbe;
+    await page.waitForTimeout(150);
+  }
+  throw new Error(
+    `no CRIT_SEC_PROBE with variant "${variant}" within ${timeoutMs}ms`,
+  );
+}
+
+test.describe("Preview isolation: preview iframe cannot exfiltrate victim session", () => {
+  test("raw preview route 308-redirects from canonical to preview host", async ({
+    request,
+  }) => {
+    // Smoke check that isolation is actually configured for this spec. If
+    // this fails, the second webServer in playwright.config.ts is missing or
+    // env vars drifted — fix the harness, not the spec.
+    const res = await request.post(`${CANONICAL_ORIGIN}/api/reviews`, {
+      data: {
+        review_type: "preview",
+        review_round: 0,
+        files: [
+          {
+            path: "index.html",
+            content: "<!doctype html><title>innocent</title>",
+            status: "modified",
+          },
+        ],
+      },
+    });
+    expect(res.status(), "preview review creation").toBe(201);
+    const body = await res.json();
+    const token = (body.url as string).split("/r/")[1];
+    const deleteToken = body.delete_token as string;
+
+    try {
+      // Hit the raw route on the canonical host. With isolation enabled the
+      // server issues a 308 redirect to the preview host. Without isolation
+      // it just serves the file (status 200) — exactly the #291 vuln.
+      // Manual redirect handling avoids Playwright following it.
+      const rawRes = await request.get(
+        `${CANONICAL_ORIGIN}/r/${token}/raw/index.html`,
+        { maxRedirects: 0 },
+      );
+      expect(rawRes.status(), "canonical-host raw status").toBe(308);
+      const location = rawRes.headers()["location"] ?? "";
+      expect(
+        location.startsWith(`${PREVIEW_ORIGIN}/r/${token}/raw/index.html`),
+        `redirect location: ${location}`,
+      ).toBe(true);
+    } finally {
+      await request.delete(`${CANONICAL_ORIGIN}/api/reviews`, {
+        data: { delete_token: deleteToken },
+      });
+    }
+  });
+
+  test("preview-host /dashboard is 404 (HostGate)", async ({ request }) => {
+    // HostGate confines the preview host to a narrow route surface. The
+    // dashboard (and any authed-only LiveView) must not be reachable there.
+    const res = await request.get(`${PREVIEW_ORIGIN}/dashboard`, {
+      maxRedirects: 0,
+    });
+    expect(res.status()).toBe(404);
+  });
+
+  test("logged-in victim's session is not exfiltrated by preview review JS", async ({
+    page,
+    request,
+  }) => {
+    // --- Setup: seed a victim user and login them on the canonical host. ---
+    const email = `victim-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}@crit-security-test.example`;
+    const name = `Victim-${Math.random().toString(36).slice(2, 8)}`;
+    const seedRes = await request.post(
+      `${CANONICAL_ORIGIN}/api/test/seed-user`,
+      {
+        data: { name, email },
+      },
+    );
+    expect(seedRes.status(), "seed-user").toBe(200);
+    const seed = await seedRes.json();
+    const userId = seed.user_id as string;
+
+    // Log in the victim on the canonical host via the test-only GET endpoint.
+    // Sets the _crit_web_session cookie scoped to 127.0.0.1.nip.io.
+    await page.goto(`${CANONICAL_ORIGIN}/test/login-as/${userId}`);
+    await expect
+      .poll(async () => (await page.textContent("body")) ?? "")
+      .toContain(`"ok":true`);
+
+    // Sanity: confirm the victim is authenticated against /dashboard before
+    // we load the attacker payload. If this fails, login-as is broken — not
+    // the security boundary.
+    await page.goto(`${CANONICAL_ORIGIN}/dashboard`);
+    await expect(page.locator("body")).toContainText(AUTHED_DASHBOARD_MARKER, {
+      timeout: 10_000,
+    });
+
+    // --- Build the attacker preview review. ---
+    const attackerHtml =
+      "<!doctype html><html><body>" +
+      "<h1>innocent-looking preview</h1>" +
+      previewOriginBeaconPayload() +
+      previewSessionRidePayload() +
+      "</body></html>";
+
+    const reviewRes = await request.post(`${CANONICAL_ORIGIN}/api/reviews`, {
+      data: {
+        review_type: "preview",
+        review_round: 0,
+        files: [
+          { path: "index.html", content: attackerHtml, status: "modified" },
+        ],
+      },
+    });
+    expect(reviewRes.status(), "attacker review creation").toBe(201);
+    const reviewJson = await reviewRes.json();
+    const token = (reviewJson.url as string).split("/r/")[1];
+    const deleteToken = reviewJson.delete_token as string;
+
+    try {
+      // Install the probe listener BEFORE we navigate so we don't miss the
+      // first postMessage the iframe emits.
+      await installProbeListener(page);
+
+      // Victim loads the shared preview review on the canonical host.
+      await page.goto(`${CANONICAL_ORIGIN}/r/${token}`);
+      await page.waitForSelector("#critPreviewIframe", { timeout: 15_000 });
+
+      // The iframe must point at the preview origin — that's the whole
+      // isolation property. If it points at the canonical host, isolation is
+      // off and the security boundary is gone.
+      const iframeSrc = await page
+        .locator("#critPreviewIframe")
+        .getAttribute("src");
+      expect(
+        iframeSrc?.startsWith(`${PREVIEW_ORIGIN}/r/${token}/raw/index.html`),
+        `iframe src = ${iframeSrc}`,
+      ).toBe(true);
+
+      // Receive the origin beacon from inside the iframe. The beacon proves
+      // the iframe's document.origin is the preview host, not the canonical
+      // host.
+      const beacon = await waitForProbe(page, "iframe-origin-beacon");
+      expect(beacon.msg, "iframe origin beacon").toBe(PREVIEW_ORIGIN);
+
+      // Receive the session-ride probe. Assert the attack did NOT reach
+      // authenticated canonical content.
+      const probe = await waitForProbe(page, "session-ride-via-dash-route");
+
+      if (probe.status === 200 || probe.hasAuth === true) {
+        throw new Error(
+          `SECURITY LEAK: attacker preview iframe reached authenticated canonical content.\n` +
+            `probe = ${JSON.stringify(probe)}\n` +
+            `victim = ${email}\n` +
+            `preview iframe origin = ${beacon.msg}\n`,
+        );
+      }
+
+      // Belt-and-suspenders: regardless of how the request is blocked, the
+      // authenticated dashboard markup must not have made it into the iframe.
+      expect(
+        probe.hasAuth,
+        "authed marker must NOT appear in iframe response",
+      ).toBe(false);
+    } finally {
+      await request.delete(`${CANONICAL_ORIGIN}/api/reviews`, {
+        data: { delete_token: deleteToken },
+      });
+    }
+  });
+});

--- a/e2e/security/payloads.ts
+++ b/e2e/security/payloads.ts
@@ -1,0 +1,105 @@
+/**
+ * Adversarial payload library for the security/isolation E2E suite.
+ *
+ * Each export is a function that returns HTML/text to be uploaded as a preview
+ * review (or back-injected into another sink — e.g. a comment body) and a
+ * matching listener predicate that decodes the postMessage probe the payload
+ * emits from inside the iframe. Add a new payload here when a new attack
+ * surface or sink emerges; the spec file (`e2e/security.spec.ts`) just imports
+ * payloads and runs them through the same harness.
+ *
+ * Convention: every payload posts a `CRIT_SEC_PROBE` message to `parent`. The
+ * spec uses `page.addInitScript` to capture these probes before the iframe
+ * navigates. None of these payloads rely on layering-specific implementation
+ * details — they assert the *security property* ("authenticated canonical
+ * content is not readable from user-authored JS inside a preview iframe"),
+ * independent of how the fix achieves it (host-gate, redirect, sandbox, CSP,
+ * …). A regression that re-introduces the vuln by any path should fail.
+ */
+
+export interface SecProbe {
+  type: "CRIT_SEC_PROBE";
+  variant: string;
+  status?: number | string;
+  hasAuth?: boolean;
+  msg?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Deterministic marker present in /dashboard's HTML for an authenticated user
+ * (`lib/crit_web/live/dashboard_live.html.heex` line 18:
+ * "Hi <name>, where to today?"). The unauth path redirects via LiveView and
+ * does NOT render this string in the initial HTTP response body. So presence
+ * of this marker unambiguously means: cookies were sent AND server treated the
+ * request as authenticated.
+ */
+export const AUTHED_DASHBOARD_MARKER = "where to today?";
+
+/**
+ * Payload: attempt to "ride" the viewer's session cookies against /dashboard
+ * from inside the preview iframe. Uses a *relative* URL (`/dashboard`), which
+ * resolves against the iframe's document origin:
+ *   - Without origin isolation: iframe document = canonical host → fetch hits
+ *     /dashboard same-origin with cookies → 200 + authed HTML → hasAuth:true.
+ *     THIS IS THE VULN. Probe exposes it.
+ *   - With origin isolation: iframe document = preview host → fetch hits
+ *     /dashboard on the preview host → HostGate 404 → no leak.
+ *
+ * `redirect: "manual"` makes the LV on_mount redirect (unauth path) return as a
+ * redirect response we can inspect, instead of Playwright following it
+ * automatically.
+ */
+export function previewSessionRidePayload(): string {
+  const marker = AUTHED_DASHBOARD_MARKER;
+  return `<script>
+(async () => {
+  const probe = (status, hasAuth, msg) =>
+    parent.postMessage({
+      type: "CRIT_SEC_PROBE",
+      variant: "session-ride-via-dash-route",
+      status,
+      hasAuth,
+      msg,
+    }, "*");
+  try {
+    const res = await fetch("/dashboard", {
+      credentials: "include",
+      redirect: "manual",
+    });
+    const text = await res.text();
+    probe(res.status, text.includes(${JSON.stringify(marker)}), text.slice(0, 160));
+  } catch (e) {
+    probe("BLOCKED", false, String(e));
+  }
+})();
+</script>`;
+}
+
+/**
+ * Sanity payload: a probe that just reports its own document origin back to
+ * the parent. Use it to assert the iframe really is on the preview host when
+ * isolation is configured, and on the canonical host when it isn't — so a
+ * misconfiguration (e.g. PREVIEW_HOST unset) is detected as a setup error
+ * rather than as a pass.
+ */
+export function previewOriginBeaconPayload(): string {
+  return `<script>
+parent.postMessage({
+  type: "CRIT_SEC_PROBE",
+  variant: "iframe-origin-beacon",
+  msg: location.origin,
+}, "*");
+</script>`;
+}
+
+/**
+ * Type guard for the probe messages.
+ */
+export function isSecProbe(d: unknown): d is SecProbe {
+  return (
+    typeof d === "object" &&
+    d !== null &&
+    (d as { type?: unknown }).type === "CRIT_SEC_PROBE"
+  );
+}

--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -390,6 +390,18 @@ defmodule CritWeb.ApiController do
           json(conn, Reviews.serialize_reply(reply))
       end
     end
+
+    # Browser-session login for security/isolation E2E: writes the app session
+    # cookie for a previously seeded user so Playwright can drive a victim
+    # browser context authenticated against the canonical host. NEVER compiled
+    # into :prod (router only mounts this under `Mix.env() in [:test, :dev]`).
+    # The route is GET-only (no CSRF concern in test/dev, and Playwright can't
+    # easily POST-with-csrf-test-helper-token through page.goto).
+    def login_as(conn, %{"user_id" => user_id}) do
+      user = Crit.Repo.get!(Crit.User, user_id)
+      conn = CritWeb.UserAuth.log_in_user(conn, user)
+      json(conn, %{ok: true, user_id: user.id, email: user.email})
+    end
   end
 
   # Handled by LocalhostCors plug — this action is never reached.

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -250,6 +250,18 @@ defmodule CritWeb.Router do
       post "/test/seed-user", ApiController, :seed_user
       post "/test/seed-org", ApiController, :seed_org
     end
+
+    # Test-only helper endpoints that require a real browser session (cookie).
+    # Compiled out of :prod. GET (not POST) on purpose: Playwright's
+    # page.goto() can't trigger a browser-pipeline POST form submit with the
+    # CSRF token, and a session-stamping endpoint is harmless for GET in a
+    # test/dev environment (`/test/login-as/:user_id` only writes the cookie,
+    # it doesn't read or mutate anything).
+    scope "/test", CritWeb do
+      pipe_through [:browser, :noindex]
+
+      get "/login-as/:user_id", ApiController, :login_as
+    end
   end
 
   if Mix.env() == :dev do

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,16 @@ const PORT = process.env.CRIT_WEB_TEST_PORT || "4003";
 // works on macOS and CI alike.
 const BASE_URL = `http://127.0.0.1:${PORT}`;
 
+// Security/isolation webServer (port 4004). Boots Phoenix with origin
+// isolation enabled: PHX_HOST=127.0.0.1.nip.io (canonical) + PREVIEW_HOST
+// preview.127.0.0.1.nip.io. nip.io wildcards both names to 127.0.0.1 so they
+// share Bandit's loopback listener but the browser treats them as distinct
+// origins (matching prod's canonical/preview split). See
+// e2e/security.spec.ts.
+const SEC_PORT = "4004";
+const SEC_CANONICAL_HOST = "127.0.0.1.nip.io";
+const SEC_BASE_URL = `http://${SEC_CANONICAL_HOST}:${SEC_PORT}`;
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: false,
@@ -22,25 +32,61 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
+      // security.spec.ts has its own project + webServer — exclude it here so
+      // it isn't run twice (which would fail in the non-isolated project).
+      testIgnore: /security\.spec\.ts/,
       use: { browserName: "chromium" },
+    },
+    {
+      // Security suite runs against its own isolated webServer (port 4004).
+      // The baseURL override routes browser navigation in security.spec.ts to
+      // the canonical isolated-host URL; the spec targets the preview host
+      // explicitly via PREVIEW_ORIGIN constants.
+      name: "security-chromium",
+      testMatch: /security\.spec\.ts/,
+      use: {
+        browserName: "chromium",
+        baseURL: SEC_BASE_URL,
+      },
     },
   ],
 
-  webServer: {
-    command: `MIX_ENV=test mix do ecto.create --quiet + ecto.migrate --quiet + phx.server`,
-    url: `${BASE_URL}/health`,
-    reuseExistingServer: !process.env.CI,
-    timeout: 60_000,
-    env: {
-      MIX_ENV: "test",
-      PORT: PORT,
-      E2E: "true",
-      PHX_SERVER: "true",
-      // Local Postgres maps host 5433 → container 5432; CI runs Postgres on
-      // 5432 and sets no DB_PORT. Forward it so the managed webServer's
-      // ecto.create/migrate reaches the right port (otherwise it exits
-      // instantly and every spec hits a dead port).
-      DB_PORT: process.env.DB_PORT || "5432",
+  webServer: [
+    {
+      command: `MIX_ENV=test mix do ecto.create --quiet + ecto.migrate --quiet + phx.server`,
+      url: `${BASE_URL}/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      env: {
+        MIX_ENV: "test",
+        PORT: PORT,
+        E2E: "true",
+        PHX_SERVER: "true",
+        // Local Postgres maps host 5433 → container 5432; CI runs Postgres on
+        // 5432 and sets no DB_PORT. Forward it so the managed webServer's
+        // ecto.create/migrate reaches the right port (otherwise it exits
+        // instantly and every spec hits a dead port).
+        DB_PORT: process.env.DB_PORT || "5432",
+      },
     },
-  },
+    {
+      // Isolated Phoenix instance for the security/isolation spec.
+      // Shares the same DB (idempotent ecto.migrate) and loopback (Port
+      // 4004) as the canonical instance; only PREVIEW_HOST + PHX_HOST differ,
+      // enabling HostGate + the canonical→preview 308 redirect.
+      command: `MIX_ENV=test mix do ecto.migrate --quiet + phx.server`,
+      url: `${SEC_BASE_URL}/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      env: {
+        MIX_ENV: "test",
+        PORT: SEC_PORT,
+        PHX_HOST: SEC_CANONICAL_HOST,
+        PREVIEW_HOST: "preview.127.0.0.1.nip.io",
+        E2E: "true",
+        PHX_SERVER: "true",
+        DB_PORT: process.env.DB_PORT || "5432",
+      },
+    },
+  ],
 });


### PR DESCRIPTION
## Summary

Adds a DAST (dynamic application security testing) suite that asserts the security property closed by #291 — **a logged-in victim's session on the canonical host cannot be read or addressed by JS running inside a preview iframe** — as a permanent Playwright test. A regression that re-introduces the vuln by any path (bypassed redirect, new sink, sandbox removal, header-based auth switch) fails the spec without anyone extending it.

This is the answer to "how do we prevent a security issue we DON'T already know about": test the *threat*, not the *control*. The control can move; the property stays.

## Background

The existing unit tests in `raw_controller_test.exs` / `host_gate_test.exs` / `security_headers_test.exs` are regression tests for the #291 *fix* — they assert "the 308 redirect happens", "the CSP contains X", etc. They trace the implementation, so they can't catch the *next* unknown trust-boundary bug. This suite flips the direction: it asserts the negative security property end-to-end against a running, authed browser.

## Changes

- **`e2e/security/payloads.ts`** — adversarial payload library. Each payload posts a `CRIT_SEC_PROBE` message to parent; the spec asserts the negative property (no authed canonical content in the iframe response). New attack class → new payload file → assertion lives in the suite forever. Doesn't depend on knowing the fix's implementation.
- **`e2e/security.spec.ts`** — 3 tests:
  - `raw preview route 308-redirects from canonical to preview host` — smoke check that isolation is configured
  - `preview-host /dashboard is 404 (HostGate)` — HostGate confines the preview host
  - `logged-in victim's session is not exfiltrated by preview review JS` — end-to-end: seeds a victim, logs them in, uploads an attacker preview review containing `fetch('/dashboard', {credentials: 'include'})`, loads it as the victim, asserts no authed canonical content reached the iframe
- **`playwright.config.ts`** — second isolated webServer on port 4004 with `PHX_HOST=127.0.0.1.nip.io` + `PREVIEW_HOST=preview.127.0.0.1.nip.io`. nip.io wildcards both names to 127.0.0.1 so the browser sees two distinct origins on the same loopback (matching prod's canonical/preview split). Adds a `security-chromium` project gated to `security.spec.ts` via `testMatch`/`testIgnore`.
- **`config/test.exs`** — `PHX_HOST`/`PREVIEW_HOST` env vars opt the test env into preview isolation (still `nil` by default → existing 1052 ExUnit tests unaffected).
- **`lib/crit_web/controllers/api_controller.ex` + `lib/crit_web/router.ex`** — `/test/login-as/:user_id` browser-only test endpoint (compiled out of `:prod` via the existing module-body `if Mix.env() in [:test, :dev] do` gate, same as `seed_user`/`seed_comment`) writes a victim session cookie via `UserAuth.log_in_user/2` so Playwright can drive an authed victim. GET-only on purpose — Playwright's `page.goto()` can't POST with CSRF.

## Verification

- `mix compile --warnings-as-errors` — clean
- `mix test` — 1052 tests pass (the 11 `accounts_test.exs` failures are pre-existing flakiness on `origin/main`, confirmed via `git stash`)
- `npx playwright test` — 134 tests pass (existing 131 + new 3)
- **Falsification check**: blanking `PREVIEW_HOST` in the second webServer causes all 3 spec tests to fail (308→200, HostGate 404→302, iframe src points at canonical not preview). Restoring makes them pass. The spec genuinely catches the bug class, not just the fix.

## Test plan

- [ ] `mise run e2e` — runs the full Playwright suite including the new security spec
- [ ] `npx playwright test security.spec.ts --project security-chromium` — runs just the new spec

## Review

Reviewed with crit (session a82dc0b1fc63) — 1 comment about `login_as` defense-in-depth, resolved by following the codebase idiom (module-body `if Mix.env()` gate, no interior runtime check). Approved.