### PR TITLE
fix: disable markdown-it replacements to preserve (c)/(r)/(tm)

### DIFF
--- a/assets/js/comments-panel.js
+++ b/assets/js/comments-panel.js
@@ -73,6 +73,9 @@ export const commentMd = markdownit({
     return ''
   },
 })
+// Disable (c)/(r)/(tm) → ©/®/™ replacements so enumerated options render
+// literally. Keep typographer (smart quotes) and disable only replacements.
+commentMd.disable('replacements')
 
 // ===== File Reference Inline Rule ===== (@path/to/file renders as a chip)
 commentMd.inline.ruler.push('file_ref', function(state, silent) {

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -4533,6 +4533,9 @@ export const DocumentRenderer = {
         return ""
       },
     })
+    // Disable (c)/(r)/(tm) → ©/®/™ replacements so enumerated options render
+    // literally. Keep typographer (smart quotes) and disable only replacements.
+    md.disable('replacements')
 
     // Task list support
     const defaultListItemOpen = md.renderer.rules.list_item_open ||


### PR DESCRIPTION
Parity fix for tomasz-tomczyk/crit#820 / tomasz-tomczyk/crit#829

Disable markdown-it's `replacements` rule on the document and comment renderers so literal `(c)`, `(r)`, and `(tm)` are preserved. Keeps `typographer: true` so smart quotes still work.

Changes:
- `assets/js/document-renderer.js`: `.disable('replacements')` for `md`
- `assets/js/comments-panel.js`: `.disable('replacements')` for `commentMd`