### PR TITLE
feat: add customizable keyboard shortcuts

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2397,6 +2397,7 @@ body.dragging { user-select: none; cursor: grabbing; }
   opacity: 1;
   transform: translateY(0);
 }
+.mini-toast--error { border-color: var(--crit-red); }
 
 /* Comment template chips */
 .comment-template-bar {
@@ -3172,12 +3173,16 @@ body.sidebar-resizing * {
   background: var(--crit-editor-bg-elevated);
   border: 1px solid var(--crit-border);
   border-radius: 4px;
+  box-sizing: border-box;
+  height: 22px;
+  line-height: 18px;
   padding: 1px 6px;
   font-family: monospace;
   font-size: 12px;
   color: var(--crit-editor-fg);
   min-width: 24px;
   text-align: center;
+  vertical-align: middle;
 }
 
 .shortcuts-table td:first-child {
@@ -3366,6 +3371,26 @@ body.sidebar-resizing * {
 .settings-pill--width .settings-pill-btn { padding: 6px 0; width: 72px; text-align: center; }
 
 /* Shortcuts table (inside settings panel) */
+.shortcuts-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--crit-editor-fg-muted);
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+.shortcut-reset-all {
+  appearance: none;
+  border: 0;
+  background: none;
+  color: var(--crit-brand);
+  cursor: pointer;
+  font: inherit;
+  white-space: nowrap;
+}
+.shortcut-reset-all:hover { text-decoration: underline; }
+.shortcut-reset-all:focus-visible { outline: none; box-shadow: var(--crit-focus); }
 .shortcuts-group-label {
   font-size: 12px;
   text-transform: uppercase;
@@ -3375,6 +3400,32 @@ body.sidebar-resizing * {
   margin-top: 16px;
 }
 .shortcuts-group-label:first-child { margin-top: 0; }
+.shortcuts-toolbar + .shortcuts-group-label { margin-top: 0; }
+.shortcut-binding {
+  appearance: none;
+  align-items: center;
+  border: 0;
+  box-sizing: border-box;
+  background: none;
+  border-radius: 4px;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  height: 26px;
+  line-height: 1;
+  padding: 2px;
+  vertical-align: middle;
+}
+.shortcut-binding:hover { background: var(--crit-editor-bg-hover); }
+.shortcut-binding:focus-visible,
+.shortcut-binding.is-capturing { outline: none; box-shadow: var(--crit-focus); }
+.shortcut-binding.is-customized kbd { border-color: var(--crit-brand); }
+.shortcut-unassigned {
+  color: var(--crit-editor-fg-muted);
+  font-size: 12px;
+  font-style: italic;
+}
 .shortcut-mode-badge {
   display: inline-block;
   font-size: 11px;

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -15,6 +15,7 @@ import {
   attachSidebarResizeHandle,
 } from "./comments-panel"
 import { createSettingsPanel } from "./settings-panel"
+import { actionForEvent } from "./shortcut-registry"
 import { pushMutation, mutationErrorMessage } from "./liveview-mutation"
 
 // Re-register hljs 'markdown' with patched grammar. Must run before any
@@ -4443,32 +4444,6 @@ function applyWidth(choice) {
 // mode supplies the per-mode bits: content-width, hide-resolved, and the files
 // keyboard-shortcut list. createSettingsPanel() is called from mounted().
 
-const FILES_SHORTCUT_GROUPS = [
-  { label: 'Navigation', shortcuts: [
-    { key: '<kbd>j</kbd>', action: 'Next block' },
-    { key: '<kbd>k</kbd>', action: 'Previous block' },
-    { key: '<kbd>Shift</kbd>+<kbd>V</kbd>', action: 'Visual line mode (extend with j/k, then c to comment)' },
-    { key: '<kbd>]</kbd>', action: 'Next comment' },
-    { key: '<kbd>[</kbd>', action: 'Previous comment' },
-  ]},
-  { label: 'Comments', shortcuts: [
-    { key: '<kbd>c</kbd>', action: 'Comment on focused block (or text selection, with quote)' },
-    { key: '<kbd>e</kbd>', action: 'Edit comment on focused block' },
-    { key: '<kbd>d</kbd>', action: 'Delete comment on focused block' },
-    { key: '<kbd>Shift</kbd>+<kbd>G</kbd>', action: 'General comment' },
-    { key: '<kbd>Ctrl</kbd>+<kbd>Enter</kbd>', action: 'Comment' },
-  ]},
-  { label: 'Review', shortcuts: [
-    { key: '<kbd>Shift</kbd>+<kbd>C</kbd>', action: 'Toggle comments panel' },
-  ]},
-  { label: 'View', shortcuts: [
-    { key: '<kbd>t</kbd>', action: 'Toggle table of contents' },
-    { key: '<kbd>h</kbd>', action: 'Toggle hide resolved' },
-    { key: '<kbd>Esc</kbd>', action: 'Cancel / clear focus' },
-    { key: '<kbd>?</kbd>', action: 'Toggle shortcuts' },
-  ]},
-]
-
 function filesSettingsAdapter(ctx) {
   return {
     showWidth: true,
@@ -4477,7 +4452,7 @@ function filesSettingsAdapter(ctx) {
     showHideResolved: true,
     readHideResolved: () => isHideResolved(ctx),
     setHideResolved: (v) => setHideResolved(ctx, v),
-    shortcutGroups: FILES_SHORTCUT_GROUPS,
+    shortcutMode: 'files',
   }
 }
 
@@ -5047,13 +5022,13 @@ export const DocumentRenderer = {
 
     ctx._keydownHandler = (e) => {
       const tag = e.target.tagName
-      if (tag === 'TEXTAREA' || tag === 'INPUT' || e.target.isContentEditable) {
+      if (tag === 'TEXTAREA' || tag === 'INPUT' || tag === 'SELECT' || e.target.isContentEditable) {
         // Textarea keydown is handled by per-form handlers with stopPropagation
         return
       }
-      // Allow Shift (for Shift+C) but block other modifiers
-      if (e.metaKey || e.ctrlKey || e.altKey) return
-
+      const interactive = e.target.closest?.(
+        'button, a[href], summary, [role="button"], [role="link"], [role="radio"], [role="checkbox"], [role="switch"], [role="tab"], [role="menuitem"], [role="option"], [role="slider"]'
+      )
       // Settings panel (shortcuts tab via ?)
       if (e.key === '?') {
         e.preventDefault()
@@ -5068,16 +5043,22 @@ export const DocumentRenderer = {
         }
         return
       }
+      // Preserve keys with native widget semantics while still allowing
+      // letter shortcuts after a toolbar button was clicked and retained focus.
+      if (interactive && [' ', 'Enter', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) return
+
+      const shortcutAction = actionForEvent(e, 'files')
+      if (!shortcutAction && (e.metaKey || e.ctrlKey || e.altKey)) return
 
       // Comments panel toggle
-      if (e.key === 'C' && e.shiftKey) {
+      if (shortcutAction === 'toggle_comments') {
         e.preventDefault()
         toggleCommentsPanel(ctx)
         return
       }
 
       // Hide resolved toggle
-      if (e.key === 'h') {
+      if (shortcutAction === 'toggle_resolved') {
         e.preventDefault()
         const current = isHideResolved(ctx)
         setHideResolved(ctx, !current)
@@ -5088,11 +5069,11 @@ export const DocumentRenderer = {
       }
 
       // Comment navigation
-      if (e.key === '[') { e.preventDefault(); navigateToComment(ctx, -1); return }
-      if (e.key === ']') { e.preventDefault(); navigateToComment(ctx, 1); return }
+      if (shortcutAction === 'previous_comment') { e.preventDefault(); navigateToComment(ctx, -1); return }
+      if (shortcutAction === 'next_comment') { e.preventDefault(); navigateToComment(ctx, 1); return }
 
       // Review comment form
-      if (e.key === 'G' && e.shiftKey) {
+      if (shortcutAction === 'general_comment') {
         e.preventDefault()
         openReviewCommentForm(ctx)
         return
@@ -5101,23 +5082,22 @@ export const DocumentRenderer = {
       const blocks = ctx.el.querySelectorAll('.line-block')
       const blockCount = blocks.length
 
-      switch (e.key) {
-        case 'j': {
+      switch (shortcutAction || e.key) {
+        case 'next_block': {
           e.preventDefault()
           const next = ctx.focusedBlockIndex < blockCount - 1 ? ctx.focusedBlockIndex + 1 : 0
           focusBlock(ctx, next)
           if (ctx.visualMode) extendVisualSelection(ctx)
           break
         }
-        case 'k': {
+        case 'previous_block': {
           e.preventDefault()
           const prev = ctx.focusedBlockIndex > 0 ? ctx.focusedBlockIndex - 1 : blockCount - 1
           focusBlock(ctx, prev)
           if (ctx.visualMode) extendVisualSelection(ctx)
           break
         }
-        case 'V': {
-          if (!e.shiftKey) break
+        case 'visual_mode': {
           e.preventDefault()
           if (ctx.visualMode) {
             exitVisualMode(ctx, true)
@@ -5126,7 +5106,7 @@ export const DocumentRenderer = {
           }
           break
         }
-        case 'c': {
+        case 'comment': {
           e.preventDefault()
           // Visual mode: comment on the active selection.
           if (ctx.visualMode && ctx.selectionStart !== null && ctx.selectionEnd !== null) {
@@ -5171,7 +5151,7 @@ export const DocumentRenderer = {
           })
           break
         }
-        case 'e': {
+        case 'edit_comment': {
           e.preventDefault()
           if (ctx.focusedBlockIndex < 0) break
           const lineBlocks = getFocusedLineBlocks(ctx)
@@ -5195,7 +5175,7 @@ export const DocumentRenderer = {
           render(ctx)
           break
         }
-        case 'd': {
+        case 'delete_comment': {
           e.preventDefault()
           if (ctx.focusedBlockIndex < 0) break
           const lineBlocks = getFocusedLineBlocks(ctx)
@@ -5210,7 +5190,7 @@ export const DocumentRenderer = {
           if (comment) pushCommentMutation(ctx, 'delete_comment', { id: comment.id })
           break
         }
-        case 't': {
+        case 'toggle_toc': {
           e.preventDefault()
           const tocToggle = document.getElementById('crit-toc-toggle')
           if (tocToggle) tocToggle.click()

--- a/assets/js/preview-mode.js
+++ b/assets/js/preview-mode.js
@@ -29,17 +29,8 @@
 
 import { renderCommentCard, attachSidebarResizeHandle, escapeHtml, startInlineBodyEdit } from "./comments-panel"
 import { createSettingsPanel } from "./settings-panel"
+import { actionForEvent } from "./shortcut-registry"
 import { pushMutation, mutationErrorMessage } from "./liveview-mutation"
-
-// Preview-mode keyboard shortcuts (the shared settings overlay's Shortcuts tab).
-// Preview's interaction model is the Navigate/Pin header toggle + composer, so
-// the list is short and honest (no vim keys like files mode).
-const PREVIEW_SHORTCUT_GROUPS = [
-  { label: "Commenting", shortcuts: [
-    { key: "<kbd>Ctrl</kbd>+<kbd>Enter</kbd>", action: "Submit the open comment or reply" },
-    { key: "<kbd>Esc</kbd>", action: "Cancel the open composer or reply" },
-  ]},
-]
 
 // Chrome → Agent message types (copied verbatim from agent-protocol.js C2A).
 const C2A = {
@@ -60,6 +51,10 @@ const A2C = {
   PIN_CLICKED: "pin-clicked",
   FOCUS_STATE: "focus-state",
 }
+
+// Crit Web-only companion script forwards shortcuts pressed inside the
+// sandboxed preview iframe. Keep this outside the vendored Crit protocol.
+const WEB_A2C_SHORTCUT_KEY = "crit-web-shortcut-key"
 
 // Viewport presets — mirrors crit live-mode.js VIEWPORTS.
 const VIEWPORTS = [
@@ -141,8 +136,48 @@ export const PreviewMode = {
     this.settings = createSettingsPanel({
       showWidth: false,
       showHideResolved: false,
-      shortcutGroups: PREVIEW_SHORTCUT_GROUPS,
+      shortcutMode: "preview",
     })
+
+    this.handleShortcut = (event) => {
+      const target = event.target
+      const tag = target?.tagName
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target?.isContentEditable) return
+      const interactive = target?.closest?.(
+        'button, a[href], summary, [role="button"], [role="link"], [role="radio"], [role="checkbox"], [role="switch"], [role="tab"], [role="menuitem"], [role="option"], [role="slider"]'
+      )
+
+      if (event.key === "?") {
+        event.preventDefault()
+        this.settings.toggle("shortcuts")
+        return
+      }
+      if (this.settings.isOpen()) {
+        if (event.key === "Escape") {
+          event.preventDefault()
+          this.settings.close()
+        }
+        return
+      }
+      if (event.key === "Escape" && this.mode === "pin") {
+        event.preventDefault()
+        this.setMode("navigate")
+        return
+      }
+      // Preserve keys with native widget semantics while still allowing
+      // letter shortcuts after a toolbar button was clicked and retained focus.
+      if (interactive && [" ", "Enter", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return
+
+      const action = actionForEvent(event, "preview")
+      if (action === "toggle_pin_mode") {
+        event.preventDefault()
+        const pinButton = this.modeToggle?.querySelector('[data-mode="pin"]')
+        if (this.mode !== "pin" && pinButton?.hasAttribute("disabled")) return
+        this.setMode(this.mode === "pin" ? "navigate" : "pin")
+      }
+    }
+    this.onShortcut = (event) => this.handleShortcut(event)
+    document.addEventListener("keydown", this.onShortcut)
 
     // Agent bridge. The agent posts from the iframe's content window; we only
     // accept messages whose source is our iframe and whose origin is ours
@@ -215,6 +250,7 @@ export const PreviewMode = {
   },
 
   destroyed() {
+    if (this.onShortcut) document.removeEventListener("keydown", this.onShortcut)
     if (this.onMessage) window.removeEventListener("message", this.onMessage)
     if (this.onResize) window.removeEventListener("resize", this.onResize)
     if (this.onToggleComments) this.el.removeEventListener("crit:toggle-comments", this.onToggleComments)
@@ -571,6 +607,20 @@ export const PreviewMode = {
       case A2C.FOCUS_STATE:
         // No-op: crit uses this to suppress shortcuts while typing in the
         // iframe; preview-mode has no global shortcuts to suppress.
+        break
+      case WEB_A2C_SHORTCUT_KEY:
+        if (typeof msg.key !== "string" || typeof msg.code !== "string") break
+        if (![msg.ctrlKey, msg.altKey, msg.shiftKey, msg.metaKey].every(value => typeof value === "boolean")) break
+        this.handleShortcut({
+          key: msg.key,
+          code: msg.code,
+          ctrlKey: msg.ctrlKey,
+          altKey: msg.altKey,
+          shiftKey: msg.shiftKey,
+          metaKey: msg.metaKey,
+          target: null,
+          preventDefault() {},
+        })
         break
       default:
         break

--- a/assets/js/settings-panel.js
+++ b/assets/js/settings-panel.js
@@ -15,6 +15,17 @@
 // pure data on the adapter: preview drops Content-Width, supplies its own
 // shortcut list, and (for now) omits Hide-resolved.
 
+import {
+  eventToBinding,
+  findConflict,
+  getBinding,
+  groupsForMode,
+  isCustomized,
+  isReservedBinding,
+  resetAll,
+  setBinding,
+} from "./shortcut-registry"
+
 const THEME_ICONS = {
   system: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M2 4.25A2.25 2.25 0 0 1 4.25 2h7.5A2.25 2.25 0 0 1 14 4.25v5.5A2.25 2.25 0 0 1 11.75 12h-1.312c.1.128.21.248.328.36a.75.75 0 0 1 .234.545v.345a.75.75 0 0 1-.75.75h-4.5a.75.75 0 0 1-.75-.75v-.345a.75.75 0 0 1 .234-.545c.118-.111.228-.232.328-.36H4.25A2.25 2.25 0 0 1 2 9.75v-5.5Zm2.25-.75a.75.75 0 0 0-.75.75v4.5c0 .414.336.75.75.75h7.5a.75.75 0 0 0 .75-.75v-4.5a.75.75 0 0 0-.75-.75h-7.5Z" clip-rule="evenodd"/></svg>',
   light: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="M8 1a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 1ZM10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0ZM12.95 4.11a.75.75 0 1 0-1.06-1.06l-1.062 1.06a.75.75 0 0 0 1.061 1.062l1.06-1.061ZM15 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 15 8ZM11.89 12.95a.75.75 0 0 0 1.06-1.06l-1.06-1.062a.75.75 0 0 0-1.062 1.061l1.061 1.06ZM8 12a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 12ZM5.172 11.89a.75.75 0 0 0-1.061-1.062L3.05 11.89a.75.75 0 1 0 1.06 1.06l1.06-1.06ZM4 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 4 8ZM4.11 5.172A.75.75 0 0 0 5.173 4.11L4.11 3.05a.75.75 0 1 0-1.06 1.06l1.06 1.06Z"/></svg>',
@@ -39,7 +50,7 @@ function updatePillIndicator(indicatorId, values, current) {
 // handle. adapter:
 //   showWidth: bool, readWidth(): string, applyWidth(choice)          (files)
 //   showHideResolved: bool, readHideResolved(): bool, setHideResolved(v) (files)
-//   shortcutGroups: [{ label, shortcuts: [{ key, action, mode? }] }]  (per-mode)
+//   shortcutMode: "files" | "preview"
 // Theme + About are universal and need no adapter input.
 export function createSettingsPanel(adapter) {
   const overlay = document.getElementById('settingsOverlay')
@@ -148,18 +159,111 @@ export function createSettingsPanel(adapter) {
   function renderShortcutsPane() {
     const pane = document.getElementById('shortcutsPane')
     if (!pane) return
-    const groups = adapter.shortcutGroups || []
-    let html = ''
+    const groups = groupsForMode(adapter.shortcutMode)
+    let html = '<div class="shortcuts-toolbar">'
+    html += '<span>Click a shortcut, then press its new keys. Backspace disables it.</span>'
+    html += '<button type="button" class="shortcut-reset-all">Reset all</button>'
+    html += '</div>'
+
+    function escapeHtml(value) {
+      return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+    }
+
+    function bindingHtml(binding) {
+      if (!binding) return '<span class="shortcut-unassigned">Unassigned</span>'
+      return binding.split('+').map(part => '<kbd>' + escapeHtml(part) + '</kbd>').join('+')
+    }
+
     groups.forEach(function(group) {
       html += '<div class="shortcuts-group-label">' + group.label + '</div>'
       html += '<table class="shortcuts-table">'
       group.shortcuts.forEach(function(s) {
         const modeTag = s.mode ? '<span class="shortcut-mode-badge">' + s.mode + '</span>' : ''
-        html += '<tr><td>' + s.key + '</td><td>' + s.action + modeTag + '</td></tr>'
+        const binding = s.id ? getBinding(s.id) : s.binding
+        let key = bindingHtml(binding)
+        if (s.id && !s.fixed) {
+          const customized = isCustomized(s.id) ? ' is-customized' : ''
+          key = '<button type="button" class="shortcut-binding' + customized + '" data-shortcut-id="' + escapeHtml(s.id) +
+            '" aria-label="Change shortcut for ' + escapeHtml(s.action) + '">' + key + '</button>'
+        }
+        html += '<tr><td>' + key + '</td><td>' + escapeHtml(s.action) + modeTag + '</td></tr>'
       })
       html += '</table>'
     })
     pane.innerHTML = html
+
+    function showError(message) {
+      let host = document.querySelector('.mini-toast-host')
+      if (!host) {
+        host = document.createElement('div')
+        host.className = 'mini-toast-host'
+        document.body.appendChild(host)
+      }
+      const toast = document.createElement('div')
+      toast.className = 'mini-toast mini-toast--error'
+      toast.textContent = message
+      host.appendChild(toast)
+      requestAnimationFrame(() => toast.classList.add('mini-toast-visible'))
+      setTimeout(() => {
+        toast.addEventListener('transitionend', () => toast.remove(), { once: true })
+        toast.classList.remove('mini-toast-visible')
+      }, 3000)
+    }
+
+    const rerender = () => renderShortcutsPane()
+    pane.querySelector('.shortcut-reset-all')?.addEventListener('click', () => {
+      resetAll()
+      rerender()
+    })
+
+    pane.querySelectorAll('.shortcut-binding').forEach(button => {
+      button.addEventListener('click', () => {
+        button.classList.add('is-capturing')
+        button.innerHTML = '<kbd>Press keys…</kbd>'
+      })
+      button.addEventListener('blur', event => {
+        if (!button.classList.contains('is-capturing')) return
+        const next = event.relatedTarget
+        if (next?.closest?.('.shortcut-binding, .shortcut-reset-all')) {
+          button.classList.remove('is-capturing')
+          button.innerHTML = bindingHtml(getBinding(button.dataset.shortcutId))
+          return
+        }
+        rerender()
+      })
+      button.addEventListener('keydown', event => {
+        if (!button.classList.contains('is-capturing')) return
+        event.preventDefault()
+        event.stopImmediatePropagation()
+        if (event.key === 'Escape') { rerender(); return }
+
+        const binding = ['Backspace', 'Delete'].includes(event.key) ? '' : eventToBinding(event)
+        if (!binding && !['Backspace', 'Delete'].includes(event.key)) return
+        const id = button.dataset.shortcutId
+
+        const reject = message => {
+          button.classList.remove('is-capturing')
+          button.innerHTML = bindingHtml(getBinding(id))
+          showError(message)
+        }
+        if (isReservedBinding(binding)) {
+          reject(binding + ' is reserved by Crit Web.')
+          return
+        }
+        const conflict = findConflict(id, binding)
+        if (conflict) {
+          reject(binding + ' is already assigned to “' + conflict.action + '”.')
+          return
+        }
+        setBinding(id, binding)
+        rerender()
+      })
+    })
   }
 
   function renderAboutPane() {

--- a/assets/js/shortcut-registry.js
+++ b/assets/js/shortcut-registry.js
@@ -1,0 +1,163 @@
+// Shared keyboard shortcut definitions, persistence, and key normalization.
+// Overrides are local to this Crit Web origin and shared by files + preview.
+
+const STORAGE_KEY = "crit-shortcuts"
+const FILES = ["files"]
+const PREVIEW = ["preview"]
+const BOTH = ["files", "preview"]
+
+export const shortcutGroups = [
+  { label: "Navigation", shortcuts: [
+    { id: "next_block", binding: "j", action: "Next block", modes: FILES },
+    { id: "previous_block", binding: "k", action: "Previous block", modes: FILES },
+    { id: "visual_mode", binding: "Shift+V", action: "Visual line mode (extend with next/previous block, then comment)", modes: FILES },
+    { id: "next_comment", binding: "]", action: "Next comment", modes: FILES },
+    { id: "previous_comment", binding: "[", action: "Previous comment", modes: FILES },
+  ] },
+  { label: "Comments", shortcuts: [
+    { id: "comment", binding: "c", action: "Comment on focused block (or text selection, with quote)", modes: FILES },
+    { id: "edit_comment", binding: "e", action: "Edit comment on focused block", modes: FILES },
+    { id: "delete_comment", binding: "d", action: "Delete comment on focused block", modes: FILES },
+    { id: "general_comment", binding: "Shift+G", action: "General comment", modes: FILES },
+    { binding: "Ctrl+Enter", action: "Submit the open comment or reply", modes: BOTH, fixed: true },
+  ] },
+  { label: "Review", shortcuts: [
+    { id: "toggle_comments", binding: "Shift+C", action: "Toggle comments panel", modes: FILES },
+  ] },
+  { label: "Preview", shortcuts: [
+    { id: "toggle_pin_mode", binding: "p", action: "Toggle pin mode", modes: PREVIEW },
+  ] },
+  { label: "View", shortcuts: [
+    { id: "toggle_toc", binding: "t", action: "Toggle table of contents", modes: FILES },
+    { id: "toggle_resolved", binding: "h", action: "Toggle hide resolved", modes: FILES },
+    { binding: "Esc", action: "Cancel / clear focus", modes: BOTH, fixed: true },
+    { binding: "?", action: "Toggle this panel", modes: BOTH, fixed: true },
+  ] },
+]
+
+const byId = new Map()
+shortcutGroups.forEach(group => group.shortcuts.forEach(shortcut => {
+  if (shortcut.id) byId.set(shortcut.id, shortcut)
+}))
+
+function readOverrides() {
+  try {
+    const value = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}")
+    if (!value || typeof value !== "object" || Array.isArray(value)) return {}
+    return Object.fromEntries(Object.entries(value).filter(([id, binding]) => (
+      byId.has(id) && typeof binding === "string"
+    )))
+  } catch (_) {
+    return {}
+  }
+}
+
+function writeOverrides(value) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(value || {}))
+}
+
+export function getBinding(id) {
+  const shortcut = byId.get(id)
+  if (!shortcut) return ""
+  const saved = readOverrides()
+  return Object.prototype.hasOwnProperty.call(saved, id) ? saved[id] : shortcut.binding
+}
+
+export function setBinding(id, binding) {
+  const shortcut = byId.get(id)
+  if (!shortcut) return false
+  const saved = readOverrides()
+  if (binding === shortcut.binding) delete saved[id]
+  else saved[id] = binding
+  writeOverrides(saved)
+  return true
+}
+
+export function resetAll() {
+  writeOverrides({})
+}
+
+export function isCustomized(id) {
+  return Object.prototype.hasOwnProperty.call(readOverrides(), id)
+}
+
+export function eventToBinding(event) {
+  let key = event.key
+  if (!key || ["Shift", "Control", "Alt", "Meta"].includes(key)) return ""
+  const names = { " ": "Space", Escape: "Esc" }
+  key = names[key] || key
+
+  const shiftedGlyphs = {
+    "!": "1", "@": "2", "#": "3", "$": "4", "%": "5", "^": "6",
+    "&": "7", "*": "8", "(": "9", ")": "0", _: "-", "+": "=",
+    "{": "[", "}": "]", ":": ";", '"': "'", "<": ",", ">": ".",
+    "?": "/", "|": "\\", "~": "`",
+  }
+  let shifted = !!event.shiftKey
+  if (shiftedGlyphs[key]) {
+    key = shiftedGlyphs[key]
+    shifted = true
+  }
+
+  if (shifted && /^Digit[0-9]$/.test(event.code || "")) key = event.code.slice(5)
+  else if (shifted) {
+    const codeKeys = {
+      BracketLeft: "[", BracketRight: "]", Semicolon: ";", Quote: "'",
+      Comma: ",", Period: ".", Slash: "/", Backslash: "\\", Backquote: "`",
+      Minus: "-", Equal: "=",
+    }
+    if (codeKeys[event.code]) key = codeKeys[event.code]
+  }
+  if (key.length === 1 && /^[a-zA-Z]$/.test(key)) {
+    key = shifted ? key.toUpperCase() : key.toLowerCase()
+  }
+
+  const parts = []
+  if (event.ctrlKey) parts.push("Ctrl")
+  if (event.altKey) parts.push("Alt")
+  if (shifted) parts.push("Shift")
+  if (event.metaKey) parts.push("Meta")
+  parts.push(key)
+  return parts.join("+")
+}
+
+export function actionForEvent(event, mode) {
+  const binding = eventToBinding(event)
+  if (!binding) return ""
+  for (const group of shortcutGroups) {
+    for (const shortcut of group.shortcuts) {
+      if (shortcut.id && shortcut.modes.includes(mode) && getBinding(shortcut.id) === binding) {
+        return shortcut.id
+      }
+    }
+  }
+  return ""
+}
+
+export function findConflict(id, binding) {
+  if (!binding) return null
+  const target = byId.get(id)
+  if (!target) return null
+  for (const group of shortcutGroups) {
+    for (const shortcut of group.shortcuts) {
+      if (!shortcut.id || shortcut.id === id) continue
+      if (!shortcut.modes.some(mode => target.modes.includes(mode))) continue
+      if (getBinding(shortcut.id) === binding) return shortcut
+    }
+  }
+  return null
+}
+
+export function groupsForMode(mode) {
+  return shortcutGroups.map(group => ({
+    label: group.label,
+    shortcuts: group.shortcuts.filter(shortcut => shortcut.modes.includes(mode)),
+  })).filter(group => group.shortcuts.length > 0)
+}
+
+export function isReservedBinding(binding) {
+  if (["Esc", "Tab", "Enter"].includes(binding)) return true
+  const parts = binding.split("+")
+  if (parts[parts.length - 1] === "/" && parts.includes("Shift")) return true
+  return parts[parts.length - 1] === "Enter" && (parts.includes("Ctrl") || parts.includes("Meta"))
+}

--- a/e2e/keyboard.spec.ts
+++ b/e2e/keyboard.spec.ts
@@ -97,6 +97,118 @@ test.describe("Keyboard Shortcuts", () => {
     await expect(overlay).not.toBeVisible();
   });
 
+  test("custom shortcut applies immediately, persists, and resets", async ({
+    page,
+  }) => {
+    await loadReview(page, token);
+    await page.keyboard.press("?");
+    await page.locator('[data-shortcut-id="next_block"]').click();
+    await page.keyboard.press("ArrowDown");
+    await expect(page.locator('[data-shortcut-id="next_block"]')).toContainText("ArrowDown");
+
+    await page.locator("#settingsOverlay").click({ position: { x: 10, y: 10 } });
+    await page.keyboard.press("j");
+    await expect(page.locator(".line-block.focused")).toHaveCount(0);
+    await page.keyboard.press("ArrowDown");
+    await expect(page.locator(".line-block.focused")).toHaveCount(1);
+
+    await loadReview(page, token);
+    await page.locator("#settingsToggle").click();
+    await page.locator('[data-tab="shortcuts"]').click();
+    await expect(page.locator('[data-shortcut-id="next_block"]')).toContainText("ArrowDown");
+    await page.locator(".shortcut-reset-all").click();
+    await page.locator("#settingsOverlay").click({ position: { x: 10, y: 10 } });
+    await page.keyboard.press("j");
+    await expect(page.locator(".line-block.focused")).toHaveCount(1);
+  });
+
+  test("shortcut conflicts use a toast without changing row height", async ({
+    page,
+  }) => {
+    await loadReview(page, token);
+    await page.keyboard.press("?");
+    await expect.poll(() => page.locator(".settings-dialog").evaluate(
+      element => getComputedStyle(element).transform
+    )).toBe("none");
+    const previous = page.locator('[data-shortcut-id="previous_block"]');
+    const row = previous.locator("xpath=ancestor::tr");
+    const before = await row.evaluate(element => element.getBoundingClientRect().height);
+    await previous.click();
+    const editing = await row.evaluate(element => element.getBoundingClientRect().height);
+    expect(editing).toBe(before);
+    await page.keyboard.press("j");
+
+    await expect(page.locator(".mini-toast--error")).toContainText(
+      "already assigned to “Next block”"
+    );
+  });
+
+  test("capture can move to another shortcut or Reset all on the first click", async ({
+    page,
+  }) => {
+    await loadReview(page, token);
+    await page.keyboard.press("?");
+    const next = page.locator('[data-shortcut-id="next_block"]');
+    const previous = page.locator('[data-shortcut-id="previous_block"]');
+
+    await next.click();
+    await previous.click();
+    await expect(next).toContainText("j");
+    await expect(previous).toContainText("Press keys…");
+
+    await page.locator(".shortcut-reset-all").click();
+    await expect(previous).toContainText("k");
+    await expect(page.locator(".shortcut-binding.is-capturing")).toHaveCount(0);
+  });
+
+  test("modified question-mark chords are reserved", async ({ page }) => {
+    await loadReview(page, token);
+    await page.keyboard.press("?");
+    const next = page.locator('[data-shortcut-id="next_block"]');
+    await next.click();
+    await page.keyboard.press("Control+Shift+/");
+
+    await expect(page.locator(".mini-toast--error")).toContainText("is reserved by Crit Web");
+    await expect(next).toContainText("j");
+  });
+
+  test("custom Space shortcut does not hijack a focused button", async ({ page }) => {
+    await loadReview(page, token);
+    await page.keyboard.press("?");
+    await page.locator('[data-shortcut-id="next_block"]').click();
+    await page.keyboard.press("Space");
+    await page.locator("#settingsOverlay").click({ position: { x: 10, y: 10 } });
+
+    await page.locator("#settingsToggle").focus();
+    await page.keyboard.press("Space");
+    await expect(page.locator("#settingsOverlay.active")).toBeVisible();
+    await expect(page.locator(".line-block.focused")).toHaveCount(0);
+  });
+
+  test("fixed settings shortcuts work while a settings control is focused", async ({ page }) => {
+    await loadReview(page, token);
+    await page.keyboard.press("?");
+    await page.locator(".shortcut-reset-all").focus();
+    await page.keyboard.press("Escape");
+    await expect(page.locator("#settingsOverlay.active")).toHaveCount(0);
+
+    await page.locator("#settingsToggle").click();
+    await page.locator('.settings-tab[data-tab="shortcuts"]').focus();
+    await page.keyboard.press("?");
+    await expect(page.locator("#settingsOverlay.active")).toHaveCount(0);
+  });
+
+  test("malformed persisted shortcut values fall back without breaking settings", async ({ page }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", error => pageErrors.push(error));
+    await page.addInitScript(() => localStorage.setItem("crit-shortcuts", JSON.stringify({ next_block: 7 })));
+    await loadReview(page, token);
+    await page.keyboard.press("?");
+
+    await expect(page.locator('[data-shortcut-id="next_block"]')).toContainText("j");
+    expect(pageErrors).toEqual([]);
+  });
+
   test("[ and ] navigate between comments", async ({ page, request }) => {
     await seedComment(request, token, {
       body: "First shortcut comment",

--- a/e2e/preview.spec.ts
+++ b/e2e/preview.spec.ts
@@ -57,6 +57,44 @@ test.describe("Preview mode", () => {
     await expect(frame.locator("#counter")).toHaveText("Clicked 0 times");
   });
 
+  test("custom pin shortcut can be set and used from preview mode", async ({
+    page,
+    request,
+  }) => {
+    const review = await createPreviewReview(request);
+    token = review.token;
+    deleteToken = review.deleteToken;
+
+    await loadPreview(page, token);
+    const pin = page.locator('#critPreviewMode button[data-mode="pin"]');
+    await expect(pin).toBeEnabled({ timeout: 10_000 });
+
+    await pin.click();
+    await page.keyboard.press("Escape");
+    await expect(pin).not.toHaveClass(/crit-toggle-btn--active/);
+
+    await page.locator("#settingsToggle").click();
+    await page.locator('.settings-tab[data-tab="shortcuts"]').click();
+    await page.locator('[data-shortcut-id="toggle_pin_mode"]').click();
+    await page.keyboard.press("x");
+    await page.locator("#settingsOverlay").click({ position: { x: 10, y: 10 } });
+
+    await page.keyboard.press("p");
+    await expect(pin).not.toHaveClass(/crit-toggle-btn--active/);
+    await page.keyboard.press("x");
+    await expect(pin).toHaveClass(/crit-toggle-btn--active/);
+
+    const frame = page.frameLocator("#critPreviewIframe");
+    await page.keyboard.press("x");
+    await frame.locator("#hero").click();
+    await page.keyboard.press("x");
+    await expect(pin).toHaveClass(/crit-toggle-btn--active/);
+
+    await page.keyboard.press("?");
+    await expect(page.locator('[data-shortcut-id="toggle_pin_mode"]')).toContainText("x");
+    await page.locator(".shortcut-reset-all").click();
+  });
+
   test("existing dom-anchored comment shows as a card and matches the badge", async ({
     page,
     request,

--- a/e2e/security.spec.ts
+++ b/e2e/security.spec.ts
@@ -166,10 +166,18 @@ test.describe("Preview isolation: preview iframe cannot exfiltrate victim sessio
       await expect(marker).toHaveCSS("width", "22px");
       await expect(marker).toHaveCSS("background-color", "rgb(37, 99, 235)");
 
-      await pinButton.click();
+      await page.locator("#settingsToggle").click();
+      await page.locator('.settings-tab[data-tab="shortcuts"]').click();
+      await page.locator('[data-shortcut-id="toggle_pin_mode"]').click();
+      await page.keyboard.press("x");
+      await page.locator("#settingsOverlay").click({ position: { x: 10, y: 10 } });
+
+      const previewFrame = page.frameLocator("#critPreviewIframe");
+      await previewFrame.locator("#hero").click();
+      await page.keyboard.press("x");
       await expect(pinButton).toHaveAttribute("aria-pressed", "true");
 
-      await page.frameLocator("#critPreviewIframe").locator("#hero").click();
+      await previewFrame.locator("#hero").click();
       await expect(page.locator(".crit-preview-composer-body")).toBeVisible({
         timeout: 10_000,
       });

--- a/lib/crit_web/controllers/raw_controller.ex
+++ b/lib/crit_web/controllers/raw_controller.ex
@@ -6,12 +6,10 @@ defmodule CritWeb.RawController do
 
   plug :require_review_scope
 
-  # The 8 transport-agnostic agent scripts crit injects into preview iframes,
-  # vendored verbatim into priv/static/preview-agent/. Order matters and must
-  # match crit's `AgentScriptFiles` (server.go): protocol first, helpers next,
-  # the main agent entry point last. Keeping the order identical preserves
-  # DOM-anchor compatibility across the crit (Go) and crit-web (Phoenix)
-  # renderers. `agent-marker.css` is served separately and is NOT injected.
+  # The first 8 transport-agnostic scripts are vendored verbatim from crit and
+  # retain its `AgentScriptFiles` order. The final Crit Web-only bridge forwards
+  # keys from the sandboxed iframe to the customizable preview shortcut handler.
+  # `agent-marker.css` is served separately and is NOT injected.
   @agent_script_files [
     "agent-protocol.js",
     "agent-anchor-utils.js",
@@ -20,7 +18,8 @@ defmodule CritWeb.RawController do
     "agent-mutation-batcher.js",
     "agent-resolution.js",
     "agent-reanchor-state.js",
-    "crit-agent.js"
+    "crit-agent.js",
+    "crit-web-shortcuts.js"
   ]
 
   # Marker overlay CSS. crit local serves this at `/agent-marker.css`. The

--- a/priv/static/preview-agent/crit-web-shortcuts.js
+++ b/priv/static/preview-agent/crit-web-shortcuts.js
@@ -1,0 +1,40 @@
+// Crit Web-only shortcut forwarding for sandboxed preview iframes.
+'use strict';
+(function () {
+  var script = document.currentScript;
+  if (!script || !script.src) return;
+
+  var parentOrigin;
+  try { parentOrigin = new URL(script.src).origin; } catch (_) { return; }
+
+  function isTextInput(el) {
+    if (!el || !el.tagName) return false;
+    var tag = el.tagName.toUpperCase();
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
+  }
+
+  function isInteractive(el) {
+    return !!(el && el.closest && el.closest(
+      'button, a[href], summary, [role="button"], [role="link"], [role="radio"], [role="checkbox"], [role="switch"], [role="tab"], [role="menuitem"], [role="option"], [role="slider"]'
+    ));
+  }
+
+  document.addEventListener('keydown', function (event) {
+    if (isTextInput(event.target)) return;
+    if (isInteractive(event.target) && [
+      ' ', 'Enter', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'
+    ].indexOf(event.key) !== -1) return;
+
+    try {
+      window.parent.postMessage({
+        type: 'crit-web-shortcut-key',
+        key: event.key,
+        code: event.code,
+        ctrlKey: event.ctrlKey,
+        altKey: event.altKey,
+        shiftKey: event.shiftKey,
+        metaKey: event.metaKey,
+      }, parentOrigin);
+    } catch (_) { /* noop */ }
+  }, true);
+})();

--- a/test/crit_web/controllers/raw_controller_test.exs
+++ b/test/crit_web/controllers/raw_controller_test.exs
@@ -178,7 +178,7 @@ defmodule CritWeb.RawControllerTest do
       body = response(conn, 200)
       assert response_content_type(conn, :html) =~ "text/html"
 
-      # All 7 agent scripts injected, in crit's exact order.
+      # Vendored agent scripts plus the Crit Web shortcut bridge are injected.
       expected_scripts = [
         "agent-protocol.js",
         "agent-anchor-utils.js",
@@ -186,7 +186,8 @@ defmodule CritWeb.RawControllerTest do
         "agent-mutation-batcher.js",
         "agent-resolution.js",
         "agent-reanchor-state.js",
-        "crit-agent.js"
+        "crit-agent.js",
+        "crit-web-shortcuts.js"
       ]
 
       for name <- expected_scripts do


### PR DESCRIPTION
## Summary

- add persistent, editable shortcuts for files and preview modes
- validate conflicts and reserved bindings, with disable/reset support
- preserve native controls and forward shortcuts from sandboxed preview frames
- keep shortcut rows stable while editing

## Review

- [x] Code review passed
- [x] Intent audit passed
- [x] Crit parity checked

## Test plan

- `mise exec -- mix precommit` — 1,118 tests passed
- `mise run e2e` — 148 browser/security tests passed

See also [Crit PR 785](https://github.com/tomasz-tomczyk/crit/pull/785).
