### PR TITLE
fix: use correct go install path with /cmd/crit

### DIFF
--- a/lib/crit_web/controllers/page_html.ex
+++ b/lib/crit_web/controllers/page_html.ex
@@ -323,9 +323,9 @@ defmodule CritWeb.PageHTML do
     >
       <div
         class="copy-btn flex items-center bg-(--crit-code-bg) cursor-pointer text-(--crit-fg-muted)"
-        data-copy="go install github.com/tomasz-tomczyk/crit@latest"
+        data-copy="go install github.com/tomasz-tomczyk/crit/cmd/crit@latest"
       >
-        <pre class="flex-1 font-mono text-sm text-(--crit-fg-primary) m-0 px-5 py-3.5 overflow-x-auto"><span class="text-(--crit-fg-muted) select-none">$ </span>go install github.com/tomasz-tomczyk/crit@latest</pre>
+        <pre class="flex-1 font-mono text-sm text-(--crit-fg-primary) m-0 px-5 py-3.5 overflow-x-auto"><span class="text-(--crit-fg-muted) select-none">$ </span>go install github.com/tomasz-tomczyk/crit/cmd/crit@latest</pre>
         <div class="shrink-0 p-3">
           <.icon name="hero-clipboard" class="size-4 icon-default" />
           <.icon name="hero-clipboard-document-check" class="size-4 icon-copied hidden" />

--- a/priv/articles/how-to-plan-document-and-review/index.md
+++ b/priv/articles/how-to-plan-document-and-review/index.md
@@ -80,7 +80,7 @@ nix profile install github:tomasz-tomczyk/crit
 If you have Go installed on your machine you can also install Crit with:
 
 ```bash
-go install github.com/tomasz-tomczyk/crit@latest
+go install github.com/tomasz-tomczyk/crit/cmd/crit@latest
 ```
 
 And then simply run:

--- a/priv/static/llms.txt
+++ b/priv/static/llms.txt
@@ -15,7 +15,7 @@ Install (pick one):
 
 ```
 brew install tomasz-tomczyk/tap/crit
-go install github.com/tomasz-tomczyk/crit@latest
+go install github.com/tomasz-tomczyk/crit/cmd/crit@latest
 nix run github:tomasz-tomczyk/crit
 ```
 


### PR DESCRIPTION
## Summary
- Website install instructions still used `go install github.com/tomasz-tomczyk/crit@latest`, which fails because that module path has no package (same bug as tomasz-tomczyk/crit#741 for the README).
- Updated homepage/getting-started install widget, `llms.txt`, and the plan/review article to `.../crit/cmd/crit@latest`.

Fixes https://github.com/tomasz-tomczyk/crit/issues/760

## Review
- [x] Code review: passed (intent audit clean; elixir-expert SHIP IT)
- [x] Parity audit: N/A (marketing copy only; crit README already correct)

## Test plan
- [x] `mix precommit` green (1078 tests)
- [x] Grep worktree: zero remaining `crit@latest` package-root install paths
- [ ] Spot-check https://crit.md and /getting-started Go tab after deploy


Made with [Cursor](https://cursor.com)