### PR TITLE
fix: load preview marker CSS from the preview host

### DIFF
--- a/e2e/security.spec.ts
+++ b/e2e/security.spec.ts
@@ -157,8 +157,8 @@ test.describe("Preview isolation: preview iframe cannot exfiltrate victim sessio
       );
       await expect(pinButton).toBeEnabled({ timeout: 15_000 });
 
-      // The agent fetches marker CSS from the canonical host. Confirm the
-      // isolated preview origin receives that stylesheet through narrow CORS.
+      // The agent fetches marker CSS relative to the iframe document (preview
+      // host). Confirm styled markers render through preview-host CORS.
       const marker = page
         .frameLocator("#critPreviewIframe")
         .locator(".crit-live-marker");

--- a/e2e/security.spec.ts
+++ b/e2e/security.spec.ts
@@ -157,8 +157,8 @@ test.describe("Preview isolation: preview iframe cannot exfiltrate victim sessio
       );
       await expect(pinButton).toBeEnabled({ timeout: 15_000 });
 
-      // The agent fetches marker CSS relative to the iframe document (preview
-      // host). Confirm styled markers render through preview-host CORS.
+      // The agent prefers marker CSS on the iframe document host (preview),
+      // with API-origin fallback. Confirm styled markers via preview-host CORS.
       const marker = page
         .frameLocator("#critPreviewIframe")
         .locator(".crit-live-marker");

--- a/lib/crit_web/controllers/page_html/self_hosting.html.heex
+++ b/lib/crit_web/controllers/page_html/self_hosting.html.heex
@@ -686,7 +686,11 @@
         Both hostnames must resolve to crit-web. With Caddy, add the preview host to the same
         <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">reverse_proxy</code>
         block as <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">PHX_HOST</code>.
-        No second container is needed.
+        No second container is needed. Preview pin styles load from
+        <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">PREVIEW_HOST/agent-marker.css</code>
+        (not the app host), so an SSO proxy on
+        <code class="text-xs bg-(--crit-bg-elevated) px-1 py-0.5 rounded">PHX_HOST</code>
+        does not need to allowlist that path — keep the preview host reachable without a login wall.
       </p>
     </section>
 

--- a/lib/crit_web/controllers/raw_controller.ex
+++ b/lib/crit_web/controllers/raw_controller.ex
@@ -24,9 +24,9 @@ defmodule CritWeb.RawController do
   ]
 
   # Marker overlay CSS. crit local serves this at `/agent-marker.css`. The
-  # vendored crit-agent.js fetches it with a relative URL so the request hits
-  # the iframe document host (preview host when PREVIEW_HOST is set). CORS on
-  # this endpoint allows opaque-origin sandboxed iframes to read the body.
+  # vendored crit-agent.js tries a relative URL first (preview host when
+  # PREVIEW_HOST is set), then falls back to the API/app origin. CORS on this
+  # endpoint allows opaque-origin sandboxed iframes to read the body.
   # Read at compile time; `@external_resource` triggers a recompile on change.
   @marker_css_path Path.join([
                      __DIR__,
@@ -143,11 +143,11 @@ defmodule CritWeb.RawController do
     |> halt()
   end
 
-  # The injected crit-agent fetches marker CSS via relative `/agent-marker.css`
-  # (document URL host — the preview host when PREVIEW_HOST is set). That keeps
-  # the stylesheet off the SSO-gated canonical app host; HostGate allows this
-  # path on the preview origin. CORS `*` is still required because isolated
-  # preview iframes are opaque-origin sandboxes (`Origin: null`).
+  # The injected crit-agent prefers relative `/agent-marker.css` (document host
+  # — the preview host when PREVIEW_HOST is set), falling back to the app
+  # origin. Relative keeps the stylesheet off an SSO-gated PHX_HOST; HostGate
+  # allows this path on the preview origin. CORS `*` is still required because
+  # isolated preview iframes are opaque-origin sandboxes (`Origin: null`).
   def marker_css(conn, _params) do
     conn
     |> maybe_allow_preview_origin()

--- a/lib/crit_web/controllers/raw_controller.ex
+++ b/lib/crit_web/controllers/raw_controller.ex
@@ -23,10 +23,10 @@ defmodule CritWeb.RawController do
     "crit-agent.js"
   ]
 
-  # Marker overlay CSS. crit local serves this at `/agent-marker.css` and the
-  # vendored crit-agent.js fetches it from the origin encoded in its own script
-  # URL. With an isolated PREVIEW_HOST that is the canonical chrome origin, so
-  # marker_css/2 grants that configured preview origin narrow read access.
+  # Marker overlay CSS. crit local serves this at `/agent-marker.css`. The
+  # vendored crit-agent.js fetches it with a relative URL so the request hits
+  # the iframe document host (preview host when PREVIEW_HOST is set). CORS on
+  # this endpoint allows opaque-origin sandboxed iframes to read the body.
   # Read at compile time; `@external_resource` triggers a recompile on change.
   @marker_css_path Path.join([
                      __DIR__,
@@ -143,10 +143,11 @@ defmodule CritWeb.RawController do
     |> halt()
   end
 
-  # The injected crit-agent fetches its marker overlay CSS from
-  # `<origin>/agent-marker.css` (hard-coded in the vendored, byte-identical
-  # crit-agent.js — crit local serves it at this same root path). Serve it here
-  # so the fetch succeeds instead of 404ing in the iframe console.
+  # The injected crit-agent fetches marker CSS via relative `/agent-marker.css`
+  # (document URL host — the preview host when PREVIEW_HOST is set). That keeps
+  # the stylesheet off the SSO-gated canonical app host; HostGate allows this
+  # path on the preview origin. CORS `*` is still required because isolated
+  # preview iframes are opaque-origin sandboxes (`Origin: null`).
   def marker_css(conn, _params) do
     conn
     |> maybe_allow_preview_origin()
@@ -157,9 +158,6 @@ defmodule CritWeb.RawController do
 
   defp maybe_allow_preview_origin(conn) do
     if CritWeb.Hosts.preview_host_enabled?() do
-      # In isolated mode, the preview iframe is sandboxed without
-      # allow-same-origin, so subresource requests originate from an opaque
-      # "null" origin. Use wildcard CORS for this static marker stylesheet.
       put_resp_header(conn, "access-control-allow-origin", "*")
     else
       conn

--- a/priv/static/preview-agent/crit-agent.js
+++ b/priv/static/preview-agent/crit-agent.js
@@ -64,9 +64,14 @@
 
   // ---------- Phase D: marker overlay + MutationObserver ----------
   function bootMarkers() {
-    // Inline marker CSS — fetched cross-origin from API port.
+    // Marker CSS is resolved against the iframe document URL (relative), not
+    // expectedApiOrigin. On crit-web with PREVIEW_HOST the document lives on
+    // the preview host while agent scripts are loaded from the canonical app
+    // origin for postMessage trust — fetching CSS from the app host breaks
+    // behind SSO (credential-less fetch gets a 302 login redirect). Relative
+    // keeps the stylesheet on the same host as the preview document.
     try {
-      fetch(expectedApiOrigin + '/agent-marker.css', { credentials: 'omit' })
+      fetch('/agent-marker.css', { credentials: 'omit' })
         .then(function (res) { return res.ok ? res.text() : ''; })
         .then(function (css) {
           if (!css) return;

--- a/priv/static/preview-agent/crit-agent.js
+++ b/priv/static/preview-agent/crit-agent.js
@@ -64,22 +64,26 @@
 
   // ---------- Phase D: marker overlay + MutationObserver ----------
   function bootMarkers() {
-    // Marker CSS is resolved against the iframe document URL (relative), not
-    // expectedApiOrigin. On crit-web with PREVIEW_HOST the document lives on
-    // the preview host while agent scripts are loaded from the canonical app
-    // origin for postMessage trust — fetching CSS from the app host breaks
-    // behind SSO (credential-less fetch gets a 302 login redirect). Relative
-    // keeps the stylesheet on the same host as the preview document.
+    // Marker CSS: try the iframe document host first (relative), then the
+    // API origin. Hosted PREVIEW_HOST previews need relative — scripts load
+    // from the app origin for postMessage trust, but credential-less CSS
+    // fetches to that origin 302 behind SSO. Local live mode needs the
+    // fallback — the iframe document is the user app, CSS is on the API port.
+    function loadMarkerCss(url) {
+      return fetch(url, { credentials: 'omit' })
+        .then(function (res) { return res.ok ? res.text() : Promise.reject(); });
+    }
+    function injectMarkerCss(css) {
+      if (!css) return;
+      var style = document.createElement('style');
+      style.setAttribute('data-crit-marker-css', '1');
+      style.textContent = css;
+      document.head.appendChild(style);
+    }
     try {
-      fetch('/agent-marker.css', { credentials: 'omit' })
-        .then(function (res) { return res.ok ? res.text() : ''; })
-        .then(function (css) {
-          if (!css) return;
-          var style = document.createElement('style');
-          style.setAttribute('data-crit-marker-css', '1');
-          style.textContent = css;
-          document.head.appendChild(style);
-        })
+      loadMarkerCss('/agent-marker.css')
+        .catch(function () { return loadMarkerCss(expectedApiOrigin + '/agent-marker.css'); })
+        .then(injectMarkerCss)
         .catch(function () { /* non-fatal */ });
     } catch (_) { /* ignore */ }
     if (markersAPI && markersAPI.createOverlay && document.body) {

--- a/test/crit_web/controllers/raw_controller_test.exs
+++ b/test/crit_web/controllers/raw_controller_test.exs
@@ -134,7 +134,7 @@ defmodule CritWeb.RawControllerTest do
       assert get_resp_header(conn, "access-control-allow-origin") == ["*"]
     end
 
-    test "serves marker CSS on the preview host for relative agent fetches", %{conn: conn} do
+    test "serves marker CSS on the preview host for agent relative fetches", %{conn: conn} do
       with_preview_hosts()
 
       conn =

--- a/test/crit_web/controllers/raw_controller_test.exs
+++ b/test/crit_web/controllers/raw_controller_test.exs
@@ -134,6 +134,18 @@ defmodule CritWeb.RawControllerTest do
       assert get_resp_header(conn, "access-control-allow-origin") == ["*"]
     end
 
+    test "serves marker CSS on the preview host for relative agent fetches", %{conn: conn} do
+      with_preview_hosts()
+
+      conn =
+        conn
+        |> Map.put(:host, "preview.example.test")
+        |> get(~p"/agent-marker.css")
+
+      assert response(conn, 200) =~ ".crit-live-marker"
+      assert get_resp_header(conn, "access-control-allow-origin") == ["*"]
+    end
+
     test "does not add marker CSS CORS when preview isolation is disabled", %{conn: conn} do
       conn = get(conn, ~p"/agent-marker.css")
 


### PR DESCRIPTION
## Summary
- Sync dual-fetch crit-agent.js so pins load CSS from PREVIEW_HOST (SSO-safe)
- Document preview-host marker CSS on self-hosting page; cover HostGate/CORS path in tests

## Review
- [x] Code review: passed
- [x] Parity audit: passed (vendored from crit)

## Test plan
- [x] mix precommit (local sync vs canonical main drifts until crit merges — CI OK)
- [x] mise run e2e -- e2e/security.spec.ts
- See also: tomasz-tomczyk/crit#778