### PR TITLE
chore: run CI on PRs only, upload coverage on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,59 @@
+name: Coverage
+
+on:
+  push:
+    branches: ["main"]
+
+env:
+  MIX_ENV: test
+
+jobs:
+  coverage:
+    name: Upload coverage
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: crit_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.19"
+          otp-version: "28"
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v6
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Run tests with coverage
+        run: mix coveralls.json
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost/crit_test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          files: cover/excoveralls.json
+          flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,6 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Tests use `DataCase` (database) or `ConnCase` (HTTP). Test database: `crit_test`
 
 **E2E** (Playwright): `mise run e2e` is the one command — idempotent and self-bootstrapping, so a fresh worktree runs the suite without any manual `npm install`. It runs `npm ci` (root Playwright deps, which `wt step copy-ignored` can't copy because the source checkout never installs them), `npx playwright install chromium`, `npm install --prefix assets`, `mix assets.build`, ensures the DB is up, then `npx playwright test`. `playwright.config.ts`'s managed `webServer` starts Phoenix and runs ecto.create/migrate itself. Mirrors `.github/workflows/e2e.yml`.
 
-CI runs the same sequence in `.github/workflows/ci.yml` (Postgres 17 service, Elixir 1.19 / OTP 28), with `mix coveralls.json` instead of plain `mix test` for Codecov upload.
+CI runs the same sequence in `.github/workflows/ci.yml` (Postgres 17 service, Elixir 1.19 / OTP 28), with `mix coveralls.json` instead of plain `mix test` for Codecov upload. `.github/workflows/coverage.yml` uploads the same coverage on push to `main`.
 </important>
 
 <important if="you need to know the route surface or are adding/modifying a route">


### PR DESCRIPTION
## Summary

CI was running the full suite on every push to `main` in addition to PRs, but just about every change already goes through a PR. This PR makes CI PR-only and keeps a minimal coverage upload on main so Codecov base coverage stays fresh.

- `ci.yml` and `e2e.yml` now trigger on `pull_request` only.
- New `coverage.yml` runs `mix coveralls.json` and uploads to Codecov on push to `main`.
- Updated the stale AGENTS.md CI reference.

## Review

- [x] Code review: passed
- [x] Parity audit: N/A (CI-only)

## Test plan

- [x] `actionlint` passes on all workflows

See also: tomasz-tomczyk/crit#786 — same change for crit.