### PR TITLE
feat: add configurable code font setting

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -51,6 +51,7 @@
   /* ---- Fonts ---- */
   --crit-font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --crit-font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+  --crit-font-code: var(--crit-font-mono);
 
   /* ---- Content width ---- */
   --crit-content-width: 1040px;
@@ -188,6 +189,8 @@
 [data-width="wide"]    { --crit-content-width: 1280px; }
 
 [data-theme="dark"] {
+  --crit-font-code: var(--crit-font-mono);
+
   /* ---- Surfaces ---- */
   --crit-bg-page:     #0e0f13;
   --crit-bg-card:     #171922;
@@ -314,6 +317,8 @@
 }
 
 [data-theme="light"] {
+  --crit-font-code: var(--crit-font-mono);
+
   /* ---- Surfaces ---- */
   --crit-bg-page:     #ffffff;
   --crit-bg-card:     #f6f8fa;
@@ -442,6 +447,8 @@
 /* System preference: light — overrides dark :root defaults when OS is light */
 @media (prefers-color-scheme: light) {
   html:not([data-theme]) {
+    --crit-font-code: var(--crit-font-mono);
+
     /* ---- Surfaces ---- */
     --crit-bg-page:     #ffffff;
     --crit-bg-card:     #f6f8fa;
@@ -996,7 +1003,7 @@ body.dragging { user-select: none; cursor: grabbing; }
 .line-content a { color: var(--crit-brand); text-decoration: none; border-bottom: 1px solid transparent; transition: border-color 0.15s; }
 .line-content a:hover { border-bottom-color: var(--crit-brand); }
 .line-content code {
-  font-family: var(--crit-font-mono); font-size: 0.88em;
+  font-family: var(--crit-font-code); font-size: 0.88em;
   background: var(--crit-editor-code-bg); padding: 2px 6px; border-radius: 4px; border: 1px solid var(--crit-border);
 }
 .line-content pre { margin: 6px 0; padding: 16px; background: var(--crit-editor-code-bg); border: 1px solid var(--crit-border); border-radius: 8px; overflow-x: auto; line-height: 1.5; }
@@ -1028,7 +1035,7 @@ body.dragging { user-select: none; cursor: grabbing; }
 
 /* Per-line code blocks */
 .line-content.code-line {
-  background: var(--crit-editor-code-bg); font-family: var(--crit-font-mono); font-size: 0.875rem; line-height: 1.5;
+  background: var(--crit-editor-code-bg); font-family: var(--crit-font-code); font-size: 0.875rem; line-height: 1.5;
   padding-left: 16px; padding-right: 16px; border-left: 1px solid var(--crit-border); border-right: 1px solid var(--crit-border);
   overflow-x: auto; white-space: pre; scrollbar-width: none;
 }
@@ -1104,7 +1111,7 @@ body.dragging { user-select: none; cursor: grabbing; }
 .comment-body { padding: 10px 14px; color: var(--crit-editor-fg); font-size: 14px; line-height: 1.6; word-break: break-word; }
 .comment-body p { margin: 0 0 0.5em; }
 .comment-body p:last-child { margin-bottom: 0; }
-.comment-body code { background: var(--crit-editor-bg-elevated); padding: 1px 5px; border-radius: 3px; font-size: 0.9em; }
+.comment-body code { background: var(--crit-editor-bg-elevated); padding: 1px 5px; border-radius: 3px; font-family: var(--crit-font-code); font-size: 0.9em; }
 .comment-body pre { background: var(--crit-editor-bg-elevated); padding: 8px 10px; border-radius: 4px; overflow-x: auto; margin: 0.5em 0; }
 .comment-body pre code { background: none; padding: 0; }
 .comment-body img { max-width: 100%; height: auto; border-radius: 4px; border: 1px solid var(--crit-border); margin: 4px 0; display: block; }
@@ -1115,7 +1122,7 @@ body.dragging { user-select: none; cursor: grabbing; }
   border-radius: 6px;
   overflow: hidden;
   margin: 8px 0;
-  font-family: var(--crit-font-mono);
+  font-family: var(--crit-font-code);
   font-size: 12px;
   line-height: 20px;
 }
@@ -3330,6 +3337,38 @@ body.sidebar-resizing * {
   font-weight: 500;
   color: var(--crit-editor-fg);
 }
+.settings-display-label--sub {
+  padding-left: 12px;
+  color: var(--crit-editor-fg-muted);
+  font-size: 12px;
+}
+.settings-display-row[hidden] { display: none; }
+.settings-select,
+.settings-text-input {
+  border: 1px solid var(--crit-border);
+  border-radius: 6px;
+  background: var(--crit-editor-bg-elevated);
+  color: var(--crit-editor-fg);
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 8px;
+}
+.settings-select {
+  max-width: 60%;
+  cursor: pointer;
+}
+.settings-text-input {
+  width: 260px;
+  max-width: 60%;
+  font-family: var(--crit-font-mono);
+}
+.settings-text-input::placeholder { color: var(--crit-editor-fg-muted); }
+.settings-select:focus-visible,
+.settings-text-input:focus-visible {
+  outline: 2px solid var(--crit-brand);
+  outline-offset: 1px;
+}
+.settings-text-input.is-invalid { border-color: var(--crit-red); }
 
 /* Pill toggles for theme and width inside the panel */
 .settings-pill {
@@ -4058,7 +4097,9 @@ body.sidebar-resizing * {
 
   /* iOS Safari zooms any focused input below 16px. */
   .comment-form textarea,
-  .reply-input {
+  .reply-input,
+  .settings-select,
+  .settings-text-input {
     font-size: 16px;
   }
 

--- a/assets/js/settings-panel.js
+++ b/assets/js/settings-panel.js
@@ -32,8 +32,68 @@ const THEME_ICONS = {
   dark: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="M14.438 10.148c.19-.425-.321-.787-.748-.601A5.5 5.5 0 0 1 6.453 2.31c.186-.427-.176-.938-.6-.748a6.501 6.501 0 1 0 8.585 8.586Z"/></svg>',
 }
 
+const CODE_FONT_STORAGE_KEY = 'crit:code-font'
+const MAX_CODE_FONT_LENGTH = 256
+const CODE_FONT_PRESETS = [
+  { id: 'default', label: 'Default (JetBrains Mono)', stack: '' },
+  { id: 'system', label: 'System monospace', stack: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace' },
+]
+
+function sanitizeCodeFont(value) {
+  const font = String(value ?? '').trim()
+  if (!font) return ''
+  if (font.length > MAX_CODE_FONT_LENGTH || /[;{}<>@]/.test(font)) return ''
+  if (/url\s*\(/i.test(font) || /expression\s*\(/i.test(font)) return ''
+  if (typeof CSS !== 'undefined' && CSS.supports && !CSS.supports('font-family', font)) return ''
+  return font
+}
+
+function readCodeFont() {
+  try { return localStorage.getItem(CODE_FONT_STORAGE_KEY) || '' } catch (_) { return '' }
+}
+
+function applyCodeFont(value) {
+  const font = sanitizeCodeFont(value)
+  if (font) document.documentElement.style.setProperty('--crit-font-code', font)
+  else document.documentElement.style.removeProperty('--crit-font-code')
+  return font
+}
+
+function setCodeFont(value) {
+  const font = applyCodeFont(value)
+  try { localStorage.setItem(CODE_FONT_STORAGE_KEY, font) } catch (_) {}
+  return font
+}
+
+function showError(message) {
+  let host = document.querySelector('.mini-toast-host')
+  if (!host) {
+    host = document.createElement('div')
+    host.className = 'mini-toast-host'
+    document.body.appendChild(host)
+  }
+  const toast = document.createElement('div')
+  toast.className = 'mini-toast mini-toast--error'
+  toast.textContent = message
+  host.appendChild(toast)
+  requestAnimationFrame(() => toast.classList.add('mini-toast-visible'))
+  setTimeout(() => {
+    toast.addEventListener('transitionend', () => toast.remove(), { once: true })
+    toast.classList.remove('mini-toast-visible')
+  }, 3000)
+}
+
 function cap(s) {
   return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
 }
 
 function updatePillIndicator(indicatorId, values, current) {
@@ -68,6 +128,8 @@ export function createSettingsPanel(adapter) {
     listeners.push([el, ev, fn])
   }
 
+  if (adapter.shortcutMode === 'files') applyCodeFont(readCodeFont())
+
   function renderSettingsPane() {
     const pane = document.getElementById('settingsPane')
     if (!pane) return
@@ -87,6 +149,27 @@ export function createSettingsPanel(adapter) {
       html += '<button class="settings-pill-btn' + active + '" data-settings-theme="' + theme + '" title="' + cap(theme) + ' theme">' + THEME_ICONS[theme] + '</button>'
     })
     html += '</div></div>'
+
+    // The hosted viewer cannot discover browser-local fonts without a
+    // permission-gated API, so keep the portable presets plus Custom here.
+    if (adapter.shortcutMode === 'files') {
+      const currentCodeFont = readCodeFont()
+      const preset = CODE_FONT_PRESETS.find(option => option.stack === currentCodeFont)
+      const selectedId = preset ? preset.id : 'custom'
+      html += '<div class="settings-display-row">'
+      html += '<span class="settings-display-label">Code font</span>'
+      html += '<select class="settings-select" id="codeFontSelect" aria-label="Code font">'
+      CODE_FONT_PRESETS.forEach(function(option) {
+        html += '<option value="' + option.id + '"' + (option.id === selectedId ? ' selected' : '') + '>' + option.label + '</option>'
+      })
+      html += '<option value="custom"' + (selectedId === 'custom' ? ' selected' : '') + '>Custom…</option>'
+      html += '</select></div>'
+      html += '<div class="settings-display-row" id="codeFontCustomRow"' + (selectedId === 'custom' ? '' : ' hidden') + '>'
+      html += '<label class="settings-display-label settings-display-label--sub" for="codeFontCustomInput">Custom font-family</label>'
+      html += '<input type="text" class="settings-text-input" id="codeFontCustomInput" spellcheck="false" autocomplete="off" maxlength="256"'
+      html += ' placeholder="\'Fira Code\', monospace" value="' + escapeHtml(selectedId === 'custom' ? currentCodeFont : '') + '">'
+      html += '</div>'
+    }
 
     // Content width row (files mode only)
     if (adapter.showWidth) {
@@ -131,6 +214,33 @@ export function createSettingsPanel(adapter) {
     })
     updatePillIndicator('settingsThemeIndicator', ['system', 'light', 'dark'], currentTheme)
 
+    const fontSelect = pane.querySelector('#codeFontSelect')
+    const fontCustomRow = pane.querySelector('#codeFontCustomRow')
+    const fontCustomInput = pane.querySelector('#codeFontCustomInput')
+    function markInvalidFont(invalid) {
+      if (!fontCustomInput) return
+      fontCustomInput.classList.toggle('is-invalid', invalid)
+      fontCustomInput.setAttribute('aria-invalid', invalid ? 'true' : 'false')
+    }
+    fontSelect?.addEventListener('change', function() {
+      if (fontSelect.value === 'custom') {
+        if (fontCustomRow) fontCustomRow.hidden = false
+        fontCustomInput?.focus()
+        if (fontCustomInput?.value.trim()) setCodeFont(fontCustomInput.value)
+        return
+      }
+      if (fontCustomRow) fontCustomRow.hidden = true
+      markInvalidFont(false)
+      const preset = CODE_FONT_PRESETS.find(option => option.id === fontSelect.value)
+      setCodeFont(preset?.stack || '')
+    })
+    fontCustomInput?.addEventListener('change', function() {
+      const raw = fontCustomInput.value
+      const rejected = !!raw.trim() && !setCodeFont(raw)
+      markInvalidFont(rejected)
+      if (rejected) showError('Not a valid font-family value — using the default.')
+    })
+
     // Width pill (files only)
     if (adapter.showWidth) {
       pane.querySelectorAll('[data-settings-width]').forEach(function(btn) {
@@ -165,15 +275,6 @@ export function createSettingsPanel(adapter) {
     html += '<button type="button" class="shortcut-reset-all">Reset all</button>'
     html += '</div>'
 
-    function escapeHtml(value) {
-      return String(value ?? '')
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;')
-    }
-
     function bindingHtml(binding) {
       if (!binding) return '<span class="shortcut-unassigned">Unassigned</span>'
       return binding.split('+').map(part => '<kbd>' + escapeHtml(part) + '</kbd>').join('+')
@@ -195,24 +296,6 @@ export function createSettingsPanel(adapter) {
       html += '</table>'
     })
     pane.innerHTML = html
-
-    function showError(message) {
-      let host = document.querySelector('.mini-toast-host')
-      if (!host) {
-        host = document.createElement('div')
-        host.className = 'mini-toast-host'
-        document.body.appendChild(host)
-      }
-      const toast = document.createElement('div')
-      toast.className = 'mini-toast mini-toast--error'
-      toast.textContent = message
-      host.appendChild(toast)
-      requestAnimationFrame(() => toast.classList.add('mini-toast-visible'))
-      setTimeout(() => {
-        toast.addEventListener('transitionend', () => toast.remove(), { once: true })
-        toast.classList.remove('mini-toast-visible')
-      }, 3000)
-    }
 
     const rerender = () => renderShortcutsPane()
     pane.querySelector('.shortcut-reset-all')?.addEventListener('click', () => {

--- a/e2e/code-font.spec.ts
+++ b/e2e/code-font.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+import { createReview, deleteReview, loadReview } from "./helpers";
+
+test.describe("Code font setting", () => {
+  let token: string;
+  let deleteToken: string;
+
+  test.beforeEach(async ({ page, request }) => {
+    const review = await createReview(request, {
+      files: [{ path: "example.go", content: "package main\n\nfunc main() {}\n" }],
+    });
+    token = review.token;
+    deleteToken = review.deleteToken;
+    await loadReview(page, token);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await deleteReview(request, deleteToken);
+  });
+
+  test("applies the system preset to code only and persists it", async ({ page }) => {
+    const codeFont = () => page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--crit-font-code").trim()
+    );
+    const uiFont = () => page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--crit-font-mono").trim()
+    );
+    const originalUiFont = await uiFont();
+
+    await page.locator("#settingsToggle").click();
+    await page.locator("#codeFontSelect").selectOption("system");
+    await expect.poll(codeFont).toBe("ui-monospace, SFMono-Regular, Menlo, Consolas, monospace");
+    expect(await uiFont()).toBe(originalUiFont);
+    const consumerFonts = await page.evaluate(() => {
+      const probe = document.createElement("div");
+      probe.innerHTML = '<div class="line-content code-line">code</div>'
+        + '<div class="suggestion-diff">suggestion</div>'
+        + '<div class="comment-body"><code>comment code</code></div>';
+      document.body.appendChild(probe);
+      return Array.from(probe.querySelectorAll(".code-line, .suggestion-diff, .comment-body code"))
+        .map(element => getComputedStyle(element).fontFamily);
+    });
+    expect(consumerFonts).toHaveLength(3);
+    consumerFonts.forEach(font => expect(font).toContain("ui-monospace"));
+
+    await page.reload();
+    await expect.poll(codeFont).toBe("ui-monospace, SFMono-Regular, Menlo, Consolas, monospace");
+  });
+
+  test("supports custom stacks and rejects declaration escapes", async ({ page }) => {
+    await page.locator("#settingsToggle").click();
+    await page.locator("#codeFontSelect").selectOption("custom");
+    const input = page.locator("#codeFontCustomInput");
+
+    await input.fill("'Comic Mono', monospace");
+    await input.blur();
+    await expect.poll(() => page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--crit-font-code").trim()
+    )).toBe("'Comic Mono', monospace");
+
+    await input.fill("monospace; background: red");
+    await input.blur();
+    await expect(input).toHaveAttribute("aria-invalid", "true");
+    await expect(page.locator(".mini-toast--error")).toContainText("valid font-family");
+  });
+});


### PR DESCRIPTION
## Summary

- add Default, System monospace, and Custom code-font choices to hosted code reviews
- apply the preference only to code/diff surfaces and persist it in localStorage
- validate custom font-family values and keep review UI typography unchanged
- add browser coverage for persistence, sanitization, and actual CSS consumers

The hosted viewer intentionally omits daemon-installed font discovery because the server and browser font inventories may differ.

See also: tomasz-tomczyk/crit#819

## Test plan

- `mix precommit` (1121 tests)
- `mise run e2e` (150 tests)
- `mise run e2e -- code-font.spec.ts`