### PR TITLE
fix: reflect CORS headers before ApiAuth on /api routes

### DIFF
--- a/lib/crit_web/plugs/localhost_cors.ex
+++ b/lib/crit_web/plugs/localhost_cors.ex
@@ -7,6 +7,12 @@ defmodule CritWeb.Plugs.LocalhostCors do
   router must also declare an `options` route for each path the browser sends a
   preflight to (e.g. PUT /reviews/:token), otherwise the preflight 404s before
   this plug runs.
+
+  Must run BEFORE `CritWeb.Plugs.ApiAuth` in the `:api` pipeline. Browsers never
+  send `Authorization` on CORS preflight, so an early ApiAuth 401 would omit
+  `Access-Control-Allow-Origin` and surface as a CORS failure in the console
+  instead of a readable 401. Running first also stamps CORS headers onto any
+  subsequent error response (401/429/etc.) for localhost origins.
   """
   import Plug.Conn
 

--- a/lib/crit_web/router.ex
+++ b/lib/crit_web/router.ex
@@ -20,6 +20,11 @@ defmodule CritWeb.Router do
     plug :accepts, ["json"]
     plug CritWeb.Plugs.SecurityHeaders
     plug CritWeb.Plugs.RateLimit, response: :json
+    # LocalhostCors must run BEFORE ApiAuth: browsers never send Authorization
+    # on CORS preflight (OPTIONS), and a 401 from ApiAuth must still carry
+    # Access-Control-Allow-Origin so the browser surfaces the real status
+    # instead of a opaque CORS failure. LocalhostCors halts OPTIONS itself.
+    plug CritWeb.Plugs.LocalhostCors
     plug CritWeb.Plugs.ApiAuth
   end
 
@@ -222,7 +227,8 @@ defmodule CritWeb.Router do
   end
 
   scope "/api", CritWeb do
-    pipe_through [:api, :noindex, CritWeb.Plugs.LocalhostCors]
+    # LocalhostCors lives in the :api pipeline (before ApiAuth) — see pipeline.
+    pipe_through [:api, :noindex]
 
     options "/reviews", ApiController, :options
     post "/reviews", ApiController, :create

--- a/test/crit_web/plugs/localhost_cors_test.exs
+++ b/test/crit_web/plugs/localhost_cors_test.exs
@@ -1,0 +1,91 @@
+defmodule CritWeb.Plugs.LocalhostCorsTest do
+  # async: false — mutates Application.put_env(:crit, :selfhosted), which is global.
+  use CritWeb.ConnCase, async: false
+
+  alias Crit.Accounts.Scope
+  alias Crit.Reviews
+
+  @origin "http://localhost:54358"
+
+  defp with_enforcement(fun) do
+    orig_selfhosted = Application.get_env(:crit, :selfhosted)
+    orig_provider = Application.get_env(:crit, :oauth_provider)
+
+    Application.put_env(:crit, :selfhosted, true)
+    Application.put_env(:crit, :oauth_provider, "github")
+
+    try do
+      fun.()
+    after
+      if is_nil(orig_selfhosted),
+        do: Application.delete_env(:crit, :selfhosted),
+        else: Application.put_env(:crit, :selfhosted, orig_selfhosted)
+
+      if is_nil(orig_provider),
+        do: Application.delete_env(:crit, :oauth_provider),
+        else: Application.put_env(:crit, :oauth_provider, orig_provider)
+    end
+  end
+
+  defp create_review do
+    {:ok, review} =
+      Reviews.create_review(
+        Scope.for_visitor("cors-test-#{System.unique_integer([:positive])}"),
+        [%{"path" => "test.md", "content" => "# Hello"}],
+        0,
+        []
+      )
+
+    review
+  end
+
+  describe "preflight on an instance that enforces auth" do
+    test "OPTIONS /api/reviews (unpublish preflight) still reflects CORS headers", %{conn: conn} do
+      with_enforcement(fn ->
+        conn =
+          conn
+          |> put_req_header("origin", @origin)
+          |> put_req_header("access-control-request-method", "DELETE")
+          |> put_req_header("access-control-request-headers", "content-type")
+          |> options("/api/reviews")
+
+        assert conn.status == 204
+        assert get_resp_header(conn, "access-control-allow-origin") == [@origin]
+        assert get_resp_header(conn, "access-control-allow-methods") |> List.first() =~ "DELETE"
+      end)
+    end
+
+    test "OPTIONS /api/reviews/:token (re-share preflight) still reflects CORS headers", %{
+      conn: conn
+    } do
+      review = create_review()
+
+      with_enforcement(fn ->
+        conn =
+          conn
+          |> put_req_header("origin", @origin)
+          |> put_req_header("access-control-request-method", "PUT")
+          |> options("/api/reviews/#{review.token}")
+
+        assert conn.status == 204
+        assert get_resp_header(conn, "access-control-allow-origin") == [@origin]
+      end)
+    end
+  end
+
+  describe "error responses on cross-origin requests" do
+    test "401 from ApiAuth still carries CORS headers so the browser sees the status", %{
+      conn: conn
+    } do
+      with_enforcement(fn ->
+        conn =
+          conn
+          |> put_req_header("origin", @origin)
+          |> delete("/api/reviews", %{delete_token: "does-not-matter"})
+
+        assert conn.status == 401
+        assert get_resp_header(conn, "access-control-allow-origin") == [@origin]
+      end)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Move `LocalhostCors` ahead of `ApiAuth` in the `:api` pipeline so browser CORS preflights (and 401 responses) from localhost get `Access-Control-Allow-Origin`.
- Fixes self-hosted OAuth instances where OPTIONS `/api/reviews` returned a bare 401 and Chrome reported a CORS failure on Unpublish / Pull / Re-share.
- Add regression tests for the selfhosted+OAuth enforcement case.

## Review
- [x] Code review: passed
- [x] Parity audit: N/A

## Test plan
- [x] `mix precommit` (after test DB reset)
- [x] New `LocalhostCorsTest` covers OPTIONS + 401 with CORS headers under selfhosted+OAuth
- [ ] Manual: from local crit UI against a selfhosted OAuth instance, Unpublish no longer shows a CORS console error

See also: tomasz-tomczyk/crit#809