### PR TITLE
feat: add instance share policy controls

### DIFF
--- a/assets/js/share_receiver/handlers.js
+++ b/assets/js/share_receiver/handlers.js
@@ -27,6 +27,14 @@ export async function fetchComments(msg) {
   return await readResponse(resp);
 }
 
+export async function sharePolicy() {
+  const resp = await fetch('/api/share-policy', {
+    method: 'GET',
+    credentials: 'same-origin',
+  });
+  return await readResponse(resp);
+}
+
 export async function upsert(msg) {
   if (!msg.token) throw new Error('missing token');
   return await jsonOp(

--- a/assets/js/share_receiver/index.js
+++ b/assets/js/share_receiver/index.js
@@ -24,6 +24,7 @@ import * as handlers from './handlers.js';
 window.__handlers = {
   share: handlers.share,
   fetch: handlers.fetchComments,
+  sharePolicy: handlers.sharePolicy,
   upsert: handlers.upsert,
   unpublish: handlers.unpublish,
 };

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -165,6 +165,7 @@ defmodule Crit.Reviews do
   """
   def make_public(%Scope{} = scope, review_id) do
     with {:ok, review} <- fetch_review_for_owner(scope, review_id),
+         :ok <- ensure_visibility_allowed(:public),
          :ok <- ensure_unlisted(review) do
       review
       |> Review.visibility_changeset(%{visibility: :public})
@@ -189,6 +190,7 @@ defmodule Crit.Reviews do
   """
   def update_review(%Scope{} = scope, review_id, attrs) when is_map(attrs) do
     with {:ok, review} <- fetch_review_for_owner(scope, review_id),
+         :ok <- ensure_comment_policy_update_allowed(review, attrs),
          {:ok, updated} <-
            review
            |> Review.update_changeset(attrs)
@@ -289,13 +291,16 @@ defmodule Crit.Reviews do
     review_type = Keyword.get(opts, :review_type) || "files"
     org_slug = Keyword.get(opts, :org)
     explicit_visibility = Keyword.get(opts, :visibility)
+    explicit_comment_policy = Keyword.get(opts, :comment_policy)
 
-    max_total_size = Settings.get().max_document_bytes
+    settings = Settings.get()
+    max_total_size = settings.max_document_bytes
 
     if total_bytes > max_total_size do
       {:error, :total_size_exceeded}
     else
-      with {:ok, org_attrs} <- resolve_org(scope, org_slug, explicit_visibility) do
+      with {:ok, comment_policy} <- resolve_comment_policy(explicit_comment_policy, settings),
+           {:ok, org_attrs} <- resolve_org(scope, org_slug, explicit_visibility, settings) do
         review_changeset =
           %Review{}
           |> Review.create_changeset(%{
@@ -303,6 +308,7 @@ defmodule Crit.Reviews do
             "cli_args" => cli_args,
             "review_type" => review_type
           })
+          |> Ecto.Changeset.put_change(:comment_policy, comment_policy)
           |> then(fn cs ->
             if user_id, do: Ecto.Changeset.put_change(cs, :user_id, user_id), else: cs
           end)
@@ -312,6 +318,9 @@ defmodule Crit.Reviews do
                 cs
                 |> Ecto.Changeset.put_change(:organization_id, org_id)
                 |> Ecto.Changeset.put_change(:visibility, vis)
+
+              %{visibility: vis} ->
+                Ecto.Changeset.put_change(cs, :visibility, vis)
 
               _ ->
                 cs
@@ -332,9 +341,25 @@ defmodule Crit.Reviews do
   end
 
   # Resolve org slug to org_id + visibility. Returns {:ok, map | nil} or {:error, reason}.
-  defp resolve_org(_scope, nil, _explicit_visibility), do: {:ok, nil}
+  defp resolve_org(_scope, nil, nil, settings) do
+    case Settings.default_visibility(settings) do
+      nil -> {:error, :visibility_not_allowed}
+      visibility -> {:ok, %{visibility: visibility}}
+    end
+  end
 
-  defp resolve_org(%Scope{} = scope, org_slug, explicit_visibility) do
+  defp resolve_org(_scope, nil, explicit_visibility, settings) do
+    visibility = Settings.normalize_visibility(explicit_visibility)
+
+    cond do
+      is_nil(visibility) -> {:error, :invalid_visibility}
+      visibility == :organization -> {:error, :visibility_not_allowed}
+      Settings.visibility_allowed?(visibility, settings) -> {:ok, %{visibility: visibility}}
+      true -> {:error, :visibility_not_allowed}
+    end
+  end
+
+  defp resolve_org(%Scope{} = scope, org_slug, explicit_visibility, settings) do
     user_id = Scope.user_id(scope)
 
     if is_nil(user_id) do
@@ -351,10 +376,60 @@ defmodule Crit.Reviews do
 
             {:ok, _membership} ->
               visibility = explicit_visibility || :organization
-              {:ok, %{organization_id: org.id, visibility: visibility}}
+
+              cond do
+                visibility == :organization and
+                    Settings.visibility_allowed?(:organization, settings) ->
+                  {:ok, %{organization_id: org.id, visibility: visibility}}
+
+                visibility == :organization ->
+                  {:error, :visibility_not_allowed}
+
+                is_nil(Settings.normalize_visibility(visibility)) ->
+                  {:error, :invalid_visibility}
+
+                Settings.visibility_allowed?(visibility, settings) ->
+                  {:ok, %{organization_id: org.id, visibility: visibility}}
+
+                true ->
+                  {:error, :visibility_not_allowed}
+              end
           end
       end
     end
+  end
+
+  defp resolve_comment_policy(nil, settings), do: {:ok, Settings.default_comment_policy(settings)}
+
+  defp resolve_comment_policy(raw, settings) do
+    policy = Settings.normalize_comment_policy(raw)
+
+    cond do
+      is_nil(policy) -> {:error, :invalid_comment_policy}
+      Settings.comment_policy_allowed?(policy, settings) -> {:ok, policy}
+      true -> {:error, :comment_policy_not_allowed}
+    end
+  end
+
+  defp ensure_comment_policy_update_allowed(%Review{} = review, attrs) do
+    case Map.get(attrs, :comment_policy) || Map.get(attrs, "comment_policy") do
+      nil ->
+        :ok
+
+      raw ->
+        policy = Settings.normalize_comment_policy(raw)
+
+        cond do
+          is_nil(policy) -> :ok
+          policy == review.comment_policy -> :ok
+          Settings.comment_policy_allowed?(policy) -> :ok
+          true -> {:error, :comment_policy_not_allowed}
+        end
+    end
+  end
+
+  defp ensure_visibility_allowed(visibility) do
+    if Settings.visibility_allowed?(visibility), do: :ok, else: {:error, :visibility_not_allowed}
   end
 
   defp do_create_review(

--- a/lib/crit/setting.ex
+++ b/lib/crit/setting.ex
@@ -13,12 +13,22 @@ defmodule Crit.Setting do
 
   @kb 1024
   @mb 1_048_576
+  @comment_policies [:open, :logged_in_only, :disallowed]
+  @review_visibilities [:unlisted, :public, :organization]
 
   @primary_key {:id, :integer, autogenerate: false}
   schema "settings" do
     field :max_document_bytes, :integer
     field :max_comments_per_review, :integer
     field :max_comment_body_bytes, :integer
+
+    field :allowed_comment_policies, {:array, Ecto.Enum},
+      values: @comment_policies,
+      default: @comment_policies
+
+    field :allowed_review_visibilities, {:array, Ecto.Enum},
+      values: @review_visibilities,
+      default: @review_visibilities
 
     # Virtual fields that the form binds to. Converted to bytes by `changeset/2`.
     field :max_document_mb, :float, virtual: true
@@ -27,7 +37,13 @@ defmodule Crit.Setting do
     timestamps(type: :utc_datetime)
   end
 
-  @form_fields [:max_document_mb, :max_comments_per_review, :max_comment_body_kb]
+  @form_fields [
+    :max_document_mb,
+    :max_comments_per_review,
+    :max_comment_body_kb,
+    :allowed_comment_policies,
+    :allowed_review_visibilities
+  ]
 
   @doc """
   Changeset for updating instance settings via the admin form.
@@ -43,6 +59,10 @@ defmodule Crit.Setting do
     |> validate_number(:max_document_mb, greater_than: 0)
     |> validate_number(:max_comments_per_review, greater_than: 0)
     |> validate_number(:max_comment_body_kb, greater_than: 0)
+    |> validate_subset(:allowed_comment_policies, @comment_policies)
+    |> validate_length(:allowed_comment_policies, min: 1)
+    |> validate_subset(:allowed_review_visibilities, @review_visibilities)
+    |> validate_length(:allowed_review_visibilities, min: 1)
     |> put_byte_field(:max_document_mb, :max_document_bytes, @mb)
     |> put_byte_field(:max_comment_body_kb, :max_comment_body_bytes, @kb)
   end

--- a/lib/crit/settings.ex
+++ b/lib/crit/settings.ex
@@ -9,6 +9,9 @@ defmodule Crit.Settings do
   alias Crit.{Repo, Setting}
 
   @singleton_id 1
+  @default_comment_policy :open
+  @default_visibility :unlisted
+  @personal_visibilities [:unlisted, :public]
 
   @doc """
   Returns the singleton settings row. Raises if missing — the migration
@@ -33,4 +36,57 @@ defmodule Crit.Settings do
   def change(setting \\ get(), attrs \\ %{}) do
     Setting.changeset(setting, attrs)
   end
+
+  @doc "Returns share policy allow-lists for clients that expose share options."
+  def share_policy(setting \\ get()) do
+    %{
+      allowed_comment_policies: setting.allowed_comment_policies,
+      allowed_review_visibilities: setting.allowed_review_visibilities
+    }
+  end
+
+  def comment_policy_allowed?(policy, setting \\ get()) do
+    policy = normalize_comment_policy(policy)
+    not is_nil(policy) and policy in setting.allowed_comment_policies
+  end
+
+  def visibility_allowed?(visibility, setting \\ get()) do
+    visibility = normalize_visibility(visibility)
+    not is_nil(visibility) and visibility in setting.allowed_review_visibilities
+  end
+
+  def default_comment_policy(setting \\ get()) do
+    if @default_comment_policy in setting.allowed_comment_policies do
+      @default_comment_policy
+    else
+      List.first(setting.allowed_comment_policies)
+    end
+  end
+
+  def default_visibility(setting \\ get()) do
+    personal_allowed =
+      Enum.filter(setting.allowed_review_visibilities, &(&1 in @personal_visibilities))
+
+    if @default_visibility in personal_allowed do
+      @default_visibility
+    else
+      List.first(personal_allowed)
+    end
+  end
+
+  def normalize_comment_policy(policy) when policy in [:open, :logged_in_only, :disallowed],
+    do: policy
+
+  def normalize_comment_policy("open"), do: :open
+  def normalize_comment_policy("logged_in_only"), do: :logged_in_only
+  def normalize_comment_policy("disallowed"), do: :disallowed
+  def normalize_comment_policy(_), do: nil
+
+  def normalize_visibility(visibility) when visibility in [:unlisted, :public, :organization],
+    do: visibility
+
+  def normalize_visibility("unlisted"), do: :unlisted
+  def normalize_visibility("public"), do: :public
+  def normalize_visibility("organization"), do: :organization
+  def normalize_visibility(_), do: nil
 end

--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -248,20 +248,72 @@ defmodule CritWeb.ApiController do
     payload = Map.take(params, ["files", "comments", "review_round", "cli_args"])
     scope = api_scope(conn)
 
-    case Reviews.upsert_review(scope, token, delete_token, payload) do
-      {:ok, :updated, review} ->
-        respond_with_upsert(conn, scope, review, params, true)
+    with {:ok, existing_review} <- get_upsert_review(token, delete_token),
+         :ok <- validate_upsert_comment_policy(scope, existing_review, params) do
+      case Reviews.upsert_review(scope, token, delete_token, payload) do
+        {:ok, :updated, review} ->
+          respond_with_upsert(conn, scope, review, params, true)
 
-      {:ok, :no_changes, review} ->
-        respond_with_upsert(conn, scope, review, params, false)
+        {:ok, :no_changes, review} ->
+          respond_with_upsert(conn, scope, review, params, false)
 
+        {:error, :not_found} ->
+          not_found(conn)
+
+        {:error, :unauthorized} ->
+          conn |> put_status(401) |> json(%{error: "unauthorized"})
+      end
+    else
       {:error, :not_found} ->
         not_found(conn)
 
       {:error, :unauthorized} ->
         conn |> put_status(401) |> json(%{error: "unauthorized"})
+
+      {:error, :comment_policy_not_allowed} ->
+        policy_error(conn, :comment_policy_not_allowed)
+
+      {:error, :invalid_comment_policy} ->
+        policy_error(conn, :invalid_comment_policy)
     end
   end
+
+  defp get_upsert_review(token, delete_token) do
+    case Reviews.get_by_token(token) do
+      nil -> {:error, :not_found}
+      %{delete_token: ^delete_token} = review -> {:ok, review}
+      _review -> {:error, :unauthorized}
+    end
+  end
+
+  defp validate_upsert_comment_policy(scope, review, %{"comment_policy" => raw})
+       when is_binary(raw) do
+    if !can_manage_comment_policy?(scope, review) do
+      :ok
+    else
+      validate_owner_comment_policy(review, raw)
+    end
+  end
+
+  defp validate_upsert_comment_policy(_scope, _review, _params), do: :ok
+
+  defp validate_owner_comment_policy(review, raw) do
+    with {:ok, policy} <- parse_comment_policy(raw) do
+      cond do
+        policy == review.comment_policy -> :ok
+        Settings.comment_policy_allowed?(policy) -> :ok
+        true -> {:error, :comment_policy_not_allowed}
+      end
+    else
+      :error -> {:error, :invalid_comment_policy}
+    end
+  end
+
+  defp can_manage_comment_policy?(%Scope{} = scope, %{user_id: owner_id})
+       when not is_nil(owner_id),
+       do: Scope.user_id(scope) == owner_id
+
+  defp can_manage_comment_policy?(_scope, _review), do: false
 
   defp respond_with_upsert(conn, scope, review, params, changed) do
     case maybe_update_comment_policy(scope, review, params) do
@@ -277,21 +329,33 @@ defmodule CritWeb.ApiController do
 
       {:error, :comment_policy_not_allowed} ->
         policy_error(conn, :comment_policy_not_allowed)
+
+      {:error, :invalid_comment_policy} ->
+        policy_error(conn, :invalid_comment_policy)
     end
   end
 
   defp maybe_update_comment_policy(scope, review, %{"comment_policy" => raw})
        when is_binary(raw) do
+    if !can_manage_comment_policy?(scope, review) do
+      {:ok, review}
+    else
+      update_owner_comment_policy(scope, review, raw)
+    end
+  end
+
+  defp maybe_update_comment_policy(_scope, review, _params), do: {:ok, review}
+
+  defp update_owner_comment_policy(scope, review, raw) do
     with {:ok, policy} <- parse_comment_policy(raw),
          {:ok, updated} <- Reviews.update_review(scope, review.id, %{comment_policy: policy}) do
       {:ok, updated}
     else
       {:error, :comment_policy_not_allowed} -> {:error, :comment_policy_not_allowed}
+      :error -> {:error, :invalid_comment_policy}
       _ -> {:ok, review}
     end
   end
-
-  defp maybe_update_comment_policy(_scope, review, _params), do: {:ok, review}
 
   defp parse_comment_policy("open"), do: {:ok, :open}
   defp parse_comment_policy("logged_in_only"), do: {:ok, :logged_in_only}

--- a/lib/crit_web/controllers/api_controller.ex
+++ b/lib/crit_web/controllers/api_controller.ex
@@ -16,6 +16,7 @@ defmodule CritWeb.ApiController do
     review_comments = params["review_comments"] || []
     org_slug = params["org"]
     visibility = parse_visibility(params["visibility"])
+    comment_policy = params["comment_policy"]
     review_type = parse_review_type(params["review_type"])
     scope = api_scope(conn)
     max_comments = Settings.get().max_comments_per_review
@@ -32,10 +33,10 @@ defmodule CritWeb.ApiController do
                cli_args: cli_args,
                org: org_slug,
                visibility: visibility,
+               comment_policy: comment_policy,
                review_type: review_type
              ) do
           {:ok, review} ->
-            review = maybe_update_comment_policy(scope, review, params)
             url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
 
             conn
@@ -55,6 +56,15 @@ defmodule CritWeb.ApiController do
           {:error, :not_a_member} ->
             conn |> put_status(403) |> json(%{error: "You are not a member of this organization"})
 
+          {:error, reason}
+          when reason in [
+                 :comment_policy_not_allowed,
+                 :visibility_not_allowed,
+                 :invalid_comment_policy,
+                 :invalid_visibility
+               ] ->
+            policy_error(conn, reason)
+
           {:error, %Ecto.Changeset{} = changeset} ->
             errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
             conn |> put_status(422) |> json(%{error: "Validation failed", details: errors})
@@ -70,6 +80,7 @@ defmodule CritWeb.ApiController do
     review_comments = params["review_comments"] || []
     org_slug = params["org"]
     visibility = parse_visibility(params["visibility"])
+    comment_policy = params["comment_policy"]
     review_type = parse_review_type(params["review_type"])
     scope = api_scope(conn)
 
@@ -94,10 +105,10 @@ defmodule CritWeb.ApiController do
                cli_args: cli_args,
                org: org_slug,
                visibility: visibility,
+               comment_policy: comment_policy,
                review_type: review_type
              ) do
           {:ok, review} ->
-            review = maybe_update_comment_policy(scope, review, params)
             url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
 
             conn
@@ -117,6 +128,15 @@ defmodule CritWeb.ApiController do
           {:error, :not_a_member} ->
             conn |> put_status(403) |> json(%{error: "You are not a member of this organization"})
 
+          {:error, reason}
+          when reason in [
+                 :comment_policy_not_allowed,
+                 :visibility_not_allowed,
+                 :invalid_comment_policy,
+                 :invalid_visibility
+               ] ->
+            policy_error(conn, reason)
+
           {:error, %Ecto.Changeset{} = changeset} ->
             errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
             conn |> put_status(422) |> json(%{error: "Validation failed", details: errors})
@@ -126,6 +146,15 @@ defmodule CritWeb.ApiController do
 
   def create(conn, _params) do
     conn |> put_status(422) |> json(%{error: "content is required"})
+  end
+
+  def share_policy(conn, _params) do
+    policy = Settings.share_policy()
+
+    json(conn, %{
+      allowed_comment_policies: policy.allowed_comment_policies,
+      allowed_review_visibilities: policy.allowed_review_visibilities
+    })
   end
 
   def document(conn, %{"token" => token}) do
@@ -221,26 +250,10 @@ defmodule CritWeb.ApiController do
 
     case Reviews.upsert_review(scope, token, delete_token, payload) do
       {:ok, :updated, review} ->
-        review = maybe_update_comment_policy(scope, review, params)
-        url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
-
-        json(conn, %{
-          url: url,
-          review_round: review.review_round,
-          changed: true,
-          comment_policy: review.comment_policy
-        })
+        respond_with_upsert(conn, scope, review, params, true)
 
       {:ok, :no_changes, review} ->
-        review = maybe_update_comment_policy(scope, review, params)
-        url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
-
-        json(conn, %{
-          url: url,
-          review_round: review.review_round,
-          changed: false,
-          comment_policy: review.comment_policy
-        })
+        respond_with_upsert(conn, scope, review, params, false)
 
       {:error, :not_found} ->
         not_found(conn)
@@ -250,22 +263,55 @@ defmodule CritWeb.ApiController do
     end
   end
 
+  defp respond_with_upsert(conn, scope, review, params, changed) do
+    case maybe_update_comment_policy(scope, review, params) do
+      {:ok, review} ->
+        url = CritWeb.Endpoint.url() <> ~p"/r/#{review.token}"
+
+        json(conn, %{
+          url: url,
+          review_round: review.review_round,
+          changed: changed,
+          comment_policy: review.comment_policy
+        })
+
+      {:error, :comment_policy_not_allowed} ->
+        policy_error(conn, :comment_policy_not_allowed)
+    end
+  end
+
   defp maybe_update_comment_policy(scope, review, %{"comment_policy" => raw})
        when is_binary(raw) do
     with {:ok, policy} <- parse_comment_policy(raw),
          {:ok, updated} <- Reviews.update_review(scope, review.id, %{comment_policy: policy}) do
-      updated
+      {:ok, updated}
     else
-      _ -> review
+      {:error, :comment_policy_not_allowed} -> {:error, :comment_policy_not_allowed}
+      _ -> {:ok, review}
     end
   end
 
-  defp maybe_update_comment_policy(_scope, review, _params), do: review
+  defp maybe_update_comment_policy(_scope, review, _params), do: {:ok, review}
 
   defp parse_comment_policy("open"), do: {:ok, :open}
   defp parse_comment_policy("logged_in_only"), do: {:ok, :logged_in_only}
   defp parse_comment_policy("disallowed"), do: {:ok, :disallowed}
   defp parse_comment_policy(_), do: :error
+
+  defp policy_error(conn, :comment_policy_not_allowed),
+    do: conn |> put_status(422) |> json(%{error: "Comment mode is not allowed on this instance"})
+
+  defp policy_error(conn, :visibility_not_allowed),
+    do:
+      conn
+      |> put_status(422)
+      |> json(%{error: "Review visibility is not allowed on this instance"})
+
+  defp policy_error(conn, :invalid_comment_policy),
+    do: conn |> put_status(422) |> json(%{error: "Invalid comment policy"})
+
+  defp policy_error(conn, :invalid_visibility),
+    do: conn |> put_status(422) |> json(%{error: "Invalid visibility"})
 
   def delete_review(conn, %{"delete_token" => delete_token})
       when is_binary(delete_token) and delete_token != "" do
@@ -442,7 +488,8 @@ defmodule CritWeb.ApiController do
   defp parse_visibility("unlisted"), do: :unlisted
   defp parse_visibility("public"), do: :public
   defp parse_visibility("organization"), do: :organization
-  defp parse_visibility(_), do: nil
+  defp parse_visibility(nil), do: nil
+  defp parse_visibility(value), do: value
 
   defp parse_review_type("preview"), do: "preview"
   defp parse_review_type(_), do: "files"

--- a/lib/crit_web/live/admin_settings_live.ex
+++ b/lib/crit_web/live/admin_settings_live.ex
@@ -20,6 +20,8 @@ defmodule CritWeb.AdminSettingsLive do
 
   @impl true
   def handle_event("validate", %{"setting" => params}, socket) do
+    params = normalize_policy_params(params)
+
     changeset =
       socket.assigns.setting
       |> Settings.change(params)
@@ -30,6 +32,8 @@ defmodule CritWeb.AdminSettingsLive do
 
   @impl true
   def handle_event("save", %{"setting" => params}, socket) do
+    params = normalize_policy_params(params)
+
     case Settings.update(params) do
       {:ok, setting} ->
         {:noreply,
@@ -53,5 +57,11 @@ defmodule CritWeb.AdminSettingsLive do
     }
 
     to_form(Settings.change(setting), as: "setting")
+  end
+
+  defp normalize_policy_params(params) do
+    params
+    |> Map.put_new("allowed_comment_policies", [])
+    |> Map.put_new("allowed_review_visibilities", [])
   end
 end

--- a/lib/crit_web/live/admin_settings_live.html.heex
+++ b/lib/crit_web/live/admin_settings_live.html.heex
@@ -141,6 +141,112 @@
         </p>
       </div>
 
+      <div class="border-t border-(--crit-border) pt-6">
+        <fieldset>
+          <legend class="block text-sm font-medium text-(--crit-fg-primary) mb-2">
+            Allowed comment modes for new shared reviews
+          </legend>
+          <% selected_comment_policies =
+            Enum.map(@form[:allowed_comment_policies].value || [], &to_string/1) %>
+          <div class="flex flex-col gap-2">
+            <label
+              :for={
+                {value, label} <- [
+                  {"open", "Open"},
+                  {"logged_in_only", "Login required"},
+                  {"disallowed", "Disabled"}
+                ]
+              }
+              class="flex items-center gap-2 text-sm text-(--crit-fg-secondary)"
+            >
+              <input
+                type="checkbox"
+                name="setting[allowed_comment_policies][]"
+                value={value}
+                checked={value in selected_comment_policies}
+                disabled={
+                  length(selected_comment_policies) == 1 and value in selected_comment_policies
+                }
+                class="size-4 rounded border-(--crit-border) bg-(--crit-bg-page) text-(--crit-brand) focus:ring-(--crit-brand)"
+              />
+              <input
+                :if={
+                  length(selected_comment_policies) == 1 and value in selected_comment_policies
+                }
+                type="hidden"
+                name="setting[allowed_comment_policies][]"
+                value={value}
+              />
+              <span>{label}</span>
+            </label>
+          </div>
+          <p class="mt-1.5 text-xs text-(--crit-fg-muted)">
+            Share clients should disable modes not selected here. At least one mode must remain allowed.
+          </p>
+          <p
+            :for={err <- @form[:allowed_comment_policies].errors}
+            :if={Phoenix.Component.used_input?(@form[:allowed_comment_policies])}
+            class="mt-1.5 text-xs text-red-500"
+          >
+            {CritWeb.CoreComponents.translate_error(err)}
+          </p>
+        </fieldset>
+      </div>
+
+      <div>
+        <fieldset>
+          <legend class="block text-sm font-medium text-(--crit-fg-primary) mb-2">
+            Allowed visibility for new shared reviews
+          </legend>
+          <% selected_review_visibilities =
+            Enum.map(@form[:allowed_review_visibilities].value || [], &to_string/1) %>
+          <div class="flex flex-col gap-2">
+            <label
+              :for={
+                {value, label} <- [
+                  {"unlisted", "Unlisted"},
+                  {"public", "Public"},
+                  {"organization", "Organization"}
+                ]
+              }
+              class="flex items-center gap-2 text-sm text-(--crit-fg-secondary)"
+            >
+              <input
+                type="checkbox"
+                name="setting[allowed_review_visibilities][]"
+                value={value}
+                checked={value in selected_review_visibilities}
+                disabled={
+                  length(selected_review_visibilities) == 1 and
+                    value in selected_review_visibilities
+                }
+                class="size-4 rounded border-(--crit-border) bg-(--crit-bg-page) text-(--crit-brand) focus:ring-(--crit-brand)"
+              />
+              <input
+                :if={
+                  length(selected_review_visibilities) == 1 and
+                    value in selected_review_visibilities
+                }
+                type="hidden"
+                name="setting[allowed_review_visibilities][]"
+                value={value}
+              />
+              <span>{label}</span>
+            </label>
+          </div>
+          <p class="mt-1.5 text-xs text-(--crit-fg-muted)">
+            Organization visibility applies only to reviews shared to an organization.
+          </p>
+          <p
+            :for={err <- @form[:allowed_review_visibilities].errors}
+            :if={Phoenix.Component.used_input?(@form[:allowed_review_visibilities])}
+            class="mt-1.5 text-xs text-red-500"
+          >
+            {CritWeb.CoreComponents.translate_error(err)}
+          </p>
+        </fieldset>
+      </div>
+
       <div>
         <button
           type="submit"

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -4,6 +4,7 @@ defmodule CritWeb.ReviewLive do
   alias Crit.Accounts.Scope
   alias Crit.Review
   alias Crit.Reviews
+  alias Crit.Settings
 
   # Auth is gated by the router's :require_review_scope on_mount hook
   # (CritWeb.UserAuth), which also assigns :current_scope. On selfhosted+OAuth,
@@ -133,6 +134,7 @@ defmodule CritWeb.ReviewLive do
          |> assign(:canonical_url, canonical_url)
          |> assign(:owner?, owner?)
          |> assign(:comment_policy, review.comment_policy)
+         |> assign(:share_policy, Settings.share_policy())
          |> assign(:can_comment?, can_comment?(scope, review))
          |> assign(:current_path, ~p"/r/#{review.token}"), layout: {CritWeb.Layouts, :review}}
     end
@@ -156,6 +158,9 @@ defmodule CritWeb.ReviewLive do
 
       {:error, :already_public} ->
         {:noreply, put_flash(socket, :info, "Review is already public.")}
+
+      {:error, :visibility_not_allowed} ->
+        {:noreply, put_flash(socket, :error, "Public reviews are disabled on this instance.")}
 
       {:error, :unauthorized} ->
         {:noreply, put_flash(socket, :error, "Not allowed.")}
@@ -189,6 +194,9 @@ defmodule CritWeb.ReviewLive do
 
       {:error, :not_found} ->
         {:noreply, put_flash(socket, :error, "Review not found.")}
+
+      {:error, :comment_policy_not_allowed} ->
+        {:noreply, put_flash(socket, :error, "That comment mode is disabled on this instance.")}
 
       {:error, %Ecto.Changeset{}} ->
         {:noreply, put_flash(socket, :error, "Could not update the comment policy.")}

--- a/lib/crit_web/live/review_live.html.heex
+++ b/lib/crit_web/live/review_live.html.heex
@@ -387,7 +387,7 @@
       >
         <:actions>
           <%= cond do %>
-            <% owner? and @review.visibility == :unlisted -> %>
+            <% owner? and @review.visibility == :unlisted and :public in @share_policy.allowed_review_visibilities -> %>
               <CritWeb.Components.PopoverMenu.popover_menu
                 id="visibility-menu"
                 test_prefix="visibility"
@@ -475,15 +475,23 @@
                   <.icon name="hero-chevron-down" class="size-3" />
                 </:trigger>
                 <%= for option <- [:open, :logged_in_only, :disallowed] do %>
+                  <% allowed? = option in @share_policy.allowed_comment_policies %>
                   <button
                     type="button"
                     phx-click={
-                      CritWeb.Components.PopoverMenu.close_js("comment-policy-menu")
-                      |> Phoenix.LiveView.JS.push("update_comment_policy")
+                      if allowed? do
+                        CritWeb.Components.PopoverMenu.close_js("comment-policy-menu")
+                        |> Phoenix.LiveView.JS.push("update_comment_policy")
+                      end
                     }
                     phx-value-policy={option}
                     data-test={"comment-policy-set-#{option}"}
-                    class="crit-comment-policy-option"
+                    disabled={!allowed?}
+                    title={if allowed?, do: nil, else: "Disabled by instance policy"}
+                    class={[
+                      "crit-comment-policy-option",
+                      if(!allowed?, do: "opacity-50 cursor-not-allowed")
+                    ]}
                     aria-current={@comment_policy == option}
                   >
                     <div class="crit-comment-policy-option-icon">

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -205,6 +205,13 @@ defmodule CritWeb.Router do
     post "/token", DeviceApiController, :token
   end
 
+  scope "/api", CritWeb do
+    pipe_through [:device_api, :noindex, CritWeb.Plugs.LocalhostCors]
+
+    options "/share-policy", ApiController, :options
+    get "/share-policy", ApiController, :share_policy
+  end
+
   # Auth API — always requires Bearer token
   scope "/api/auth", CritWeb do
     pipe_through [:auth_api, :noindex]

--- a/priv/repo/migrations/20260708120000_add_share_policy_to_settings.exs
+++ b/priv/repo/migrations/20260708120000_add_share_policy_to_settings.exs
@@ -1,0 +1,25 @@
+defmodule Crit.Repo.Migrations.AddSharePolicyToSettings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:settings) do
+      add :allowed_comment_policies, {:array, :string},
+        null: false,
+        default: ["open", "logged_in_only", "disallowed"]
+
+      add :allowed_review_visibilities, {:array, :string},
+        null: false,
+        default: ["unlisted", "public", "organization"]
+    end
+
+    create constraint(:settings, :allowed_comment_policies_must_be_valid,
+             check:
+               "allowed_comment_policies <@ ARRAY['open','logged_in_only','disallowed']::varchar[] AND cardinality(allowed_comment_policies) >= 1"
+           )
+
+    create constraint(:settings, :allowed_review_visibilities_must_be_valid,
+             check:
+               "allowed_review_visibilities <@ ARRAY['unlisted','public','organization']::varchar[] AND cardinality(allowed_review_visibilities) >= 1"
+           )
+  end
+end

--- a/test/crit/reviews_comment_policy_test.exs
+++ b/test/crit/reviews_comment_policy_test.exs
@@ -3,6 +3,7 @@ defmodule Crit.ReviewsCommentPolicyTest do
 
   alias Crit.Accounts.Scope
   alias Crit.Reviews
+  alias Crit.Settings
 
   defp owner_user_fixture do
     {:ok, user} =
@@ -25,6 +26,20 @@ defmodule Crit.ReviewsCommentPolicyTest do
       )
 
     review
+  end
+
+  defp update_share_policy(attrs) do
+    setting = Settings.get()
+
+    Settings.update(%{
+      "max_document_mb" => Crit.Setting.bytes_to_mb(setting.max_document_bytes),
+      "max_comments_per_review" => setting.max_comments_per_review,
+      "max_comment_body_kb" => Crit.Setting.bytes_to_kb(setting.max_comment_body_bytes),
+      "allowed_comment_policies" =>
+        Map.get(attrs, :allowed_comment_policies, setting.allowed_comment_policies),
+      "allowed_review_visibilities" =>
+        Map.get(attrs, :allowed_review_visibilities, setting.allowed_review_visibilities)
+    })
   end
 
   # Subscribe to the review topic from a separate process and forward all
@@ -129,6 +144,19 @@ defmodule Crit.ReviewsCommentPolicyTest do
 
       assert {:error, %Ecto.Changeset{}} =
                Reviews.update_review(Scope.for_user(user), review.id, %{comment_policy: :bogus})
+    end
+
+    test "owner cannot change to a comment_policy disabled by instance policy" do
+      {:ok, _} = update_share_policy(%{allowed_comment_policies: ["open", "logged_in_only"]})
+      user = owner_user_fixture()
+      review = create_review_for(user)
+
+      assert {:error, :comment_policy_not_allowed} =
+               Reviews.update_review(Scope.for_user(user), review.id, %{
+                 comment_policy: :disallowed
+               })
+
+      assert Reviews.get_by_token(review.token).comment_policy == :open
     end
 
     test "unknown attrs keys are silently dropped by the changeset cast list" do

--- a/test/crit/reviews_visibility_test.exs
+++ b/test/crit/reviews_visibility_test.exs
@@ -3,6 +3,7 @@ defmodule Crit.ReviewsVisibilityTest do
 
   alias Crit.Accounts.Scope
   alias Crit.Reviews
+  alias Crit.Settings
 
   defp owner_user_fixture do
     {:ok, user} =
@@ -27,6 +28,20 @@ defmodule Crit.ReviewsVisibilityTest do
     review
   end
 
+  defp update_share_policy(attrs) do
+    setting = Settings.get()
+
+    Settings.update(%{
+      "max_document_mb" => Crit.Setting.bytes_to_mb(setting.max_document_bytes),
+      "max_comments_per_review" => setting.max_comments_per_review,
+      "max_comment_body_kb" => Crit.Setting.bytes_to_kb(setting.max_comment_body_bytes),
+      "allowed_comment_policies" =>
+        Map.get(attrs, :allowed_comment_policies, setting.allowed_comment_policies),
+      "allowed_review_visibilities" =>
+        Map.get(attrs, :allowed_review_visibilities, setting.allowed_review_visibilities)
+    })
+  end
+
   test "owner can promote an unlisted review to :public" do
     user = owner_user_fixture()
     scope = Scope.for_user(user)
@@ -44,6 +59,29 @@ defmodule Crit.ReviewsVisibilityTest do
 
     {:ok, _} = Reviews.make_public(scope, review.id)
     assert {:error, :already_public} = Reviews.make_public(scope, review.id)
+  end
+
+  test "make_public/2 returns :visibility_not_allowed when public is disabled" do
+    {:ok, _} = update_share_policy(%{allowed_review_visibilities: ["unlisted"]})
+    user = owner_user_fixture()
+    scope = Scope.for_user(user)
+    review = create_review_for(user)
+
+    assert {:error, :visibility_not_allowed} = Reviews.make_public(scope, review.id)
+    assert Reviews.get_by_token(review.token).visibility == :unlisted
+  end
+
+  test "create_review/6 rejects personal review when only organization visibility is allowed" do
+    {:ok, _} = update_share_policy(%{allowed_review_visibilities: ["organization"]})
+    user = owner_user_fixture()
+
+    assert {:error, :visibility_not_allowed} =
+             Reviews.create_review(
+               Scope.for_user(user),
+               [%{"path" => "a.md", "content" => "x"}],
+               0,
+               []
+             )
   end
 
   test "non-owner authenticated user cannot promote" do

--- a/test/crit/settings_test.exs
+++ b/test/crit/settings_test.exs
@@ -10,6 +10,8 @@ defmodule Crit.SettingsTest do
       assert is_integer(setting.max_document_bytes)
       assert is_integer(setting.max_comments_per_review)
       assert is_integer(setting.max_comment_body_bytes)
+      assert setting.allowed_comment_policies == [:open, :logged_in_only, :disallowed]
+      assert setting.allowed_review_visibilities == [:unlisted, :public, :organization]
     end
   end
 
@@ -19,13 +21,17 @@ defmodule Crit.SettingsTest do
         Settings.update(%{
           "max_document_mb" => 5,
           "max_comments_per_review" => 100,
-          "max_comment_body_kb" => 50
+          "max_comment_body_kb" => 50,
+          "allowed_comment_policies" => ["open", "disallowed"],
+          "allowed_review_visibilities" => ["unlisted"]
         })
 
       assert updated.id == 1
       assert updated.max_document_bytes == 5 * 1_048_576
       assert updated.max_comments_per_review == 100
       assert updated.max_comment_body_bytes == 50 * 1024
+      assert updated.allowed_comment_policies == [:open, :disallowed]
+      assert updated.allowed_review_visibilities == [:unlisted]
     end
 
     test "fractional MB rounds to bytes" do
@@ -37,6 +43,35 @@ defmodule Crit.SettingsTest do
         })
 
       assert updated.max_document_bytes == round(1.5 * 1_048_576)
+    end
+
+    test "rejects empty policy allow-lists" do
+      assert {:error, changeset} =
+               Settings.update(%{
+                 "max_document_mb" => 10,
+                 "max_comments_per_review" => 100,
+                 "max_comment_body_kb" => 50,
+                 "allowed_comment_policies" => [],
+                 "allowed_review_visibilities" => []
+               })
+
+      refute changeset.valid?
+      assert {_msg, _} = changeset.errors[:allowed_comment_policies]
+      assert {_msg, _} = changeset.errors[:allowed_review_visibilities]
+    end
+
+    test "rejects invalid policy values" do
+      assert {:error, changeset} =
+               Settings.update(%{
+                 "max_document_mb" => 10,
+                 "max_comments_per_review" => 100,
+                 "max_comment_body_kb" => 50,
+                 "allowed_comment_policies" => ["open", "bogus"],
+                 "allowed_review_visibilities" => ["public"]
+               })
+
+      refute changeset.valid?
+      assert {_msg, _} = changeset.errors[:allowed_comment_policies]
     end
 
     test "rejects zero" do
@@ -74,9 +109,40 @@ defmodule Crit.SettingsTest do
           id: 2,
           max_document_bytes: 1,
           max_comments_per_review: 1,
-          max_comment_body_bytes: 1
+          max_comment_body_bytes: 1,
+          allowed_comment_policies: [:open],
+          allowed_review_visibilities: [:organization]
         })
       end
+    end
+  end
+
+  describe "share policy helpers" do
+    test "choose old defaults when still allowed, otherwise the first allowed value" do
+      {:ok, setting} =
+        Settings.update(%{
+          "max_document_mb" => 10,
+          "max_comments_per_review" => 100,
+          "max_comment_body_kb" => 50,
+          "allowed_comment_policies" => ["logged_in_only", "disallowed"],
+          "allowed_review_visibilities" => ["public"]
+        })
+
+      assert Settings.default_comment_policy(setting) == :logged_in_only
+      assert Settings.default_visibility(setting) == :public
+    end
+
+    test "personal default visibility ignores organization-only policy" do
+      {:ok, setting} =
+        Settings.update(%{
+          "max_document_mb" => 10,
+          "max_comments_per_review" => 100,
+          "max_comment_body_kb" => 50,
+          "allowed_comment_policies" => ["open"],
+          "allowed_review_visibilities" => ["organization"]
+        })
+
+      assert Settings.default_visibility(setting) == nil
     end
   end
 end

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -882,6 +882,7 @@ defmodule CritWeb.ApiControllerTest do
 
       conn =
         conn
+        |> unique_ip()
         |> put_req_header("authorization", "Bearer " <> plaintext)
         |> put_req_header("content-type", "application/json")
         |> put("/api/reviews/#{review.token}", %{
@@ -909,6 +910,7 @@ defmodule CritWeb.ApiControllerTest do
 
       conn =
         conn
+        |> unique_ip()
         |> put_req_header("authorization", "Bearer " <> plaintext)
         |> put_req_header("content-type", "application/json")
         |> put("/api/reviews/#{review.token}", %{

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -896,6 +896,66 @@ defmodule CritWeb.ApiControllerTest do
       assert Reviews.get_by_token(review.token).comment_policy == :logged_in_only
     end
 
+    test "owner PUT rejects invalid comment_policy", %{conn: conn} do
+      {user, plaintext} = owner_with_token()
+
+      {:ok, review} =
+        Reviews.create_review(
+          Scope.for_user(user),
+          [%{"path" => "p.md", "content" => "x"}],
+          1,
+          []
+        )
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer " <> plaintext)
+        |> put_req_header("content-type", "application/json")
+        |> put("/api/reviews/#{review.token}", %{
+          delete_token: review.delete_token,
+          files: [%{path: "p.md", content: "y"}],
+          comments: [],
+          review_round: 1,
+          comment_policy: "invalid"
+        })
+
+      assert json_response(conn, 422)["error"] =~ "Invalid comment policy"
+    end
+
+    test "owner PUT rejects disabled comment_policy before mutating review content", %{conn: conn} do
+      {user, plaintext} = owner_with_token()
+      {:ok, _} = update_share_policy(%{allowed_comment_policies: ["open", "logged_in_only"]})
+
+      {:ok, review} =
+        Reviews.create_review(
+          Scope.for_user(user),
+          [%{"path" => "p.md", "content" => "x"}],
+          1,
+          []
+        )
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer " <> plaintext)
+        |> put_req_header("content-type", "application/json")
+        |> put("/api/reviews/#{review.token}", %{
+          delete_token: review.delete_token,
+          files: [%{path: "p.md", content: "y"}],
+          comments: [],
+          review_round: 1,
+          comment_policy: "disallowed"
+        })
+
+      assert json_response(conn, 422)["error"] =~ "Comment mode"
+
+      persisted = Reviews.get_by_token(review.token)
+      assert persisted.review_round == review.review_round
+      assert persisted.comment_policy == :open
+
+      conn = get(build_conn(), ~p"/api/reviews/#{review.token}/document")
+      assert %{"files" => [%{"content" => "x"}]} = json_response(conn, 200)
+    end
+
     test "non-owner cannot set comment_policy via PUT (field silently ignored)", %{conn: conn} do
       review = create_review()
 

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -3,8 +3,28 @@ defmodule CritWeb.ApiControllerTest do
 
   alias Crit.Accounts.Scope
   alias Crit.Reviews
+  alias Crit.Settings
 
   defp anon_scope, do: Scope.for_visitor("api-test-#{System.unique_integer([:positive])}")
+
+  defp unique_ip(conn) do
+    n = System.unique_integer([:positive])
+    %{conn | remote_ip: {10, rem(n, 250), rem(div(n, 250), 250), rem(div(n, 62_500), 250)}}
+  end
+
+  defp update_share_policy(attrs) do
+    setting = Settings.get()
+
+    Settings.update(%{
+      "max_document_mb" => Crit.Setting.bytes_to_mb(setting.max_document_bytes),
+      "max_comments_per_review" => setting.max_comments_per_review,
+      "max_comment_body_kb" => Crit.Setting.bytes_to_kb(setting.max_comment_body_bytes),
+      "allowed_comment_policies" =>
+        Map.get(attrs, :allowed_comment_policies, setting.allowed_comment_policies),
+      "allowed_review_visibilities" =>
+        Map.get(attrs, :allowed_review_visibilities, setting.allowed_review_visibilities)
+    })
+  end
 
   defp create_review do
     {:ok, review} =
@@ -29,6 +49,23 @@ defmodule CritWeb.ApiControllerTest do
       assert %{"url" => url, "delete_token" => token} = json_response(conn, 201)
       assert String.contains?(url, "/r/")
       assert String.length(token) == 21
+    end
+  end
+
+  describe "GET /api/share-policy" do
+    test "returns instance share option allow-lists", %{conn: conn} do
+      {:ok, _} =
+        update_share_policy(%{
+          allowed_comment_policies: ["logged_in_only", "disallowed"],
+          allowed_review_visibilities: ["public", "organization"]
+        })
+
+      conn = get(conn, ~p"/api/share-policy")
+
+      assert json_response(conn, 200) == %{
+               "allowed_comment_policies" => ["logged_in_only", "disallowed"],
+               "allowed_review_visibilities" => ["public", "organization"]
+             }
     end
   end
 
@@ -896,18 +933,104 @@ defmodule CritWeb.ApiControllerTest do
       assert Reviews.get_by_token(token).comment_policy == :logged_in_only
     end
 
-    test "anonymous POST /api/reviews silently ignores comment_policy", %{conn: conn} do
+    test "anonymous POST /api/reviews can set an allowed comment_policy at creation", %{
+      conn: conn
+    } do
       conn =
-        post(conn, ~p"/api/reviews", %{
+        conn
+        |> unique_ip()
+        |> post(~p"/api/reviews", %{
           files: [%{path: "a.md", content: "x"}],
           comments: [],
           comment_policy: "disallowed"
         })
 
       body = json_response(conn, 201)
-      assert body["comment_policy"] == "open"
+      assert body["comment_policy"] == "disallowed"
       token = body["url"] |> String.split("/r/") |> List.last()
-      assert Reviews.get_by_token(token).comment_policy == :open
+      assert Reviews.get_by_token(token).comment_policy == :disallowed
+    end
+
+    test "POST /api/reviews rejects a comment_policy disabled by instance policy", %{conn: conn} do
+      {:ok, _} = update_share_policy(%{allowed_comment_policies: ["open", "logged_in_only"]})
+
+      conn =
+        conn
+        |> unique_ip()
+        |> post(~p"/api/reviews", %{
+          files: [%{path: "a.md", content: "x"}],
+          comments: [],
+          comment_policy: "disallowed"
+        })
+
+      assert json_response(conn, 422)["error"] =~ "Comment mode"
+    end
+
+    test "POST /api/reviews defaults to the first allowed comment_policy when open is disabled",
+         %{
+           conn: conn
+         } do
+      {:ok, _} =
+        update_share_policy(%{allowed_comment_policies: ["logged_in_only", "disallowed"]})
+
+      conn =
+        conn
+        |> unique_ip()
+        |> post(~p"/api/reviews", %{
+          files: [%{path: "a.md", content: "x"}],
+          comments: []
+        })
+
+      body = json_response(conn, 201)
+      assert body["comment_policy"] == "logged_in_only"
+      token = body["url"] |> String.split("/r/") |> List.last()
+      assert Reviews.get_by_token(token).comment_policy == :logged_in_only
+    end
+
+    test "POST /api/reviews rejects visibility disabled by instance policy", %{conn: conn} do
+      {:ok, _} = update_share_policy(%{allowed_review_visibilities: ["unlisted"]})
+
+      conn =
+        conn
+        |> unique_ip()
+        |> post(~p"/api/reviews", %{
+          files: [%{path: "a.md", content: "x"}],
+          comments: [],
+          visibility: "public"
+        })
+
+      assert json_response(conn, 422)["error"] =~ "visibility"
+    end
+
+    test "POST /api/reviews defaults to public when unlisted is disabled", %{conn: conn} do
+      {:ok, _} = update_share_policy(%{allowed_review_visibilities: ["public"]})
+
+      conn =
+        conn
+        |> unique_ip()
+        |> post(~p"/api/reviews", %{
+          files: [%{path: "a.md", content: "x"}],
+          comments: []
+        })
+
+      body = json_response(conn, 201)
+      token = body["url"] |> String.split("/r/") |> List.last()
+      assert Reviews.get_by_token(token).visibility == :public
+    end
+
+    test "POST /api/reviews rejects personal share when only organization visibility is allowed",
+         %{conn: conn} do
+      {:ok, _} = update_share_policy(%{allowed_review_visibilities: ["organization"]})
+
+      conn =
+        conn
+        |> unique_ip()
+        |> post(~p"/api/reviews", %{
+          files: [%{path: "a.md", content: "x"}],
+          comments: []
+        })
+
+      assert json_response(conn, 422)["error"] =~ "visibility"
     end
   end
 
@@ -1024,6 +1147,26 @@ defmodule CritWeb.ApiControllerTest do
         })
 
       assert json_response(conn, 403)["error"] =~ "not a member"
+    end
+
+    test "create returns 422 when organization visibility is disabled", %{
+      conn: conn,
+      admin: admin,
+      org: org
+    } do
+      {:ok, _} = update_share_policy(%{allowed_review_visibilities: ["unlisted", "public"]})
+      {:ok, {plaintext, _}} = Crit.Accounts.create_token(admin, "test")
+
+      conn =
+        conn
+        |> unique_ip()
+        |> put_req_header("authorization", "Bearer " <> plaintext)
+        |> post(~p"/api/reviews", %{
+          files: [%{path: "a.md", content: "x"}],
+          org: org.slug
+        })
+
+      assert json_response(conn, 422)["error"] =~ "visibility"
     end
   end
 

--- a/test/crit_web/controllers/share_receiver_controller_test.exs
+++ b/test/crit_web/controllers/share_receiver_controller_test.exs
@@ -25,5 +25,15 @@ defmodule CritWeb.ShareReceiverControllerTest do
       html = conn |> get(~p"/share-receiver") |> html_response(200)
       assert html =~ "/assets/js/share_receiver"
     end
+
+    test "source exposes share policy relay operation" do
+      root = File.cwd!()
+      index = File.read!(Path.join(root, "assets/js/share_receiver/index.js"))
+      handlers = File.read!(Path.join(root, "assets/js/share_receiver/handlers.js"))
+
+      assert index =~ "sharePolicy: handlers.sharePolicy"
+      assert handlers =~ "export async function sharePolicy"
+      assert handlers =~ "/api/share-policy"
+    end
   end
 end


### PR DESCRIPTION
## Summary
- add configurable instance share policy settings for allowed review visibilities and comment policies
- expose `GET /api/share-policy` and enforce configured policy on review create/update/commenting paths
- add admin settings controls plus review/share UI filtering and proxy-auth share receiver relay support

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Red-team pass: passed

## Test plan
- `mise exec -- mix format ...`
- `node --input-type=module --check < assets/js/share_receiver/handlers.js`
- `node --input-type=module --check < assets/js/share_receiver/index.js`
- `mise exec -- mix test test/crit_web/controllers/api_controller_test.exs:899 test/crit_web/controllers/api_controller_test.exs:924 test/crit_web/controllers/api_controller_test.exs:950 test/crit_web/controllers/share_receiver_controller_test.exs`
- `mise run db:start && mise exec -- mix precommit`
- `npm install --prefix assets && mise exec -- mix assets.build`
- `mise run e2e`

See also: https://github.com/tomasz-tomczyk/crit/pull/734