### PR TITLE
fix: render Markdown YAML frontmatter as a highlighted block

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1021,10 +1021,10 @@ async function renderMermaidBlocks(container) {
 // Callers retain the original content for source line display.
 function rewriteFrontmatterAsYamlFence(content) {
   const lines = content.split("\n")
-  if (!/^\uFEFF?---\r?$/.test(lines[0])) return content
+  if (!/^\uFEFF?---[ \t]*\r?$/.test(lines[0])) return content
 
   for (let i = 1; i < lines.length; i++) {
-    if (/^(?:---|\.\.\.)\r?$/.test(lines[i])) {
+    if (/^(?:---|\.\.\.)[ \t]*\r?$/.test(lines[i])) {
       lines[0] = "```yaml" + (lines[0].endsWith("\r") ? "\r" : "")
       lines[i] = "```" + (lines[i].endsWith("\r") ? "\r" : "")
       return lines.join("\n")

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -1017,12 +1017,29 @@ async function renderMermaidBlocks(container) {
 
 // ---- Markdown parsing & line-block building ---------------------------------
 
+// Turn valid document frontmatter into a YAML fence without shifting maps.
+// Callers retain the original content for source line display.
+function rewriteFrontmatterAsYamlFence(content) {
+  const lines = content.split("\n")
+  if (!/^\uFEFF?---\r?$/.test(lines[0])) return content
+
+  for (let i = 1; i < lines.length; i++) {
+    if (/^(?:---|\.\.\.)\r?$/.test(lines[i])) {
+      lines[0] = "```yaml" + (lines[0].endsWith("\r") ? "\r" : "")
+      lines[i] = "```" + (lines[i].endsWith("\r") ? "\r" : "")
+      return lines.join("\n")
+    }
+  }
+
+  return content
+}
+
 function buildLineBlocks(md, rawContent) {
   // Reset per-render heading-slug dedup state (see heading_open rule). Scoping
   // the counter to one buildLineBlocks() call prevents collisions accumulating
   // across renders and keeps prev/current diff renders independent.
   md.__headingSlugCounter = new Map()
-  const tokens = md.parse(rawContent, {})
+  const tokens = md.parse(rewriteFrontmatterAsYamlFence(rawContent), {})
   const sourceLines = rawContent.split("\n")
   const totalLines = sourceLines.length
   const blocks = []
@@ -3576,7 +3593,7 @@ function createResolvedElement(comment, ctx) {
 // ---- Table of Contents ------------------------------------------------------
 
 function extractTocItems(md, rawContent) {
-  const tokens = md.parse(rawContent, {})
+  const tokens = md.parse(rewriteFrontmatterAsYamlFence(rawContent), {})
   const items = []
   for (let i = 0; i < tokens.length; i++) {
     const t = tokens[i]


### PR DESCRIPTION
## Summary
- Document renderer treats leading YAML frontmatter as a YAML fence (parity with crit#821).
- Same line-preserving rewrite: parse rewritten content, display fence markers from original source lines.
- TOC extraction uses the same rewrite so headings inside frontmatter do not pollute the TOC.

Companion: https://github.com/tomasz-tomczyk/crit/pull/830

## Test plan
- [ ] CI green
- [x] Helper mirrors crit `rewriteFrontmatterAsYamlFence` (trailing whitespace allowed)