### PR TITLE
fix: preserve titles for shared HTML previews

### DIFF
--- a/lib/crit/review.ex
+++ b/lib/crit/review.ex
@@ -7,6 +7,7 @@ defmodule Crit.Review do
     field :last_activity_at, :utc_datetime
     field :review_round, :integer, default: 0
     field :cli_args, {:array, :string}, default: []
+    field :title, :string
     field :visibility, Ecto.Enum, values: [:unlisted, :public, :organization], default: :unlisted
 
     field :comment_policy, Ecto.Enum,

--- a/lib/crit/reviews.ex
+++ b/lib/crit/reviews.ex
@@ -18,10 +18,26 @@ defmodule Crit.Reviews do
   alias Crit.Organizations
 
   @doc "Returns the review-page label used for titles and notification digests."
-  def display_filename(%{files: [%{file_path: path} | _]}) when is_binary(path), do: path
-  def display_filename(%{files: [%{"file_path" => path} | _]}) when is_binary(path), do: path
+  def display_filename(review) when is_map(review) do
+    case Map.get(review, :title) do
+      title when is_binary(title) ->
+        if String.trim(title) == "", do: fallback_filename(review), else: title
 
-  def display_filename(%Review{id: id, review_round: round}) do
+      _ ->
+        fallback_filename(review)
+    end
+  end
+
+  def display_filename(_review), do: "Review"
+
+  defp fallback_filename(%{files: [%{file_path: path} | _]}) when is_binary(path), do: path
+
+  defp fallback_filename(%{files: [%{"file_path" => path} | _]}) when is_binary(path),
+    do: path
+
+  defp fallback_filename(%{first_file_path: path}) when is_binary(path), do: path
+
+  defp fallback_filename(%Review{id: id, review_round: round}) do
     Repo.one(
       from s in ReviewRoundSnapshot,
         where: s.review_id == ^id and s.round_number == ^round,
@@ -31,7 +47,7 @@ defmodule Crit.Reviews do
     ) || "Review"
   end
 
-  def display_filename(_review), do: "Review"
+  defp fallback_filename(_review), do: "Review"
 
   @doc "Fetch a review by its token, preloading comments sorted by start_line."
   def get_by_token(token) do
@@ -341,6 +357,7 @@ defmodule Crit.Reviews do
             "cli_args" => cli_args,
             "review_type" => review_type
           })
+          |> put_preview_title(review_type, cli_args)
           |> Ecto.Changeset.put_change(:comment_policy, comment_policy)
           |> then(fn cs ->
             if user_id, do: Ecto.Changeset.put_change(cs, :user_id, user_id), else: cs
@@ -999,6 +1016,17 @@ defmodule Crit.Reviews do
     |> Repo.aggregate(:count)
   end
 
+  defp put_preview_title(changeset, review_type, ["preview", path])
+       when review_type in [:preview, "preview"] and is_binary(path) do
+    if String.trim(path) == "" do
+      changeset
+    else
+      Ecto.Changeset.put_change(changeset, :title, path)
+    end
+  end
+
+  defp put_preview_title(changeset, _review_type, _cli_args), do: changeset
+
   defp apply_review_filter(query, :all), do: query
 
   defp apply_review_filter(query, {:user, user_id}) do
@@ -1063,6 +1091,7 @@ defmodule Crit.Reviews do
         r.user_id,
         r.visibility,
         r.organization_id,
+        r.title,
         fp.file_path,
         fp.content,
         u.name,
@@ -1079,6 +1108,7 @@ defmodule Crit.Reviews do
         user_id: r.user_id,
         visibility: r.visibility,
         organization_id: r.organization_id,
+        title: r.title,
         org_name: o.name,
         org_slug: o.slug,
         comment_count: count(c.id, :distinct),

--- a/lib/crit_web/components/review_table.ex
+++ b/lib/crit_web/components/review_table.ex
@@ -2,6 +2,8 @@ defmodule CritWeb.Components.ReviewTable do
   use Phoenix.Component
   use Phoenix.VerifiedRoutes, endpoint: CritWeb.Endpoint, router: CritWeb.Router
 
+  alias Crit.Reviews
+
   import CritWeb.CoreComponents, only: [icon: 1]
   import CritWeb.Helpers, only: [split_path: 1, date_label: 1, time_ago: 1]
 
@@ -51,12 +53,13 @@ defmodule CritWeb.Components.ReviewTable do
               class="size-[18px] text-(--crit-fg-muted) shrink-0"
             />
             <div class="min-w-0">
-              <% {dir, file} = split_path(review.first_file_path) %>
+              <% display_path = Reviews.display_filename(review) %>
+              <% {dir, file} = split_path(display_path) %>
               <div class="font-semibold text-sm text-(--crit-fg-primary) leading-tight truncate">
                 <span class="text-(--crit-fg-muted) font-normal">{dir}</span>{file}
               </div>
               <div class="text-xs text-(--crit-fg-muted) mt-0.5 truncate font-mono">
-                {review.first_file_path || "Untitled"}
+                {display_path}
               </div>
             </div>
           </div>

--- a/lib/crit_web/live/dashboard_live.html.heex
+++ b/lib/crit_web/live/dashboard_live.html.heex
@@ -175,7 +175,7 @@
                     :stale -> "bg-(--crit-fg-muted)"
                   end
                 ]} />
-                <% {dir, file} = split_path(review.first_file_path) %>
+                <% {dir, file} = split_path(Reviews.display_filename(review)) %>
                 <div class="flex-1 min-w-0">
                   <div class="font-semibold text-sm text-(--crit-fg-primary) leading-tight truncate">
                     <span class="text-(--crit-fg-muted) font-normal">{dir}</span>{file}

--- a/lib/crit_web/live/org/overview_live.ex
+++ b/lib/crit_web/live/org/overview_live.ex
@@ -2,7 +2,7 @@ defmodule CritWeb.Org.OverviewLive do
   use CritWeb, :live_view
 
   alias Crit.Accounts.Scope
-  alias Crit.Organizations
+  alias Crit.{Organizations, Reviews}
 
   @impl true
   def mount(_params, _session, socket) do

--- a/lib/crit_web/live/org/overview_live.html.heex
+++ b/lib/crit_web/live/org/overview_live.html.heex
@@ -58,7 +58,7 @@
                   <div class="flex items-center justify-between gap-3">
                     <div class="min-w-0 flex-1">
                       <p class="text-sm font-medium text-(--crit-fg-primary) truncate">
-                        {review.first_file_path || "review"}
+                        {Reviews.display_filename(review)}
                       </p>
                       <div class="flex items-center gap-3 mt-0.5">
                         <span :if={review.author_name} class="text-xs text-(--crit-fg-muted)">

--- a/lib/crit_web/live/overview_live.html.heex
+++ b/lib/crit_web/live/overview_live.html.heex
@@ -152,7 +152,7 @@
             >
               <div class="mb-2 px-0.5">
                 <.review_listing_header
-                  path={review.first_file_path}
+                  path={Reviews.display_filename(review)}
                   last_activity_at={review.last_activity_at}
                   file_count={review.file_count}
                   comment_count={review.comment_count}

--- a/priv/repo/migrations/20260817090000_add_title_to_reviews.exs
+++ b/priv/repo/migrations/20260817090000_add_title_to_reviews.exs
@@ -1,0 +1,15 @@
+defmodule Crit.Repo.Migrations.AddTitleToReviews do
+  use Ecto.Migration
+
+  def up do
+    alter table(:reviews) do
+      add :title, :text
+    end
+  end
+
+  def down do
+    alter table(:reviews) do
+      remove :title
+    end
+  end
+end

--- a/test/crit/reviews_test.exs
+++ b/test/crit/reviews_test.exs
@@ -26,6 +26,21 @@ defmodule Crit.ReviewsTest do
   defp default_files, do: [%{"path" => "test.md", "content" => "# Hello"}]
 
   describe "display_filename/1" do
+    test "prefers a persisted nonblank title" do
+      review = %Review{
+        title: "artifacts/reports/checkout.html",
+        files: [%{file_path: "index.html"}]
+      }
+
+      assert Reviews.display_filename(review) == "artifacts/reports/checkout.html"
+    end
+
+    test "ignores a blank persisted title" do
+      review = %Review{title: "   ", files: [%{file_path: "index.html"}]}
+
+      assert Reviews.display_filename(review) == "index.html"
+    end
+
     test "prefers embedded files, then snapshot, then Review fallback" do
       assert Reviews.display_filename(%{files: [%{file_path: "embedded.md"}]}) == "embedded.md"
 
@@ -42,6 +57,50 @@ defmodule Crit.ReviewsTest do
   end
 
   describe "create_review/6" do
+    test "stores the original path as the title for preview reviews" do
+      assert {:ok, review} =
+               Reviews.create_review(
+                 anon_scope(),
+                 [%{"path" => "index.html", "content" => "<h1>Checkout</h1>"}],
+                 0,
+                 [],
+                 [],
+                 review_type: "preview",
+                 cli_args: ["preview", "artifacts/reports/checkout.html"]
+               )
+
+      assert review.title == "artifacts/reports/checkout.html"
+      assert Reviews.display_filename(Reviews.get_by_token(review.token)) == review.title
+    end
+
+    test "does not store a title for non-preview reviews" do
+      assert {:ok, review} =
+               Reviews.create_review(anon_scope(), default_files(), 0, [], [],
+                 review_type: "files",
+                 cli_args: ["preview", "artifacts/reports/checkout.html"]
+               )
+
+      assert review.title == nil
+    end
+
+    test "does not store empty or whitespace-only preview paths" do
+      for path <- ["", "   "] do
+        assert {:ok, review} =
+                 Reviews.create_review(
+                   anon_scope(),
+                   [%{"path" => "index.html", "content" => "<h1>Preview</h1>"}],
+                   0,
+                   [],
+                   [],
+                   review_type: "preview",
+                   cli_args: ["preview", path]
+                 )
+
+        assert review.title == nil
+        assert Reviews.display_filename(Reviews.get_by_token(review.token)) == "index.html"
+      end
+    end
+
     test "anonymous → user_id nil" do
       scope = anon_scope()
       assert {:ok, review} = Reviews.create_review(scope, default_files(), 0, [])
@@ -1043,6 +1102,57 @@ defmodule Crit.ReviewsTest do
   end
 
   describe "upsert_review/4 (scope)" do
+    test "cannot change a preview title through updated cli_args when content is unchanged" do
+      scope = anon_scope()
+      files = [%{"path" => "index.html", "content" => "same"}]
+
+      assert {:ok, review} =
+               Reviews.create_review(scope, files, 1, [], [],
+                 review_type: "preview",
+                 cli_args: ["preview", "artifacts/original.html"]
+               )
+
+      assert {:ok, :no_changes, updated} =
+               Reviews.upsert_review(scope, review.token, review.delete_token, %{
+                 "files" => files,
+                 "comments" => [],
+                 "cli_args" => ["preview", "artifacts/renamed.html"],
+                 "title" => "api-supplied.html"
+               })
+
+      assert updated.cli_args == ["preview", "artifacts/renamed.html"]
+      assert updated.title == "artifacts/original.html"
+      assert Reviews.display_filename(updated) == "artifacts/original.html"
+    end
+
+    test "cannot change a preview title when updated content creates a new round" do
+      scope = anon_scope()
+
+      assert {:ok, review} =
+               Reviews.create_review(
+                 scope,
+                 [%{"path" => "index.html", "content" => "first"}],
+                 1,
+                 [],
+                 [],
+                 review_type: "preview",
+                 cli_args: ["preview", "artifacts/original.html"]
+               )
+
+      assert {:ok, :updated, updated} =
+               Reviews.upsert_review(scope, review.token, review.delete_token, %{
+                 "files" => [%{"path" => "index.html", "content" => "second"}],
+                 "comments" => [],
+                 "cli_args" => ["preview", "artifacts/renamed.html"],
+                 "title" => "api-supplied.html"
+               })
+
+      assert updated.review_round == 2
+      assert updated.cli_args == ["preview", "artifacts/renamed.html"]
+      assert updated.title == "artifacts/original.html"
+      assert Reviews.display_filename(updated) == "artifacts/original.html"
+    end
+
     test "rejects upsert with oversize cli_args" do
       scope = anon_scope()
 

--- a/test/crit_web/controllers/api_controller_test.exs
+++ b/test/crit_web/controllers/api_controller_test.exs
@@ -457,6 +457,19 @@ defmodule CritWeb.ApiControllerTest do
   end
 
   describe "POST /api/reviews with cli_args" do
+    test "ignores an arbitrary client-supplied title", %{conn: conn} do
+      payload = %{
+        "files" => [%{"path" => "plan.md", "content" => "# Plan"}],
+        "title" => "client-controlled.html"
+      }
+
+      conn = post(conn, ~p"/api/reviews", payload)
+      assert %{"url" => url} = json_response(conn, 201)
+      token = url |> String.split("/") |> List.last()
+
+      assert Reviews.get_by_token(token).title == nil
+    end
+
     test "stores cli_args through multi-file create", %{conn: conn} do
       payload = %{
         "files" => [%{"path" => "plan.md", "content" => "# Plan"}],

--- a/test/crit_web/live/dashboard_live_test.exs
+++ b/test/crit_web/live/dashboard_live_test.exs
@@ -41,6 +41,26 @@ defmodule CritWeb.DashboardLiveTest do
   end
 
   describe "personal dashboard" do
+    test "shows the original path for preview reviews", %{conn: conn} do
+      {conn, user} = login_user_with_record(conn)
+
+      review =
+        review_fixture(
+          user_id: user.id,
+          review_type: :preview,
+          cli_args: ["preview", "artifacts/reports/checkout.html"],
+          files: [%{"path" => "index.html", "content" => "<h1>Checkout</h1>"}]
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/dashboard")
+
+      assert has_element?(
+               view,
+               ~s(a[href="/r/#{review.token}"]),
+               "artifacts/reports/checkout.html"
+             )
+    end
+
     test "shows only the current user's reviews", %{conn: conn} do
       {conn, user} = login_user_with_record(conn)
       review = review_fixture(user_id: user.id)

--- a/test/crit_web/live/review_live_test.exs
+++ b/test/crit_web/live/review_live_test.exs
@@ -80,6 +80,19 @@ defmodule CritWeb.ReviewLiveTest do
 
       assert_push_event view, "init", %{review_type: "preview"}
     end
+
+    test "sets page title to the original preview path", %{conn: conn} do
+      review =
+        review_fixture(
+          files: [%{"path" => "index.html", "content" => "<h1>Hi</h1>"}],
+          review_type: :preview,
+          cli_args: ["preview", "artifacts/reports/checkout.html"]
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/r/#{review.token}")
+
+      assert page_title(view) =~ "artifacts/reports/checkout.html"
+    end
   end
 
   describe "mount with multi-file review" do

--- a/test/support/fixtures/reviews_fixtures.ex
+++ b/test/support/fixtures/reviews_fixtures.ex
@@ -26,10 +26,19 @@ defmodule Crit.ReviewsFixtures do
       end
 
     opts =
-      case attrs[:review_type] do
-        nil -> []
-        review_type -> [review_type: to_string(review_type)]
-      end
+      []
+      |> then(fn opts ->
+        case attrs[:review_type] do
+          nil -> opts
+          review_type -> Keyword.put(opts, :review_type, to_string(review_type))
+        end
+      end)
+      |> then(fn opts ->
+        case attrs[:cli_args] do
+          nil -> opts
+          cli_args -> Keyword.put(opts, :cli_args, cli_args)
+        end
+      end)
 
     {:ok, review} =
       Reviews.create_review(


### PR DESCRIPTION
## Summary

- store the original preview source path as immutable, create-only display metadata for new shares
- keep crawled entry artifacts keyed as `index.html` for preview rendering
- show the source path in review titles and dashboard/listing labels
- leave existing reviews unchanged; no legacy backfill
- do not expose title renaming through create or update APIs

## Tests

- `mise exec -- mix precommit` (1132 tests, 0 failures)
- fresh migration reset and focused suites (260 tests, 0 failures)
- real crit → crit-web preview-share E2E

Companion CLI change: tomasz-tomczyk/crit#835

Closes #344