### PR TITLE
chore: align review renderer dependencies

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -14,8 +14,8 @@
         "@tailwindcss/typography": "^0.5.19",
         "highlight.js": "^11.11.1",
         "highlightjs-heex": "^1.0.1",
-        "markdown-it": "^14.2.0",
-        "mermaid": "^11.15.0"
+        "markdown-it": "^14.3.0",
+        "mermaid": "^11.16.0"
       }
     },
     "node_modules/@antfu/install-pkg": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -16,7 +16,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "highlight.js": "^11.11.1",
     "highlightjs-heex": "^1.0.1",
-    "markdown-it": "^14.2.0",
-    "mermaid": "^11.15.0"
+    "markdown-it": "^14.3.0",
+    "mermaid": "^11.16.0"
   }
 }


### PR DESCRIPTION
## Summary
- align markdown-it and Mermaid with the versions embedded by crit
- keep local and hosted review rendering dependencies in sync

## Review
- [x] Code review: passed
- [x] Parity audit: passed

## Test plan
- `mise exec -- mix precommit` (1,072 tests)
- `npm ls markdown-it mermaid highlight.js`

See also: tomasz-tomczyk/crit#739
