### PR TITLE
fix: restore pin mode on isolated preview hosts

### DIFF
--- a/e2e/security.spec.ts
+++ b/e2e/security.spec.ts
@@ -90,24 +90,55 @@ test.describe("Preview isolation: preview iframe cannot exfiltrate victim sessio
     page,
     request,
   }) => {
+    const files = [
+      {
+        path: "index.html",
+        content:
+          '<!doctype html><html><body><p id="existing">Existing marker target</p><h1 id="hero">Pin me</h1></body></html>',
+        status: "modified",
+      },
+    ];
+
     const res = await request.post(`${CANONICAL_ORIGIN}/api/reviews`, {
       data: {
         review_type: "preview",
         review_round: 0,
-        files: [
-          {
-            path: "index.html",
-            content:
-              '<!doctype html><html><body><h1 id="hero">Pin me</h1></body></html>',
-            status: "modified",
-          },
-        ],
+        files,
       },
     });
     expect(res.status(), "preview review creation").toBe(201);
     const body = await res.json();
     const token = (body.url as string).split("/r/")[1];
     const deleteToken = body.delete_token as string;
+
+    // The stored anchor pathname is the iframe's actual raw route, which is
+    // only known after the API allocates the review token.
+    const updateRes = await request.put(
+      `${CANONICAL_ORIGIN}/api/reviews/${token}`,
+      {
+        data: {
+          delete_token: deleteToken,
+          review_round: 0,
+          files,
+          comments: [
+            {
+              start_line: 0,
+              end_line: 0,
+              body: "Existing pin",
+              scope: "file",
+              file_path: "index.html",
+              dom_anchor: {
+                pathname: `/r/${token}/raw/index.html`,
+                css_selector: "#existing",
+                tag_chain: ["body", "p"],
+                outer_html: '<p id="existing">Existing marker target</p>',
+              },
+            },
+          ],
+        },
+      },
+    );
+    expect(updateRes.status(), "preview review marker seed").toBe(200);
 
     try {
       await page.goto(`${CANONICAL_ORIGIN}/r/${token}`);
@@ -125,6 +156,16 @@ test.describe("Preview isolation: preview iframe cannot exfiltrate victim sessio
         '#critPreviewMode button[data-mode="pin"]',
       );
       await expect(pinButton).toBeEnabled({ timeout: 15_000 });
+
+      // The agent fetches marker CSS from the canonical host. Confirm the
+      // isolated preview origin receives that stylesheet through narrow CORS.
+      const marker = page
+        .frameLocator("#critPreviewIframe")
+        .locator(".crit-live-marker");
+      await expect(marker).toBeVisible({ timeout: 10_000 });
+      await expect(marker).toHaveCSS("width", "22px");
+      await expect(marker).toHaveCSS("background-color", "rgb(37, 99, 235)");
+
       await pinButton.click();
       await expect(pinButton).toHaveAttribute("aria-pressed", "true");
 

--- a/e2e/security.spec.ts
+++ b/e2e/security.spec.ts
@@ -86,6 +86,59 @@ async function waitForProbe(
 }
 
 test.describe("Preview isolation: preview iframe cannot exfiltrate victim session", () => {
+  test("isolated preview agent enables pin mode and sends selections", async ({
+    page,
+    request,
+  }) => {
+    const res = await request.post(`${CANONICAL_ORIGIN}/api/reviews`, {
+      data: {
+        review_type: "preview",
+        review_round: 0,
+        files: [
+          {
+            path: "index.html",
+            content:
+              '<!doctype html><html><body><h1 id="hero">Pin me</h1></body></html>',
+            status: "modified",
+          },
+        ],
+      },
+    });
+    expect(res.status(), "preview review creation").toBe(201);
+    const body = await res.json();
+    const token = (body.url as string).split("/r/")[1];
+    const deleteToken = body.delete_token as string;
+
+    try {
+      await page.goto(`${CANONICAL_ORIGIN}/r/${token}`);
+      await page.waitForSelector("#critPreviewIframe", { timeout: 15_000 });
+
+      const iframeSrc = await page
+        .locator("#critPreviewIframe")
+        .getAttribute("src");
+      expect(iframeSrc).toBe(`${PREVIEW_ORIGIN}/r/${token}/raw/index.html`);
+
+      // agent-ready crosses preview → canonical and enables Pin. Switching
+      // mode crosses canonical → preview; the click selection then crosses
+      // back and opens the host-side composer.
+      const pinButton = page.locator(
+        '#critPreviewMode button[data-mode="pin"]',
+      );
+      await expect(pinButton).toBeEnabled({ timeout: 15_000 });
+      await pinButton.click();
+      await expect(pinButton).toHaveAttribute("aria-pressed", "true");
+
+      await page.frameLocator("#critPreviewIframe").locator("#hero").click();
+      await expect(page.locator(".crit-preview-composer-body")).toBeVisible({
+        timeout: 10_000,
+      });
+    } finally {
+      await request.delete(`${CANONICAL_ORIGIN}/api/reviews`, {
+        data: { delete_token: deleteToken },
+      });
+    }
+  });
+
   test("raw preview route 308-redirects from canonical to preview host", async ({
     request,
   }) => {

--- a/lib/crit_web/controllers/raw_controller.ex
+++ b/lib/crit_web/controllers/raw_controller.ex
@@ -171,9 +171,16 @@ defmodule CritWeb.RawController do
   # `servePreviewHTML`: insert before the last `</body>`, falling back to an
   # append when no closing body tag exists.
   defp maybe_inject_agent_scripts(content, true, "text/html") do
+    # crit-agent derives the trusted chrome origin from its own script URL.
+    # On the isolated preview host, use canonical-host script URLs so the agent
+    # posts to (and accepts messages from) the parent ReviewLive origin rather
+    # than incorrectly targeting the iframe's preview origin.
+    script_origin =
+      if CritWeb.Hosts.preview_host_enabled?(), do: CritWeb.Hosts.canonical_origin(), else: ""
+
     scripts =
       Enum.map_join(@agent_script_files, fn name ->
-        ~s(<script src="/preview-agent/#{name}"></script>)
+        ~s(<script src="#{script_origin}/preview-agent/#{name}"></script>)
       end)
 
     inject_before_body_close(content, scripts)

--- a/lib/crit_web/controllers/raw_controller.ex
+++ b/lib/crit_web/controllers/raw_controller.ex
@@ -23,11 +23,10 @@ defmodule CritWeb.RawController do
     "crit-agent.js"
   ]
 
-  # Marker overlay CSS, inlined into preview HTML. crit local serves this at
-  # `/agent-marker.css` and the vendored crit-agent.js fetches it from there —
-  # but the preview sandbox CSP sets `connect-src 'none'` (and crit-web serves
-  # it under /preview-agent/, not root), so that fetch fails. Inlining it as a
-  # `<style>` makes the agent's failed fetch harmless and the markers styled.
+  # Marker overlay CSS. crit local serves this at `/agent-marker.css` and the
+  # vendored crit-agent.js fetches it from the origin encoded in its own script
+  # URL. With an isolated PREVIEW_HOST that is the canonical chrome origin, so
+  # marker_css/2 grants that configured preview origin narrow read access.
   # Read at compile time; `@external_resource` triggers a recompile on change.
   @marker_css_path Path.join([
                      __DIR__,
@@ -150,9 +149,18 @@ defmodule CritWeb.RawController do
   # so the fetch succeeds instead of 404ing in the iframe console.
   def marker_css(conn, _params) do
     conn
+    |> maybe_allow_preview_origin()
     |> put_resp_content_type("text/css")
     |> put_resp_header("cache-control", "public, max-age=3600")
     |> send_resp(200, @marker_css)
+  end
+
+  defp maybe_allow_preview_origin(conn) do
+    if CritWeb.Hosts.preview_host_enabled?() do
+      put_resp_header(conn, "access-control-allow-origin", CritWeb.Hosts.preview_origin())
+    else
+      conn
+    end
   end
 
   # base64 snapshots (binary assets like images) are decoded back to raw bytes.

--- a/test/crit_web/controllers/raw_controller_test.exs
+++ b/test/crit_web/controllers/raw_controller_test.exs
@@ -245,11 +245,18 @@ defmodule CritWeb.RawControllerTest do
         |> Map.put(:host, "preview.example.test")
         |> get(~p"/r/#{review.token}/raw/index.html")
 
+      body = response(conn, 200)
       [csp] = get_resp_header(conn, "content-security-policy")
       assert csp =~ "script-src *"
       assert csp =~ "connect-src *"
       assert csp =~ "frame-ancestors 'self'"
       assert csp =~ "app.example.test"
+
+      # The vendored agent derives the parent/chrome origin from its script
+      # URL. Loading it from the canonical host keeps postMessage strict while
+      # allowing the iframe itself to remain on the isolated preview host.
+      assert body =~
+               ~s(<script src="#{CritWeb.Hosts.canonical_origin()}/preview-agent/crit-agent.js"></script>)
     end
 
     test "appends agent scripts when there is no </body> tag", %{conn: conn} do

--- a/test/crit_web/controllers/raw_controller_test.exs
+++ b/test/crit_web/controllers/raw_controller_test.exs
@@ -121,6 +121,28 @@ defmodule CritWeb.RawControllerTest do
     @png_signature <<137, 80, 78, 71, 13, 10, 26, 10>>
     @png_base64 Base.encode64(@png_signature)
 
+    test "allows the configured preview origin to fetch marker CSS", %{conn: conn} do
+      with_preview_hosts()
+
+      conn =
+        conn
+        |> Map.put(:host, "app.example.test")
+        |> get(~p"/agent-marker.css")
+
+      assert response(conn, 200) =~ ".crit-live-marker"
+
+      assert get_resp_header(conn, "access-control-allow-origin") == [
+               CritWeb.Hosts.preview_origin()
+             ]
+    end
+
+    test "does not add marker CSS CORS when preview isolation is disabled", %{conn: conn} do
+      conn = get(conn, ~p"/agent-marker.css")
+
+      assert response(conn, 200) =~ ".crit-live-marker"
+      assert get_resp_header(conn, "access-control-allow-origin") == []
+    end
+
     test "serves a base64 snapshot decoded with the correct MIME type", %{conn: conn} do
       review =
         review_fixture(%{

--- a/test/crit_web/plugs/host_gate_test.exs
+++ b/test/crit_web/plugs/host_gate_test.exs
@@ -77,6 +77,17 @@ defmodule CritWeb.Plugs.HostGateTest do
     assert response(conn, 404)
   end
 
+  test "equal canonical and preview hosts fail closed", %{conn: conn} do
+    Application.put_env(:crit, :preview_host, "app.example.test")
+
+    conn =
+      conn
+      |> Map.put(:host, "app.example.test")
+      |> get(~p"/")
+
+    assert response(conn, 404) == "not found"
+  end
+
   test "preview host blocks non-GET to raw paths", %{conn: conn} do
     review =
       review_fixture(%{


### PR DESCRIPTION
## Summary
- load preview-agent scripts from the canonical app origin so strict cross-origin messaging reaches the parent review page
- allow only the configured preview origin to fetch marker styles
- add production-like two-origin coverage for Pin mode, marker styling, selections, and fail-closed host configuration

## Review
- [x] Code review: passed
- [x] Intent audit: passed
- [x] Parity audit: N/A

## Test plan
- `mise exec -- mix precommit`
- `mise run e2e`
- verified the regression test fails without the fix and passes with it
