### PR TITLE
fix: ignore unsupported media Sentry noise

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -42,6 +42,7 @@ function initSentry(liveSocket) {
         /InvalidStateError/,
         /AbortError/,
         /NotAllowedError/,
+        /^The media resource indicated by the src attribute or assigned media provider object was not suitable\.$/,
       ],
       // Replace the default Breadcrumbs integration with one that doesn't
       // capture console output or DOM text — review/comment content must not leak.


### PR DESCRIPTION
## Summary
- Ignore the exact non-actionable browser media-resource error emitted from homepage autoplay media.
- Keep other `NotSupportedError` events reportable.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A

## Test plan
- [x] Verified the anchored matcher against Sentry event-filter logic
- [x] `mise run e2e`
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [!] `mix test` has a local-only sibling preview-agent drift failure; clean reset otherwise passed 1,079 tests.

Fixes [CRIT-WEB-FRONTEND-K](https://crit-md.sentry.io/issues/137095149/)