### PR TITLE
chore: Make plain wt switch -c tip at origin/main

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,3 +1,14 @@
+# Local main is often stale (checked out in the primary worktree, rarely
+# pulled). When creating from the default base, tip the new branch at
+# origin/main so plain `wt switch -c` matches an explicit `-b origin/main`.
+# Skipped for stacked creates (`-b @`, `-b other-feature`).
+[[pre-start]]
+sync-origin = """
+{% if base and base == default_branch %}
+git fetch origin {{ default_branch }} && git reset --hard origin/{{ default_branch }}
+{% endif %}
+"""
+
 [[pre-start]]
 mise-trust = "mise trust ."
 
@@ -11,4 +22,3 @@ copy = "wt step copy-ignored"
 # Ensure the shared Postgres container is running so `mix test` works without
 # anyone running `mise run db:start` first. Idempotent and machine-global.
 db = "mise run db:start"
-


### PR DESCRIPTION
## Summary
- Add a Worktrunk `pre-start` hook that fetches and resets new default-base branches to `origin/main`
- Fixes stale local `main` so agents can use plain `wt switch -c` without `-b origin/main`
- Stacked creates (`-b @`, other bases) are unchanged

## Test plan
- [x] `wt switch -c <branch>` (no flags) → `HEAD == origin/main` while local `main` was behind
- [x] Post-start `db:start` still runs after sync (hooks approved locally)
- [ ] Reviewer: create a throwaway worktree with plain `wt switch -c` and confirm tip matches `origin/main`


Made with [Cursor](https://cursor.com)