### PR TITLE
fix: drop the preview agent handshake when the frame navigates

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3432,17 +3432,6 @@ body.sidebar-resizing * {
   font-size: 12px;
   font-style: italic;
 }
-.shortcut-mode-badge {
-  display: inline-block;
-  font-size: 11px;
-  color: var(--crit-editor-fg-muted);
-  background: var(--crit-editor-bg-elevated);
-  border: 1px solid var(--crit-border);
-  border-radius: 4px;
-  padding: 1px 6px;
-  margin-left: 6px;
-  font-weight: 500;
-}
 
 /* About tab */
 .about-header {

--- a/assets/js/preview-mode.js
+++ b/assets/js/preview-mode.js
@@ -83,6 +83,13 @@ function makeAgentSender(post) {
       ready = true
       while (queue.length) post(queue.shift())
     },
+    // Called when the frame navigates: the document we handshook with is gone.
+    // Dropping the queue is safe because handleAgentReady re-pushes mode,
+    // viewport, and pins whenever the next document announces itself.
+    reset() {
+      ready = false
+      queue.length = 0
+    },
     isReady() {
       return ready
     },
@@ -186,6 +193,19 @@ export const PreviewMode = {
     this.onMessage = (event) => this.handleAgentMessage(event)
     window.addEventListener("message", this.onMessage)
 
+    // Preview content can navigate its own frame (a link, or a hostile
+    // location.replace). Opaque-origin frames can only be targeted with "*", so
+    // a handshake that stayed valid across navigation would keep posting pins
+    // into whatever document now occupies the frame. The agent announces itself
+    // while its document parses — before this load event — so a load with no
+    // announcement since the previous one means the current document is not ours.
+    this.agentAnnounced = false
+    this.onIframeLoad = () => {
+      if (!this.agentAnnounced) this.sender.reset()
+      this.agentAnnounced = false
+    }
+    this.iframe.addEventListener("load", this.onIframeLoad)
+
     // Header comment-count button toggles the panel via JS.dispatch (survives
     // LiveView patches), same contract as files mode.
     this.onToggleComments = () => this.togglePanel()
@@ -252,6 +272,7 @@ export const PreviewMode = {
   destroyed() {
     if (this.onShortcut) document.removeEventListener("keydown", this.onShortcut)
     if (this.onMessage) window.removeEventListener("message", this.onMessage)
+    if (this.onIframeLoad && this.iframe) this.iframe.removeEventListener("load", this.onIframeLoad)
     if (this.onResize) window.removeEventListener("resize", this.onResize)
     if (this.onToggleComments) this.el.removeEventListener("crit:toggle-comments", this.onToggleComments)
     if (this.settings) this.settings.destroy()
@@ -634,6 +655,7 @@ export const PreviewMode = {
   },
 
   handleAgentReady() {
+    this.agentAnnounced = true
     this.sender.markReady()
     this.enablePinButton()
     // Push current mode, viewport, and pins now that the agent can receive them.

--- a/assets/js/settings-panel.js
+++ b/assets/js/settings-panel.js
@@ -183,7 +183,6 @@ export function createSettingsPanel(adapter) {
       html += '<div class="shortcuts-group-label">' + group.label + '</div>'
       html += '<table class="shortcuts-table">'
       group.shortcuts.forEach(function(s) {
-        const modeTag = s.mode ? '<span class="shortcut-mode-badge">' + s.mode + '</span>' : ''
         const binding = s.id ? getBinding(s.id) : s.binding
         let key = bindingHtml(binding)
         if (s.id && !s.fixed) {
@@ -191,7 +190,7 @@ export function createSettingsPanel(adapter) {
           key = '<button type="button" class="shortcut-binding' + customized + '" data-shortcut-id="' + escapeHtml(s.id) +
             '" aria-label="Change shortcut for ' + escapeHtml(s.action) + '">' + key + '</button>'
         }
-        html += '<tr><td>' + key + '</td><td>' + escapeHtml(s.action) + modeTag + '</td></tr>'
+        html += '<tr><td>' + key + '</td><td>' + escapeHtml(s.action) + '</td></tr>'
       })
       html += '</table>'
     })

--- a/e2e/security.spec.ts
+++ b/e2e/security.spec.ts
@@ -324,6 +324,18 @@ test.describe("Preview isolation: preview iframe cannot exfiltrate victim sessio
       const beacon = await waitForProbe(page, "iframe-origin-beacon");
       expect(beacon.msg, "iframe origin beacon").toBe(PREVIEW_ORIGIN);
 
+      // Isolation also rests on the frame having an *opaque* origin, which the
+      // beacon above cannot show (location.origin comes from the URL and reads
+      // PREVIEW_ORIGIN either way). Assert both halves so a sandbox that grants
+      // allow-same-origin again — handing preview JS the preview host's storage
+      // and same-origin fetch identity — fails here instead of passing silently.
+      const sandbox = await page
+        .locator("#critPreviewIframe")
+        .getAttribute("sandbox");
+      expect(sandbox ?? "", "iframe sandbox").toContain("allow-scripts");
+      expect(sandbox ?? "", "iframe sandbox").not.toContain("allow-same-origin");
+      expect(beacon.documentOrigin, "iframe document origin").toBe("null");
+
       // Receive the session-ride probe. Assert the attack did NOT reach
       // authenticated canonical content.
       const probe = await waitForProbe(page, "session-ride-via-dash-route");

--- a/e2e/security/payloads.ts
+++ b/e2e/security/payloads.ts
@@ -77,9 +77,15 @@ export function previewSessionRidePayload(): string {
 }
 
 /**
- * Sanity payload: a probe that reports its own `location.origin` back to the
- * parent. The isolation check asserts this is PREVIEW_HOST (never the
- * canonical app host).
+ * Sanity payload: a probe that reports both of the iframe's notions of "origin"
+ * back to the parent.
+ *
+ *   - `msg` is `location.origin`, derived from the document's URL. It stays
+ *     PREVIEW_HOST whether or not the sandbox grants allow-same-origin, so the
+ *     isolation check uses it to prove the preview loads off the canonical host.
+ *   - `documentOrigin` is `window.origin`, the document's *security* origin.
+ *     It is "null" exactly when the sandbox withholds allow-same-origin, which
+ *     is what makes the frame opaque.
  */
 export function previewOriginBeaconPayload(): string {
   return `<script>
@@ -87,6 +93,7 @@ parent.postMessage({
   type: "CRIT_SEC_PROBE",
   variant: "iframe-origin-beacon",
   msg: location.origin,
+  documentOrigin: String(window.origin),
 }, "*");
 </script>`;
 }


### PR DESCRIPTION
## Summary

- Preview mode's agent sender became ready on the first `AGENT_READY` and stayed ready forever, so a preview document that navigated its own frame (a link, or a hostile `location.replace`) kept receiving pin payloads. Opaque-origin frames can only be targeted with `postMessage(msg, "*")`, so there was no `targetOrigin` check to fall back on. Readiness is now cleared on any iframe `load` the agent didn't announce itself for — the agent announces while its document parses, so a load with no announcement means the document isn't ours.
- The isolation E2E couldn't catch a regression back to `allow-same-origin`: its beacon asserted `location.origin`, which is URL-derived and reads the preview host either way. It now also asserts the `sandbox` attribute and `window.origin` (the document's security origin, `"null"` exactly when opaque).
- Dropped the shortcut mode badge, which never rendered — the shortcut registry only carries `modes` arrays, never a singular `mode`.

Found by the v0.10.4 → v0.10.5 pre-release audit.

## Review

- [x] Code review: passed, no findings
- [x] Parity audit: N/A — crit local targets a concrete origin (`postMessage(m, state.proxyOrigin)`), so the sticky-handshake leak can't occur there

## Test plan

- `mix precommit` — 1121 tests, 0 failures
- `mise run e2e` — 148 passed, including both preview-isolation specs; the new opaque-sandbox assertions execute and pass under the real `PREVIEW_HOST` webServer
- `pin mode: clicking an element in the iframe creates a comment` still passes, covering the full `AGENT_READY` → pin → selection → comment handshake the reset could have broken

Made with [Cursor](https://cursor.com)