### PR TITLE
fix: recover LiveView mutations after disconnects

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -72,33 +72,66 @@ function initSentry(liveSocket) {
     const socket = liveSocket?.getSocket?.()
     if (socket) {
       const PERSISTENCE_MS = 5000
-      const STALE_TAB_MS = 30 * 60 * 1000
       const MIN_CONSECUTIVE_ERRORS = 3
       let pendingTimer = null
       let consecutiveErrors = 0
       let firstErrorAt = null
       let lastOpenAt = Date.now()
+      let lastActivityAt = Date.now()
+      let reportedForOutage = false
+
+      const noteActivity = () => { lastActivityAt = Date.now() }
+      for (const event of ["pointerdown", "keydown", "touchstart", "focus"]) {
+        window.addEventListener(event, noteActivity, { passive: true })
+      }
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible") noteActivity()
+      })
+
+      const resetOutage = () => {
+        consecutiveErrors = 0
+        firstErrorAt = null
+        reportedForOutage = false
+        if (pendingTimer !== null) {
+          clearTimeout(pendingTimer)
+          pendingTimer = null
+        }
+      }
+      window.addEventListener("crit:liveview-connected", resetOutage)
 
       socket.onError(err => {
         const msg = String(err?.message ?? err)
         if (msg === "410") return
         consecutiveErrors += 1
         if (firstErrorAt === null) firstErrorAt = Date.now()
-        if (pendingTimer !== null) return
+        if (pendingTimer !== null || reportedForOutage) return
         const errSnapshot = err
         pendingTimer = setTimeout(() => {
           pendingTimer = null
           const msSinceOpen = lastOpenAt ? Date.now() - lastOpenAt : null
-          if (msSinceOpen !== null && msSinceOpen > STALE_TAB_MS) return
+          const msSinceActivity = Date.now() - lastActivityAt
           if (consecutiveErrors < MIN_CONSECUTIVE_ERRORS) return
+          // Background tabs and offline devices routinely lose their socket.
+          // Capture only an active, online session and only once per outage.
+          if (document.visibilityState !== "visible" || !document.hasFocus() ||
+              !navigator.onLine || msSinceActivity > 30 * 60 * 1000) return
+          reportedForOutage = true
+          const transport = socket.transportName?.(socket.transport) ||
+            (socket.transport === LongPoll ? "longpoll" : "websocket")
           Sentry.captureMessage("LiveSocket transport error (persistent)", {
             level: "warning",
+            tags: { liveview_transport: transport },
             extra: {
               type: errSnapshot?.type,
               message: String(errSnapshot?.message ?? errSnapshot),
               consecutive_errors: consecutiveErrors,
+              failure_duration_ms: firstErrorAt ? Date.now() - firstErrorAt : null,
               ms_since_last_open: msSinceOpen,
-              transport: socket.transport?.name || socket.transport?.constructor?.name || null,
+              ms_since_last_activity: msSinceActivity,
+              transport,
+              visibility_state: document.visibilityState,
+              document_has_focus: document.hasFocus(),
+              navigator_online: navigator.onLine,
             },
           })
         }, PERSISTENCE_MS)
@@ -106,12 +139,9 @@ function initSentry(liveSocket) {
 
       socket.onOpen(() => {
         lastOpenAt = Date.now()
-        consecutiveErrors = 0
-        firstErrorAt = null
-        if (pendingTimer !== null) {
-          clearTimeout(pendingTimer)
-          pendingTimer = null
-        }
+        // Review hooks reset only after their LiveView has rejoined. Other
+        // pages have no review hook, so transport open is definitive there.
+        if (!isReviewPage) resetOutage()
       })
     }
   }).catch(() => {})
@@ -434,4 +464,3 @@ if (prefersReducedMotion) {
 if (/^\/articles\/[^/]+$/.test(window.location.pathname)) {
   import("./article-mermaid").then(({ initArticleMermaid }) => initArticleMermaid())
 }
-

--- a/assets/js/comments-panel.js
+++ b/assets/js/comments-panel.js
@@ -211,7 +211,10 @@ export function startInlineBodyEdit(bodyEl, rawText, onSave) {
     e.stopPropagation()
     const v = textarea.value.trim()
     if (!v) return
-    onSave(v)
+    saveBtn.disabled = true
+    Promise.resolve(onSave(v)).then(result => {
+      if (result?.ok === false) saveBtn.disabled = false
+    }).catch(() => { saveBtn.disabled = false })
   })
   textarea.addEventListener('keydown', function(e) {
     if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); e.stopPropagation(); saveBtn.click() }
@@ -262,7 +265,11 @@ export function renderReplyList(comment, adapter) {
         replyDeleteBtn.innerHTML = SVG_DELETE
         replyDeleteBtn.addEventListener('click', function(e) {
           e.stopPropagation()
-          adapter.onDeleteReply(reply.id)
+          if (replyDeleteBtn.disabled) return
+          replyDeleteBtn.disabled = true
+          Promise.resolve(adapter.onDeleteReply(reply.id)).then(result => {
+            if (result?.ok === false) replyDeleteBtn.disabled = false
+          }).catch(() => { replyDeleteBtn.disabled = false })
         })
         replyActions.appendChild(replyDeleteBtn)
       }
@@ -349,9 +356,18 @@ export function createReplyInput(commentId, adapter) {
     const body = textarea.value.trim()
     if (!body) return
     submitBtn.disabled = true
-    adapter.onAddReply(commentId, body)
-    collapse()
-    submitBtn.disabled = false
+    Promise.resolve(adapter.onAddReply(commentId, body)).then(result => {
+      if (result?.ok === false) {
+        submitBtn.disabled = false
+        textarea.focus()
+        return
+      }
+      collapse()
+      submitBtn.disabled = false
+    }).catch(() => {
+      submitBtn.disabled = false
+      textarea.focus()
+    })
   })
 
   textarea.addEventListener('keydown', function(e) {
@@ -457,7 +473,9 @@ export function renderCommentCard(comment, adapter) {
         e.stopPropagation()
         if (resolveBtn.disabled) return
         resolveBtn.disabled = true
-        adapter.onResolve(comment, !isResolved)
+        Promise.resolve(adapter.onResolve(comment, !isResolved)).then(result => {
+          if (result?.ok === false) resolveBtn.disabled = false
+        }).catch(() => { resolveBtn.disabled = false })
       })
       actions.appendChild(resolveBtn)
     }
@@ -468,7 +486,7 @@ export function renderCommentCard(comment, adapter) {
       editBtn.innerHTML = SVG_EDIT
       editBtn.addEventListener('click', function(e) {
         e.stopPropagation()
-        startInlineBodyEdit(bodyEl, comment.body, function(v) { adapter.onEditComment(comment.id, v) })
+        startInlineBodyEdit(bodyEl, comment.body, function(v) { return adapter.onEditComment(comment.id, v) })
       })
       actions.appendChild(editBtn)
     }
@@ -480,7 +498,11 @@ export function renderCommentCard(comment, adapter) {
       deleteBtn.innerHTML = SVG_DELETE
       deleteBtn.addEventListener('click', function(e) {
         e.stopPropagation()
-        adapter.onDelete(comment)
+        if (deleteBtn.disabled) return
+        deleteBtn.disabled = true
+        Promise.resolve(adapter.onDelete(comment)).then(result => {
+          if (result?.ok === false) deleteBtn.disabled = false
+        }).catch(() => { deleteBtn.disabled = false })
       })
       actions.appendChild(deleteBtn)
     }

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -15,6 +15,7 @@ import {
   attachSidebarResizeHandle,
 } from "./comments-panel"
 import { createSettingsPanel } from "./settings-panel"
+import { pushMutation, mutationErrorMessage } from "./liveview-mutation"
 
 // Re-register hljs 'markdown' with patched grammar. Must run before any
 // hljs.highlight() call. See highlight-markdown-patch.js for rationale.
@@ -306,6 +307,24 @@ function showToast(message, duration = 3000) {
     toast.classList.remove('mini-toast-visible')
     trackedSetTimeout(__activeCtx, () => toast.remove(), 300)
   }, duration)
+}
+
+function pushCommentMutation(ctx, event, payload, options = {}) {
+  return pushMutation(ctx, event, payload, {
+    ...options,
+    onError(error) {
+      showToast(mutationErrorMessage(), 5000)
+      if (options.onError) options.onError(error)
+    },
+  })
+}
+
+function setFormSubmitting(ctx, formObj, submitting) {
+  formObj.submitting = submitting
+  const form = ctx.el.querySelector('.comment-form[data-form-key="' + formObj.formKey + '"]')
+  if (!form) return
+  form.setAttribute('aria-busy', String(submitting))
+  form.querySelectorAll('button').forEach(button => { button.disabled = submitting })
 }
 
 // ---- Multi-form helpers -----------------------------------------------------
@@ -655,9 +674,13 @@ function restoreDrafts(ctx) {
         filePath: draft.filePath || null,
       }
       formObj.formKey = formKey(formObj)
+      // A reconnect can deliver init while this exact form is still open or
+      // awaiting acknowledgement. Keep its richer in-memory state (quote,
+      // scope, submitting flag) and retain the durable draft until the
+      // mutation's acknowledged success clears it.
+      if (ctx.activeForms.some(form => form.formKey === formObj.formKey)) continue
       addForm(ctx, formObj)
       restored = true
-      localStorage.removeItem(key)
     } catch (_) {
       localStorage.removeItem(key)
     }
@@ -2928,7 +2951,9 @@ function createCommentElement(comment, ctx) {
     resolveBtn.addEventListener('click', function() {
       if (resolveBtn.disabled) return;
       resolveBtn.disabled = true;
-      ctx.pushEvent("resolve_comment", { id: comment.id, resolved: true })
+      pushCommentMutation(ctx, "resolve_comment", { id: comment.id, resolved: true }, {
+        onError: () => { resolveBtn.disabled = false },
+      })
     })
     actions.appendChild(resolveBtn)
   }
@@ -2951,7 +2976,11 @@ function createCommentElement(comment, ctx) {
     deleteBtn.title = "Delete"
     deleteBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>'
     deleteBtn.addEventListener("click", () => {
-      ctx.pushEvent("delete_comment", { id: comment.id })
+      if (deleteBtn.disabled) return
+      deleteBtn.disabled = true
+      pushCommentMutation(ctx, "delete_comment", { id: comment.id }, {
+        onError: () => { deleteBtn.disabled = false },
+      })
     })
     actions.appendChild(deleteBtn)
   }
@@ -3159,9 +3188,9 @@ function createInlineEditor(comment, formObj, ctx) {
 }
 
 function submitNewComment(body, formObj, ctx) {
-  if (!body.trim()) return
+  if (!body.trim() || formObj.submitting) return
   rememberKeyboardFocusFromForm(ctx, formObj)
-  clearDraft(ctx.reviewToken, formObj)
+  setFormSubmitting(ctx, formObj, true)
   const payload = {
     body: body.trim(),
     file_path: formObj.filePath || null,
@@ -3172,21 +3201,31 @@ function submitNewComment(body, formObj, ctx) {
     payload.end_line = formObj.endLine
   }
   if (formObj.quote) payload.quote = formObj.quote
-  ctx.pushEvent("add_comment", payload)
-  removeForm(ctx, formObj.formKey)
-  if (ctx.activeForms.length === 0) {
-    ctx.selectionStart = null
-    ctx.selectionEnd = null
-  }
-  render(ctx)
+  pushCommentMutation(ctx, "add_comment", payload, {
+    onSuccess: () => {
+      clearDraft(ctx.reviewToken, formObj)
+      removeForm(ctx, formObj.formKey)
+      if (ctx.activeForms.length === 0) {
+        ctx.selectionStart = null
+        ctx.selectionEnd = null
+      }
+      render(ctx)
+    },
+    onError: () => setFormSubmitting(ctx, formObj, false),
+  })
 }
 
 function submitEditComment(id, body, formObj, ctx) {
-  if (!body.trim()) return
+  if (!body.trim() || formObj.submitting) return
   rememberKeyboardFocusFromForm(ctx, formObj)
-  ctx.pushEvent("edit_comment", { id, body: body.trim() })
-  removeForm(ctx, formObj.formKey)
-  render(ctx)
+  setFormSubmitting(ctx, formObj, true)
+  pushCommentMutation(ctx, "edit_comment", { id, body: body.trim() }, {
+    onSuccess: () => {
+      removeForm(ctx, formObj.formKey)
+      render(ctx)
+    },
+    onError: () => setFormSubmitting(ctx, formObj, false),
+  })
 }
 
 // Returns true if the user confirms discarding (or the draft is empty).
@@ -3272,10 +3311,10 @@ function commentCardAdapter(ctx, filePath) {
     canDelete: (c) => canDeleteComment(c, ctx),
     displayName: ctx.displayName,
     collapseOverrides: commentCollapseOverrides,
-    onResolve: (c, resolved) => ctx.pushEvent('resolve_comment', { id: c.id, resolved }),
-    onDelete: (c) => ctx.pushEvent('delete_comment', { id: c.id }),
-    onAddReply: (commentId, body) => ctx.pushEvent('add_reply', { comment_id: commentId, body }),
-    onDeleteReply: (id) => ctx.pushEvent('delete_reply', { id }),
+    onResolve: (c, resolved) => pushCommentMutation(ctx, 'resolve_comment', { id: c.id, resolved }),
+    onDelete: (c) => pushCommentMutation(ctx, 'delete_comment', { id: c.id }),
+    onAddReply: (commentId, body) => pushCommentMutation(ctx, 'add_reply', { comment_id: commentId, body }),
+    onDeleteReply: (id) => pushCommentMutation(ctx, 'delete_reply', { id }),
     onEditReply: (commentId, reply) => editReply(commentId, reply, ctx),
     beforeReplyExpand: () => { closeEmptyReviewForm(ctx); closeEmptyForms(ctx, null) },
     scheduleTimeout: (fn, ms) => trackedSetTimeout(ctx, fn, ms),
@@ -3379,8 +3418,11 @@ function editReply(commentId, reply, ctx) {
 
   saveBtn.addEventListener('click', () => {
     const newBody = textarea.value.trim()
-    if (!newBody) return
-    ctx.pushEvent("edit_reply", { id: reply.id, body: newBody })
+    if (!newBody || saveBtn.disabled) return
+    saveBtn.disabled = true
+    pushCommentMutation(ctx, "edit_reply", { id: reply.id, body: newBody }, {
+      onError: () => { saveBtn.disabled = false },
+    })
   })
 
   textarea.addEventListener('keydown', function(e) {
@@ -3468,7 +3510,9 @@ function createResolvedElement(comment, ctx) {
     unresolveBtn.addEventListener('click', function() {
       if (unresolveBtn.disabled) return;
       unresolveBtn.disabled = true;
-      ctx.pushEvent("resolve_comment", { id: comment.id, resolved: false })
+      pushCommentMutation(ctx, "resolve_comment", { id: comment.id, resolved: false }, {
+        onError: () => { unresolveBtn.disabled = false },
+      })
     })
     actions.appendChild(unresolveBtn)
   }
@@ -3479,7 +3523,11 @@ function createResolvedElement(comment, ctx) {
     deleteBtn.title = 'Delete'
     deleteBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>'
     deleteBtn.addEventListener('click', function() {
-      ctx.pushEvent("delete_comment", { id: comment.id })
+      if (deleteBtn.disabled) return
+      deleteBtn.disabled = true
+      pushCommentMutation(ctx, "delete_comment", { id: comment.id }, {
+        onError: () => { deleteBtn.disabled = false },
+      })
     })
     actions.appendChild(deleteBtn)
   }
@@ -5156,7 +5204,7 @@ export const DocumentRenderer = {
             c.end_line >= block.startLine && c.end_line <= block.endLine &&
             (c.file_path || null) === filePath
           )
-          if (comment) ctx.pushEvent('delete_comment', { id: comment.id })
+          if (comment) pushCommentMutation(ctx, 'delete_comment', { id: comment.id })
           break
         }
         case 't': {
@@ -5180,6 +5228,16 @@ export const DocumentRenderer = {
       }
     }
     document.addEventListener('keydown', ctx._keydownHandler)
+  },
+
+  disconnected() {
+    this.el.dataset.connectionState = 'disconnected'
+    window.dispatchEvent(new CustomEvent('crit:liveview-disconnected'))
+  },
+
+  reconnected() {
+    this.el.dataset.connectionState = 'connected'
+    window.dispatchEvent(new CustomEvent('crit:liveview-connected'))
   },
 
   destroyed() {

--- a/assets/js/liveview-mutation.js
+++ b/assets/js/liveview-mutation.js
@@ -1,0 +1,25 @@
+const DEFAULT_ERROR_MESSAGE = "We couldn't confirm whether your change was saved. Reconnect and check the review before trying again."
+
+// LiveView's hook.pushEvent returns a promise when no callback is supplied.
+// Always settle that promise here so transport timeouts never escape as
+// unhandled rejections. Callers receive an explicit result and can keep their
+// optimistic UI (forms, editors, disabled buttons) in a retryable state.
+export async function pushMutation(hook, event, payload, options = {}) {
+  try {
+    const reply = await hook.pushEvent(event, payload)
+    if (reply?.ok === false) {
+      const error = new Error(reply.error || DEFAULT_ERROR_MESSAGE)
+      if (options.onError) options.onError(error)
+      return { ok: false, error, reply }
+    }
+    if (options.onSuccess) options.onSuccess(reply)
+    return { ok: true, reply }
+  } catch (error) {
+    if (options.onError) options.onError(error)
+    return { ok: false, error }
+  }
+}
+
+export function mutationErrorMessage() {
+  return DEFAULT_ERROR_MESSAGE
+}

--- a/assets/js/preview-mode.js
+++ b/assets/js/preview-mode.js
@@ -29,6 +29,7 @@
 
 import { renderCommentCard, attachSidebarResizeHandle, escapeHtml, startInlineBodyEdit } from "./comments-panel"
 import { createSettingsPanel } from "./settings-panel"
+import { pushMutation, mutationErrorMessage } from "./liveview-mutation"
 
 // Preview-mode keyboard shortcuts (the shared settings overlay's Shortcuts tab).
 // Preview's interaction model is the Navigate/Pin header toggle + composer, so
@@ -117,6 +118,7 @@ export const PreviewMode = {
     this.viewport = { key: "desktop", w: 1280, h: 800 }
     this.htmlFile = "index.html"
     this.composerEl = null
+    this.composerSubmitting = false
     this.pendingAnchor = null
     // Per-comment collapse state + pin-number lookup, consumed by the shared
     // card renderer via the preview adapter.
@@ -166,6 +168,44 @@ export const PreviewMode = {
       this.canComment = !!can_comment
       this.renderPanel()
     })
+  },
+
+  pushMutation(event, payload, options = {}) {
+    return pushMutation(this, event, payload, {
+      ...options,
+      onError: (error) => {
+        if (options.onError) options.onError(error)
+        else this.showMutationError()
+      },
+    })
+  },
+
+  disconnected() {
+    this.el.dataset.connectionState = "disconnected"
+    window.dispatchEvent(new CustomEvent("crit:liveview-disconnected"))
+  },
+
+  reconnected() {
+    this.el.dataset.connectionState = "connected"
+    window.dispatchEvent(new CustomEvent("crit:liveview-connected"))
+  },
+
+  showMutationError() {
+    let host = document.querySelector('.mini-toast-host')
+    if (!host) {
+      host = document.createElement('div')
+      host.className = 'mini-toast-host'
+      document.body.appendChild(host)
+    }
+    const toast = document.createElement('div')
+    toast.className = 'mini-toast'
+    toast.textContent = mutationErrorMessage()
+    host.appendChild(toast)
+    requestAnimationFrame(() => toast.classList.add('mini-toast-visible'))
+    setTimeout(() => {
+      toast.classList.remove('mini-toast-visible')
+      setTimeout(() => toast.remove(), 300)
+    }, 5000)
   },
 
   destroyed() {
@@ -374,7 +414,7 @@ export const PreviewMode = {
 
   setMode(value) {
     const next = value === "pin" ? "pin" : "navigate"
-    if (this.mode === next) return
+    if (this.mode === next || this.composerSubmitting) return
     this.mode = next
     // Port of crit setMode: tell the agent the mode + flip marker tabindex so
     // Tab doesn't jump into the iframe while pinning.
@@ -560,6 +600,7 @@ export const PreviewMode = {
   },
 
   openComposer(anchor) {
+    if (this.composerSubmitting) return
     // closeComposer() nulls pendingAnchor, so set it AFTER closing any prior
     // composer — otherwise submitComposer sees a null anchor and silently
     // drops the comment (no pushEvent, nothing reaches the server).
@@ -591,20 +632,23 @@ export const PreviewMode = {
     const errEl = el.querySelector(".crit-preview-composer-error")
     const save = () => this.submitComposer(textarea, errEl)
     el.querySelector(".crit-preview-composer-save").addEventListener("click", save)
-    el.querySelector(".crit-preview-composer-cancel").addEventListener("click", () => this.closeComposer())
+    el.querySelector(".crit-preview-composer-cancel").addEventListener("click", () => {
+      if (!this.composerSubmitting) this.closeComposer()
+    })
     textarea.addEventListener("keydown", (e) => {
       if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
         e.preventDefault()
         save()
       } else if (e.key === "Escape") {
         e.preventDefault()
-        this.closeComposer()
+        if (!this.composerSubmitting) this.closeComposer()
       }
     })
     requestAnimationFrame(() => textarea.focus())
   },
 
   submitComposer(textarea, errEl) {
+    if (this.composerSubmitting) return
     const body = (textarea.value || "").trim()
     if (!body) {
       textarea.focus()
@@ -616,17 +660,34 @@ export const PreviewMode = {
     // start_line/end_line: ReviewLive's add_comment handler reads these (files
     // mode is line-anchored). DOM-anchored preview comments have no line, so
     // send 0/0 — the changeset only enforces > 0 when scope === "line".
-    this.pushEvent("add_comment", {
+    const submittedComposer = this.composerEl
+    const composerButtons = submittedComposer?.querySelectorAll("button") || []
+    this.composerSubmitting = true
+    composerButtons.forEach(button => { button.disabled = true })
+    errEl.textContent = ""
+    errEl.hidden = true
+    this.pushMutation("add_comment", {
       body,
       scope: "file",
       file_path: this.htmlFile,
       start_line: 0,
       end_line: 0,
       dom_anchor: anchor,
+    }, {
+      onSuccess: () => {
+        this.composerSubmitting = false
+        if (this.composerEl === submittedComposer) this.closeComposer()
+      },
+      onError: () => {
+        this.composerSubmitting = false
+        if (this.composerEl === submittedComposer) {
+          composerButtons.forEach(button => { button.disabled = false })
+          errEl.textContent = mutationErrorMessage()
+          errEl.hidden = false
+          textarea.focus()
+        }
+      },
     })
-    // The new comment arrives back via the comment_added push event, which
-    // re-renders the panel and re-pushes pins. Just close the composer.
-    this.closeComposer()
   },
 
   closeComposer() {
@@ -736,16 +797,16 @@ export const PreviewMode = {
         badge.textContent = String(n)
         return [badge]
       },
-      onResolve: (c, resolved) => this.pushEvent("resolve_comment", { id: c.id, resolved }),
-      onDelete: (c) => this.pushEvent("delete_comment", { id: c.id }),
-      onEditComment: (id, body) => this.pushEvent("edit_comment", { id, body }),
-      onAddReply: (commentId, body) => this.pushEvent("add_reply", { comment_id: commentId, body }),
-      onDeleteReply: (id) => this.pushEvent("delete_reply", { id }),
+      onResolve: (c, resolved) => this.pushMutation("resolve_comment", { id: c.id, resolved }),
+      onDelete: (c) => this.pushMutation("delete_comment", { id: c.id }),
+      onEditComment: (id, body) => this.pushMutation("edit_comment", { id, body }),
+      onAddReply: (commentId, body) => this.pushMutation("add_reply", { comment_id: commentId, body }),
+      onDeleteReply: (id) => this.pushMutation("delete_reply", { id }),
       onEditReply: (commentId, reply) => {
         const sel = window.CSS && CSS.escape ? CSS.escape(String(reply.id)) : reply.id
         const replyEl = this.panelBody.querySelector('[data-reply-id="' + sel + '"]')
         const bodyEl = replyEl && replyEl.querySelector(".reply-body")
-        if (bodyEl) startInlineBodyEdit(bodyEl, reply.body, (v) => this.pushEvent("edit_reply", { id: reply.id, body: v }))
+        if (bodyEl) startInlineBodyEdit(bodyEl, reply.body, (v) => this.pushMutation("edit_reply", { id: reply.id, body: v }))
       },
       scheduleTimeout: (fn, ms) => setTimeout(fn, ms),
       onCardClick: (c) => this.flashPin(c),

--- a/e2e/draft-autosave.spec.ts
+++ b/e2e/draft-autosave.spec.ts
@@ -89,6 +89,16 @@ test.describe("Draft Autosave", () => {
     const restoredTextarea = page.locator(".comment-form textarea");
     await expect(restoredTextarea).toBeVisible({ timeout: 5_000 });
     await expect(restoredTextarea).toHaveValue("Saved draft for reload");
+
+    // Restoring must not consume the durable copy. A second reload without an
+    // input event should restore the same draft again.
+    await expect.poll(() =>
+      page.evaluate(
+        () => Object.keys(localStorage).filter((key) => key.startsWith("crit-draft-")).length
+      )
+    ).toBe(1);
+    await loadReview(page, token);
+    await expect(page.locator(".comment-form textarea")).toHaveValue("Saved draft for reload");
   });
 
   test("submitting comment clears the draft", async ({ page }) => {
@@ -122,6 +132,63 @@ test.describe("Draft Autosave", () => {
           .length
     );
     expect(draftCount).toBe(0);
+  });
+
+  test("a disconnected submit keeps the draft and can be retried after reconnect", async ({
+    page,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+
+    await loadReview(page, token);
+    await page.locator(".line-gutter").first().click();
+
+    const textarea = page.locator(".comment-form textarea");
+    const submit = page.locator('.comment-form button:has-text("Comment")');
+    await textarea.fill("Keep this comment through a disconnect");
+
+    await expect(async () => {
+      const count = await page.evaluate(
+        () => Object.keys(localStorage).filter((key) => key.startsWith("crit-draft-")).length
+      );
+      expect(count).toBe(1);
+    }).toPass({ timeout: 3_000 });
+
+    await page.evaluate(() => (window as any).liveSocket.disconnect());
+    await expect(page.locator("#document-renderer")).toHaveAttribute(
+      "data-connection-state",
+      "disconnected"
+    );
+
+    await submit.click();
+
+    await expect(page.locator(".mini-toast").last()).toContainText(
+      "couldn't confirm whether your change was saved",
+      { timeout: 12_000 }
+    );
+    await expect(textarea).toHaveValue("Keep this comment through a disconnect");
+    await expect(submit).toBeEnabled();
+    expect(pageErrors).toEqual([]);
+
+    const draftCount = await page.evaluate(
+      () => Object.keys(localStorage).filter((key) => key.startsWith("crit-draft-")).length
+    );
+    expect(draftCount).toBe(1);
+
+    await page.evaluate(() => (window as any).liveSocket.connect());
+    await expect(page.locator("#document-renderer")).toHaveAttribute(
+      "data-connection-state",
+      "connected",
+      { timeout: 12_000 }
+    );
+    const draftCountAfterReconnect = await page.evaluate(
+      () => Object.keys(localStorage).filter((key) => key.startsWith("crit-draft-")).length
+    );
+    expect(draftCountAfterReconnect).toBe(1);
+
+    await submit.click();
+    await waitForCommentCard(page, "Keep this comment through a disconnect");
+    expect(pageErrors).toEqual([]);
   });
 
   test("cancelling comment form preserves the draft for later restoration", async ({ page }) => {

--- a/e2e/preview.spec.ts
+++ b/e2e/preview.spec.ts
@@ -305,4 +305,89 @@ test.describe("Preview mode", () => {
     await expect(card).toBeVisible({ timeout: 10_000 });
     await expect(page.locator("#commentsPanelCountBadge")).toHaveText("1");
   });
+
+  test("pin composer survives a disconnected submit and retries after reconnect", async ({
+    page,
+    request,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+
+    const review = await createPreviewReview(request);
+    token = review.token;
+    deleteToken = review.deleteToken;
+
+    const frame = await loadPreview(page, token);
+    const pinBtn = page.locator('#critPreviewMode button[data-mode="pin"]');
+    await expect(pinBtn).toBeEnabled({ timeout: 15_000 });
+    await pinBtn.click();
+    await frame.locator("#hero").click();
+
+    const composer = page.locator(".crit-preview-composer-body");
+    const save = page.locator(".crit-preview-composer-save");
+    await expect(composer).toBeVisible({ timeout: 10_000 });
+    await composer.fill("Keep this pinned comment through a disconnect");
+
+    await page.evaluate(() => (window as any).liveSocket.disconnect());
+    await expect(page.locator("#crit-preview-layout")).toHaveAttribute(
+      "data-connection-state",
+      "disconnected"
+    );
+    await save.click();
+
+    await expect(page.locator(".crit-preview-composer-error")).toContainText(
+      "couldn't confirm whether your change was saved",
+      { timeout: 12_000 }
+    );
+    await expect(composer).toHaveValue("Keep this pinned comment through a disconnect");
+    await expect(save).toBeEnabled();
+    expect(pageErrors).toEqual([]);
+
+    await page.evaluate(() => (window as any).liveSocket.connect());
+    await expect(page.locator("#crit-preview-layout")).toHaveAttribute(
+      "data-connection-state",
+      "connected",
+      { timeout: 12_000 }
+    );
+    await save.click();
+
+    await expect(
+      page.locator("#critPreviewPanelBody .comment-card").filter({
+        hasText: "Keep this pinned comment through a disconnect",
+      })
+    ).toBeVisible({ timeout: 10_000 });
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("pin composer ignores repeated keyboard submits while acknowledgement is pending", async ({
+    page,
+    request,
+  }) => {
+    const review = await createPreviewReview(request);
+    token = review.token;
+    deleteToken = review.deleteToken;
+
+    const frame = await loadPreview(page, token);
+    const pinBtn = page.locator('#critPreviewMode button[data-mode="pin"]');
+    await expect(pinBtn).toBeEnabled({ timeout: 15_000 });
+    await pinBtn.click();
+    await frame.locator("#hero").click();
+
+    const composer = page.locator(".crit-preview-composer-body");
+    await expect(composer).toBeVisible({ timeout: 10_000 });
+    await composer.fill("Only create this pinned comment once");
+    await page.evaluate(() => (window as any).liveSocket.enableLatencySim(750));
+
+    await composer.press("Control+Enter");
+    await page.locator('#critPreviewMode button[data-mode="navigate"]').click();
+    await expect(pinBtn).toHaveAttribute("aria-pressed", "true");
+    await expect(composer).toBeVisible();
+    await composer.press("Control+Enter");
+
+    const cards = page.locator("#critPreviewPanelBody .comment-card").filter({
+      hasText: "Only create this pinned comment once",
+    });
+    await expect(cards).toHaveCount(1, { timeout: 10_000 });
+    await page.evaluate(() => (window as any).liveSocket.disableLatencySim());
+  });
 });

--- a/lib/crit_web/live/review_live.ex
+++ b/lib/crit_web/live/review_live.ex
@@ -281,10 +281,11 @@ defmodule CritWeb.ReviewLive do
         payload = %{comment: Reviews.serialize_comment(comment)}
         socket = push_event(socket, "comment_added", payload)
         broadcast_from_review(socket, {:comment_added, payload})
-        {:noreply, socket}
+        {:reply, %{ok: true}, socket}
 
       {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, "Failed to save comment.")}
+        message = "Failed to save comment."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
     end
   end
 
@@ -302,13 +303,15 @@ defmodule CritWeb.ReviewLive do
 
         socket = push_event(socket, "comment_updated", payload)
         broadcast_from_review(socket, {:comment_updated, payload})
-        {:noreply, socket}
+        {:reply, %{ok: true}, socket}
 
       {:error, :unauthorized} ->
-        {:noreply, put_flash(socket, :error, "You can only edit your own comments.")}
+        message = "You can only edit your own comments."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
 
       {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to update comment.")}
+        message = "Failed to update comment."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
     end
   end
 
@@ -321,13 +324,15 @@ defmodule CritWeb.ReviewLive do
         payload = %{id: id}
         socket = push_event(socket, "comment_deleted", payload)
         broadcast_from_review(socket, {:comment_deleted, payload})
-        {:noreply, socket}
+        {:reply, %{ok: true}, socket}
 
       {:error, :unauthorized} ->
-        {:noreply, put_flash(socket, :error, "You can only delete your own comments.")}
+        message = "You can only delete your own comments."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
 
       {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to delete comment.")}
+        message = "Failed to delete comment."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
     end
   end
 
@@ -366,10 +371,11 @@ defmodule CritWeb.ReviewLive do
         payload = %{parent_id: comment_id, reply: Reviews.serialize_reply(reply)}
         socket = push_event(socket, "reply_added", payload)
         broadcast_from_review(socket, {:reply_added, payload})
-        {:noreply, socket}
+        {:reply, %{ok: true}, socket}
 
       {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to add reply.")}
+        message = "Failed to add reply."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
     end
   end
 
@@ -382,13 +388,15 @@ defmodule CritWeb.ReviewLive do
         payload = %{parent_id: reply.parent_id, id: reply.id, body: reply.body}
         socket = push_event(socket, "reply_updated", payload)
         broadcast_from_review(socket, {:reply_updated, payload})
-        {:noreply, socket}
+        {:reply, %{ok: true}, socket}
 
       {:error, :unauthorized} ->
-        {:noreply, put_flash(socket, :error, "You can only edit your own replies.")}
+        message = "You can only edit your own replies."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
 
       {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to update reply.")}
+        message = "Failed to update reply."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
     end
   end
 
@@ -401,13 +409,15 @@ defmodule CritWeb.ReviewLive do
         payload = %{parent_id: deleted.parent_id, id: id}
         socket = push_event(socket, "reply_deleted", payload)
         broadcast_from_review(socket, {:reply_deleted, payload})
-        {:noreply, socket}
+        {:reply, %{ok: true}, socket}
 
       {:error, :unauthorized} ->
-        {:noreply, put_flash(socket, :error, "You can only delete your own replies.")}
+        message = "You can only delete your own replies."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
 
       {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to delete reply.")}
+        message = "Failed to delete reply."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
     end
   end
 
@@ -420,14 +430,15 @@ defmodule CritWeb.ReviewLive do
         payload = %{id: comment.id, resolved: comment.resolved}
         socket = push_event(socket, "comment_resolved", payload)
         broadcast_from_review(socket, {:comment_resolved, payload})
-        {:noreply, socket}
+        {:reply, %{ok: true}, socket}
 
       {:error, :unauthorized} ->
-        {:noreply,
-         put_flash(socket, :error, "Only the comment author or review owner can resolve this.")}
+        message = "Only the comment author or review owner can resolve this."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
 
       {:error, _} ->
-        {:noreply, put_flash(socket, :error, "Failed to update comment.")}
+        message = "Failed to update comment."
+        {:reply, %{ok: false, error: message}, put_flash(socket, :error, message)}
     end
   end
 

--- a/test/crit_web/live/review_live_test.exs
+++ b/test/crit_web/live/review_live_test.exs
@@ -1284,6 +1284,56 @@ defmodule CritWeb.ReviewLiveTest do
       [updated] = Reviews.list_comments(review)
       assert updated.resolved == false
     end
+
+    test "reports authorization and missing-comment failures", %{conn: conn, review: review} do
+      other_scope = Scope.for_visitor(Ecto.UUID.generate())
+
+      {:ok, comment} =
+        Reviews.create_comment(
+          other_scope,
+          review,
+          %{"start_line" => 1, "end_line" => 1, "body" => "Other's comment"}
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      renderer = element(view, "#document-renderer")
+
+      render_hook(renderer, "resolve_comment", %{"id" => comment.id, "resolved" => true})
+      assert render(view) =~ "Only the comment author or review owner can resolve this."
+
+      render_hook(renderer, "resolve_comment", %{
+        "id" => Ecto.UUID.generate(),
+        "resolved" => true
+      })
+
+      assert render(view) =~ "Failed to update comment."
+    end
+  end
+
+  describe "mutation failure replies" do
+    test "reports missing comment failures", %{conn: conn, review: review} do
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      renderer = element(view, "#document-renderer")
+      missing_id = Ecto.UUID.generate()
+
+      render_hook(renderer, "edit_comment", %{"id" => missing_id, "body" => "Updated"})
+      assert render(view) =~ "Failed to update comment."
+
+      render_hook(renderer, "delete_comment", %{"id" => missing_id})
+      assert render(view) =~ "Failed to delete comment."
+    end
+
+    test "reports missing reply failures", %{conn: conn, review: review} do
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+      renderer = element(view, "#document-renderer")
+      missing_id = Ecto.UUID.generate()
+
+      render_hook(renderer, "edit_reply", %{"id" => missing_id, "body" => "Updated"})
+      assert render(view) =~ "Failed to update reply."
+
+      render_hook(renderer, "delete_reply", %{"id" => missing_id})
+      assert render(view) =~ "Failed to delete reply."
+    end
   end
 
   describe "demo mode filtering in handle_info" do


### PR DESCRIPTION
## Summary

- handle LiveView mutation acknowledgements and failures without unhandled Promise rejections
- preserve comment drafts, editors, replies, and preview composers across disconnects
- prevent duplicate pending submissions and reconnect composer races
- make persistent transport telemetry visibility-aware and report once per outage
- retain durable drafts through reconnects and repeated reloads

## Review

- [x] Static code review passed
- [x] Intent audit passed
- [x] Security scan passed
- [x] Parity audit passed — hosted transport-specific behavior
- [x] LongPoll recovery verified

## Test plan

- 1,072 ExUnit/precommit tests passed
- 137 full Playwright tests passed
- 16 recovery tests passed with forced LongPoll
- disconnect/reconnect, draft durability, unhandled rejection, and duplicate-submit scenarios covered

## Residual risk

A server write can theoretically commit immediately before its acknowledgement is lost. The client never retries automatically and tells the user to reconnect and inspect authoritative state before retrying. Complete prevention would require server-side mutation idempotency.
