### PR TITLE
feat: allow GitHub-compatible HTML in comment markdown

### DIFF
--- a/assets/js/comment-html.js
+++ b/assets/js/comment-html.js
@@ -1,0 +1,63 @@
+import createDOMPurify from "dompurify"
+
+// Isolated instance so comment hooks never pollute Mermaid's shared DOMPurify.
+const purify = createDOMPurify(typeof window !== "undefined" ? window : undefined)
+
+// Snapshot of HTMLPipeline::SanitizationFilter's public default allowlist.
+// Keep this in sync with crit/web/comment-html.js.
+const ALLOWED_TAGS = [
+  "h1", "h2", "h3", "h4", "h5", "h6", "br", "b", "i", "strong", "em",
+  "a", "pre", "code", "img", "tt", "div", "ins", "del", "sup", "sub",
+  "p", "picture", "ol", "ul", "table", "thead", "tbody", "tfoot",
+  "blockquote", "dl", "dt", "dd", "kbd", "q", "samp", "var", "hr", "ruby",
+  "rt", "rp", "li", "tr", "td", "th", "s", "strike", "summary", "details",
+  "caption", "figure", "figcaption", "abbr", "bdo", "cite", "dfn", "mark",
+  "small", "source", "span", "time", "wbr",
+]
+const ALLOWED_ATTR = [
+  "href", "src", "longdesc", "loading", "alt", "itemscope", "itemtype",
+  "cite", "srcset", "abbr", "accept", "accept-charset", "accesskey",
+  "action", "align", "aria-describedby", "aria-hidden", "aria-label",
+  "aria-labelledby", "axis", "border", "char", "charoff", "charset",
+  "checked", "clear", "cols", "colspan", "compact", "coords", "datetime",
+  "dir", "disabled", "enctype", "for", "frame", "headers", "height",
+  "hreflang", "hspace", "id", "ismap", "label", "lang", "maxlength",
+  "media", "method", "multiple", "name", "nohref", "noshade", "nowrap",
+  "open", "progress", "prompt", "readonly", "rel", "rev", "role", "rows",
+  "rowspan", "rules", "scope", "selected", "shape", "size", "span", "start",
+  "summary", "tabindex", "title", "type", "usemap", "valign", "value",
+  "width", "itemprop", "class", "data-ref-id",
+]
+const SAFE_CLASS = /^(?:hljs(?:-[\w-]+)?|file-ref|comment-ref|comment-ref-code)$/
+const SAFE_COMMENT_REF = /^(?:c|r|rp)_[a-f0-9]{6,}$/
+const SAFE_URL = /^(?:(?:https?|mailto):|(?:\/|\.{1,2}\/|#))/i
+
+function isSafeUrl(value) {
+  return value === "" || SAFE_URL.test(String(value).trim())
+}
+
+purify.addHook("afterSanitizeAttributes", node => {
+  for (const attr of ["href", "src", "longdesc", "cite"]) {
+    if (node.hasAttribute(attr) && !isSafeUrl(node.getAttribute(attr))) node.removeAttribute(attr)
+  }
+  if (node.hasAttribute("class")) {
+    const classes = node.getAttribute("class").split(/\s+/).filter(value => SAFE_CLASS.test(value))
+    if (classes.length) node.setAttribute("class", classes.join(" "))
+    else node.removeAttribute("class")
+  }
+  if (node.hasAttribute("data-ref-id") && !SAFE_COMMENT_REF.test(node.getAttribute("data-ref-id"))) {
+    node.removeAttribute("data-ref-id")
+  }
+})
+
+export function sanitizeCommentHtml(html) {
+  return purify.sanitize(html, {
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
+    ALLOW_DATA_ATTR: false,
+    ALLOW_ARIA_ATTR: false,
+    ALLOW_UNKNOWN_PROTOCOLS: false,
+    FORBID_TAGS: ["style", "svg", "math"],
+    FORBID_ATTR: ["style"],
+  })
+}

--- a/assets/js/comment-html.js
+++ b/assets/js/comment-html.js
@@ -28,7 +28,8 @@ const ALLOWED_ATTR = [
   "summary", "tabindex", "title", "type", "usemap", "valign", "value",
   "width", "itemprop", "class", "data-ref-id",
 ]
-const SAFE_CLASS = /^(?:hljs(?:-[\w-]+)?|file-ref|comment-ref|comment-ref-code)$/
+// Crit-generated classes only — suggestion diffs + highlight/ref spans.
+const SAFE_CLASS = /^(?:hljs(?:-[\w-]+)?|file-ref|comment-ref|comment-ref-code|suggestion(?:-[\w-]+)+|diff-word-(?:del|add))$/
 const SAFE_COMMENT_REF = /^(?:c|r|rp)_[a-f0-9]{6,}$/
 const SAFE_URL = /^(?:(?:https?|mailto):|(?:\/|\.{1,2}\/|#))/i
 

--- a/assets/js/comments-panel.js
+++ b/assets/js/comments-panel.js
@@ -17,6 +17,7 @@
 
 import markdownit from "markdown-it"
 import hljs from "highlight.js"
+import { sanitizeCommentHtml } from "./comment-html"
 
 // ---- Shared helpers ---------------------------------------------------------
 
@@ -63,7 +64,7 @@ export function authorColorIndex(author) {
 // same instance at runtime; that rule is inert for preview comments.
 
 export const commentMd = markdownit({
-  html: false,
+  html: true,
   linkify: true,
   typographer: true,
   highlight(str, lang) {
@@ -145,7 +146,7 @@ export function linkifyCommentRefsInDom(el) {
 // Render markdown into `el` and linkify comment-ref ids. `env` carries
 // originalLines for the ```suggestion fence rule (files mode); {} for preview.
 export function renderMarkdown(el, body, env) {
-  el.innerHTML = commentMd.render(body || "", env || {})
+  el.innerHTML = sanitizeCommentHtml(commentMd.render(body || "", env || {}))
   linkifyCommentRefsInDom(el)
 }
 

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -3,6 +3,7 @@ import hljs from "highlight.js"
 import { registerMarkdownPatch } from "./highlight-markdown-patch"
 import { heex } from "highlightjs-heex"
 import { makeDiff, cleanupSemantic, DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT } from "@sanity/diff-match-patch"
+import { sanitizeCommentHtml } from "./comment-html"
 import {
   commentMd,
   escapeHtml,
@@ -3022,7 +3023,7 @@ function createCommentElement(comment, ctx) {
       }
     }
   }
-  body.innerHTML = commentMd.render(comment.body, env)
+  body.innerHTML = sanitizeCommentHtml(commentMd.render(comment.body, env))
   linkifyCommentRefsInDom(body)
 
   card.appendChild(header)
@@ -3570,7 +3571,7 @@ function createResolvedElement(comment, ctx) {
       }
     }
   }
-  body.innerHTML = commentMd.render(comment.body, env)
+  body.innerHTML = sanitizeCommentHtml(commentMd.render(comment.body, env))
   linkifyCommentRefsInDom(body)
 
   card.appendChild(header)
@@ -4862,7 +4863,7 @@ export const DocumentRenderer = {
       const card = ctx.el.querySelector(`.comment-card[data-comment-id="${id}"]`)
       if (card) {
         const bodyEl = card.querySelector('.comment-body')
-        if (bodyEl) { bodyEl.innerHTML = commentMd.render(body); linkifyCommentRefsInDom(bodyEl) }
+        if (bodyEl) { bodyEl.innerHTML = sanitizeCommentHtml(commentMd.render(body)); linkifyCommentRefsInDom(bodyEl) }
       }
       rerenderPanel(ctx)
     })
@@ -4930,7 +4931,7 @@ export const DocumentRenderer = {
         const bodyEl = replyEl.querySelector('.reply-body')
         if (bodyEl) {
           bodyEl.dataset.rawBody = body
-          bodyEl.innerHTML = commentMd.render(body)
+          bodyEl.innerHTML = sanitizeCommentHtml(commentMd.render(body))
           linkifyCommentRefsInDom(bodyEl)
         }
       }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -12,6 +12,7 @@
         "@sanity/diff-match-patch": "^3.2.0",
         "@sentry/browser": "^10.51.0",
         "@tailwindcss/typography": "^0.5.19",
+        "dompurify": "3.4.13",
         "highlight.js": "^11.11.1",
         "highlightjs-heex": "^1.0.1",
         "markdown-it": "^14.3.0",
@@ -1023,9 +1024,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/assets/package.json
+++ b/assets/package.json
@@ -14,6 +14,7 @@
     "@sanity/diff-match-patch": "^3.2.0",
     "@sentry/browser": "^10.51.0",
     "@tailwindcss/typography": "^0.5.19",
+    "dompurify": "3.4.13",
     "highlight.js": "^11.11.1",
     "highlightjs-heex": "^1.0.1",
     "markdown-it": "^14.3.0",

--- a/e2e/comment-markdown.spec.ts
+++ b/e2e/comment-markdown.spec.ts
@@ -56,6 +56,29 @@ test.describe("Comment Markdown Rendering", () => {
     await expect(link).toHaveAttribute("href", "https://example.com");
   });
 
+  test("renders safe HTML while stripping unsafe markup from comments", async ({
+    page,
+  }) => {
+    await loadReview(page, token);
+    await addCommentViaUI(
+      page,
+      '<details open><summary>More context</summary>Safe content</details><!-- agent metadata --><img src=x onerror="window.__commentXss = true"><a href="javascript:alert(1)">unsafe</a>',
+      { waitText: "Safe content" },
+    );
+
+    const body = page.locator(".comment-card .comment-body");
+    await expect(body.locator("details[open] > summary")).toHaveText("More context");
+    await expect(body).toContainText("Safe content");
+    await expect(body.locator("script, [onerror], [onclick]")).toHaveCount(0);
+    await expect(body.locator('a[href^="javascript:"]')).toHaveCount(0);
+    await expect(
+      await body.evaluate((el) => {
+        const walker = document.createTreeWalker(el, NodeFilter.SHOW_COMMENT);
+        return walker.nextNode();
+      }),
+    ).toBeNull();
+  });
+
   test("renders fenced code blocks with syntax highlighting", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- Render comment markdown with `html: true`, then sanitize with an isolated DOMPurify instance
- Pin a GitHub html-pipeline–compatible allowlist (`details`/`summary`, safe tags/attrs/URLs)
- Keep Mermaid’s shared DOMPurify hooks unpolluted

## Review
- [x] Code review: passed (isolated purify + assets package.json placement)
- [x] Parity audit: matched with crit companion

## Test plan
- [x] `mix precommit` (after test DB reset)
- [x] `mise run e2e -- e2e/comment-markdown.spec.ts`

See also: tomasz-tomczyk/crit#831