### PR TITLE
fix: allow preview host raw assets without app session

### DIFF
--- a/lib/crit_web/controllers/raw_controller.ex
+++ b/lib/crit_web/controllers/raw_controller.ex
@@ -67,7 +67,7 @@ defmodule CritWeb.RawController do
     scope = conn.assigns[:current_scope] || %Crit.Accounts.Scope{}
 
     with %Review{} = review <- Reviews.get_by_token(token),
-         :ok <- Reviews.check_org_access(review, scope) do
+         :ok <- check_raw_access(conn, review, scope) do
       if redirect_preview_raw_from_canonical?(conn, review) do
         redirect_preview_raw_to_preview_host(conn)
       else
@@ -77,6 +77,24 @@ defmodule CritWeb.RawController do
       _ -> conn |> put_status(404) |> text("not found")
     end
   end
+
+  defp check_raw_access(conn, %Review{} = review, scope) do
+    cond do
+      # The isolated preview host intentionally has no app-session cookie.
+      # Preview raw assets are token-addressed and may be served there, but do
+      # not allow files-mode source raw routes onto that origin.
+      preview_host_request?(conn) and review.review_type == :preview ->
+        :ok
+
+      preview_host_request?(conn) ->
+        {:error, :not_found}
+
+      true ->
+        Reviews.check_org_access(review, scope)
+    end
+  end
+
+  defp preview_host_request?(conn), do: conn.host == CritWeb.Hosts.preview_host()
 
   defp serve_raw(conn, %Review{} = review, file_path) do
     with %{} = file <- Enum.find(review.files, fn f -> f.file_path == file_path end),
@@ -221,10 +239,15 @@ defmodule CritWeb.RawController do
 
   # Mirrors `CritWeb.UserAuth.on_mount(:require_review_scope, ...)` for the
   # plain-controller raw endpoint. On selfhosted+OAuth instances, anonymous
-  # visitors must hit the OAuth login flow with `return_to` set to the raw URL
-  # so the LiveView gate's protection isn't bypassed by the raw endpoint.
+  # canonical-host visitors must hit the OAuth login flow with `return_to` set
+  # to the raw URL so the LiveView gate's protection isn't bypassed by the raw
+  # endpoint. The dedicated preview host is excluded because it cannot and
+  # should not receive the app-host session cookie.
   defp require_review_scope(conn, _opts) do
     cond do
+      conn.host == CritWeb.Hosts.preview_host() ->
+        conn
+
       conn.assigns.current_scope.user ->
         conn
 

--- a/lib/crit_web/endpoint.ex
+++ b/lib/crit_web/endpoint.ex
@@ -22,6 +22,9 @@ defmodule CritWeb.Endpoint do
     websocket: [connect_info: [:peer_data, :uri, :user_agent, session: @session_options]],
     longpoll: [connect_info: [:peer_data, :uri, :user_agent, session: @session_options]]
 
+  plug CritWeb.Plugs.CanonicalHost
+  plug CritWeb.Plugs.HostGate
+
   # Serve at "/" the static files from "priv/static" directory.
   #
   # When code reloading is disabled (e.g., in production),
@@ -55,8 +58,6 @@ defmodule CritWeb.Endpoint do
 
   plug Plug.MethodOverride
   plug Plug.Head
-  plug CritWeb.Plugs.CanonicalHost
-  plug CritWeb.Plugs.HostGate
   plug :session
 
   # Drop request body and cookies — review documents and comment bodies must

--- a/test/crit_web/controllers/raw_controller_test.exs
+++ b/test/crit_web/controllers/raw_controller_test.exs
@@ -4,9 +4,44 @@ defmodule CritWeb.RawControllerTest do
   use CritWeb.ConnCase, async: false
 
   import Crit.ReviewsFixtures
+  import Crit.OrganizationsFixtures
+
+  alias Crit.{Repo, Reviews}
+  alias Crit.Accounts.Scope
 
   defp file(path, content, extra \\ %{}) do
     Map.merge(%{"path" => path, "content" => content}, extra)
+  end
+
+  defp insert_user!(attrs \\ %{}) do
+    base = %{
+      provider: "test",
+      provider_uid: "uid-#{System.unique_integer([:positive])}",
+      email: "u-#{System.unique_integer([:positive])}@example.com",
+      name: "Raw User"
+    }
+
+    %Crit.User{}
+    |> Crit.User.oauth_changeset(Map.merge(base, attrs))
+    |> Repo.insert!()
+  end
+
+  defp with_preview_hosts do
+    original_canonical = Application.get_env(:crit, :canonical_host)
+    original_preview = Application.get_env(:crit, :preview_host)
+
+    Application.put_env(:crit, :canonical_host, "app.example.test")
+    Application.put_env(:crit, :preview_host, "preview.example.test")
+
+    on_exit(fn ->
+      if is_nil(original_canonical),
+        do: Application.delete_env(:crit, :canonical_host),
+        else: Application.put_env(:crit, :canonical_host, original_canonical)
+
+      if is_nil(original_preview),
+        do: Application.delete_env(:crit, :preview_host),
+        else: Application.put_env(:crit, :preview_host, original_preview)
+    end)
   end
 
   describe "GET /r/:token/raw/*file_path" do
@@ -316,6 +351,44 @@ defmodule CritWeb.RawControllerTest do
         |> get(~p"/r/#{review.token}/raw/lib/foo.ex")
 
       assert response(conn, 200) == "defmodule Foo, do: :ok\n"
+    end
+
+    test "serves preview raw on the isolated preview host without app session", %{conn: conn} do
+      with_preview_hosts()
+
+      user = insert_user!()
+      org = organization_fixture(user)
+
+      {:ok, review} =
+        Reviews.create_review(
+          Scope.for_user(user),
+          [file("index.html", "<html><body><h1>Preview</h1></body></html>")],
+          0,
+          [],
+          [],
+          org: org.slug,
+          review_type: "preview"
+        )
+
+      conn =
+        conn
+        |> Map.put(:host, "preview.example.test")
+        |> get(~p"/r/#{review.token}/raw/index.html")
+
+      assert response(conn, 200) =~ "<h1>Preview</h1>"
+    end
+
+    test "does not expose files-mode raw on the isolated preview host", %{conn: conn} do
+      with_preview_hosts()
+
+      review = review_fixture(%{files: [file("lib/foo.ex", "secret")]})
+
+      conn =
+        conn
+        |> Map.put(:host, "preview.example.test")
+        |> get(~p"/r/#{review.token}/raw/lib/foo.ex")
+
+      assert response(conn, 404) == "not found"
     end
   end
 

--- a/test/crit_web/plugs/host_gate_test.exs
+++ b/test/crit_web/plugs/host_gate_test.exs
@@ -48,6 +48,15 @@ defmodule CritWeb.Plugs.HostGateTest do
     assert get_resp_header(conn, "content-type") |> hd() =~ "javascript"
   end
 
+  test "preview host blocks generic static assets", %{conn: conn} do
+    conn =
+      conn
+      |> Map.put(:host, "preview.example.test")
+      |> get("/favicon.svg")
+
+    assert response(conn, 404) == "not found"
+  end
+
   test "preview host blocks app routes", %{conn: conn} do
     conn =
       conn


### PR DESCRIPTION
## Summary
- Allow preview-review raw assets to load from `PREVIEW_HOST` without relying on the app-host session cookie
- Keep files-mode raw content blocked on the preview host
- Move host gating before static asset serving so generic static files cannot bypass preview-host route restrictions
- Add regression coverage for org-scoped preview raw access, files-mode denial, and static asset blocking

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Parity audit: N/A

## Test plan
- `mise exec -- mix test test/crit_web/controllers/raw_controller_test.exs test/crit_web/plugs/host_gate_test.exs test/crit_web/plugs/no_transform_test.exs test/crit_web/plugs/canonical_host_test.exs`
- `MIX_ENV=test mise exec -- mix ecto.reset && mise exec -- mix precommit`
- `mise run e2e -- e2e/preview.spec.ts`
