### PR TITLE
fix: port compact reply composer and shortcut hardenings

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2021,6 +2021,12 @@ body.dragging { user-select: none; cursor: grabbing; }
   border-top: 1px solid var(--crit-border);
 }
 
+/* Compact shape: the form already supplies the padding. */
+.reply-form:not(.expanded) .reply-form-buttons {
+  padding: 8px 0 0;
+  border-top: none;
+}
+
 /* ===== highlight.js Dark Theme (Tokyo Night Dark) ===== */
 .hljs{color:#9aa5ce;background:#1a1b26}
 .hljs-tag,.hljs-doctag,.hljs-selector-id,.hljs-selector-class,.hljs-regexp,.hljs-template-tag,.hljs-selector-pseudo,.hljs-selector-attr,.hljs-variable.language_,.hljs-deletion{color:#f7768e}
@@ -3177,7 +3183,7 @@ body.sidebar-resizing * {
   height: 22px;
   line-height: 18px;
   padding: 1px 6px;
-  font-family: monospace;
+  font-family: var(--crit-font-mono);
   font-size: 12px;
   color: var(--crit-editor-fg);
   min-width: 24px;

--- a/assets/js/comments-panel.js
+++ b/assets/js/comments-panel.js
@@ -320,6 +320,12 @@ export function createReplyInput(commentId, adapter) {
 
   buttons.appendChild(cancelBtn)
   buttons.appendChild(submitBtn)
+  // Always mounted; CSS hides the whole form when the card is collapsed.
+  form.appendChild(buttons)
+
+  function activeField() {
+    return form.classList.contains('expanded') ? textarea : input
+  }
 
   function expand() {
     if (form.classList.contains('expanded')) return
@@ -329,14 +335,17 @@ export function createReplyInput(commentId, adapter) {
     input.replaceWith(textarea)
     form.appendChild(buttons)
     textarea.focus()
+    // The taller textarea can push the actions off screen, and focusing it
+    // does not bring them along.
+    buttons.scrollIntoView({ block: 'nearest' })
   }
 
   function collapse() {
+    textarea.value = ''
+    input.value = ''
     if (!form.classList.contains('expanded')) return
     form.classList.remove('expanded')
     textarea.replaceWith(input)
-    input.value = ''
-    if (buttons.parentNode) buttons.remove()
   }
 
   input.addEventListener('focus', expand)
@@ -353,20 +362,21 @@ export function createReplyInput(commentId, adapter) {
   })
 
   submitBtn.addEventListener('click', function() {
-    const body = textarea.value.trim()
-    if (!body) return
+    const field = activeField()
+    const body = field.value.trim()
+    if (!body) { field.focus(); return }
     submitBtn.disabled = true
     Promise.resolve(adapter.onAddReply(commentId, body)).then(result => {
       if (result?.ok === false) {
         submitBtn.disabled = false
-        textarea.focus()
+        activeField().focus()
         return
       }
       collapse()
       submitBtn.disabled = false
     }).catch(() => {
       submitBtn.disabled = false
-      textarea.focus()
+      activeField().focus()
     })
   })
 

--- a/assets/js/shortcut-registry.js
+++ b/assets/js/shortcut-registry.js
@@ -44,9 +44,30 @@ function readOverrides() {
   try {
     const value = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}")
     if (!value || typeof value !== "object" || Array.isArray(value)) return {}
-    return Object.fromEntries(Object.entries(value).filter(([id, binding]) => (
-      byId.has(id) && typeof binding === "string"
-    )))
+    const candidates = {}
+    for (const [id, binding] of Object.entries(value)) {
+      if (byId.has(id) && typeof binding === "string" && !isReservedBinding(binding)) {
+        candidates[id] = binding
+      }
+    }
+    const valid = {}
+    for (const [id, binding] of Object.entries(candidates)) {
+      const target = byId.get(id)
+      let conflict = false
+      for (const group of shortcutGroups) {
+        for (const other of group.shortcuts) {
+          if (!other.id || other.id === id) continue
+          if (!other.modes.some(mode => target.modes.includes(mode))) continue
+          const otherBinding = Object.prototype.hasOwnProperty.call(candidates, other.id)
+            ? candidates[other.id]
+            : other.binding
+          if (otherBinding === binding) { conflict = true; break }
+        }
+        if (conflict) break
+      }
+      if (!conflict) valid[id] = binding
+    }
+    return valid
   } catch (_) {
     return {}
   }
@@ -66,6 +87,8 @@ export function getBinding(id) {
 export function setBinding(id, binding) {
   const shortcut = byId.get(id)
   if (!shortcut) return false
+  if (binding && isReservedBinding(binding)) return false
+  if (binding && findConflict(id, binding)) return false
   const saved = readOverrides()
   if (binding === shortcut.binding) delete saved[id]
   else saved[id] = binding
@@ -156,8 +179,9 @@ export function groupsForMode(mode) {
 }
 
 export function isReservedBinding(binding) {
+  // Digits 1–9 stay unreserved on hosted (story chapter jumps are CLI-only).
   if (["Esc", "Tab", "Enter"].includes(binding)) return true
-  const parts = binding.split("+")
+  const parts = binding ? binding.split("+") : []
   if (parts[parts.length - 1] === "/" && parts.includes("Shift")) return true
   return parts[parts.length - 1] === "Enter" && (parts.includes("Ctrl") || parts.includes("Meta"))
 }


### PR DESCRIPTION
## Summary
- Always-mount Reply/Cancel with `activeField` submit and compact CSS (crit local #777 parity)
- Sanitize reserved/conflicting shortcut overrides on read/write (#792 parity; digits stay unreserved on hosted)
- Use `--crit-font-mono` for shortcuts-table kbd

## Review
- [x] Code review: passed
- [x] Parity audit: passed

## Test plan
- [x] `mix test` (1118 passed)
- [x] `mise run e2e` (148 passed)

See also: tomasz-tomczyk/crit#804, tomasz-tomczyk/crit#805