### PR TITLE
feat: port change-nav to hosted review and align markdown deps

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -873,6 +873,14 @@
   box-shadow: inset 2px 0 0 var(--crit-brand);
 }
 .line-block.focused .line-gutter { background: var(--crit-line-focus-bg); }
+@keyframes change-flash {
+  0%, 15% { background-color: var(--crit-change-flash-bg); }
+  100% { background-color: transparent; }
+}
+.line-block.change-flash,
+.deletion-marker.change-flash {
+  animation: change-flash 1s ease-out;
+}
 
 /* Visual line mode: recolor the focused block's left accent so it's clearly
    distinct from the default j/k cursor, signalling that j/k now extends the
@@ -1076,6 +1084,12 @@ body.dragging { user-select: none; cursor: grabbing; }
 .native-table .line-block.selected > .line-content,
 .native-table .line-block.form-selected > .line-content { background: var(--crit-brand-subtle); }
 .native-table .line-block.focused > .line-content { background: var(--crit-line-focus-bg); }
+.native-table .line-block.change-flash > .line-content {
+  animation: change-flash 1s ease-out;
+}
+.native-table-annotation.change-flash .deletion-marker {
+  animation: change-flash 1s ease-out;
+}
 .native-table .table-last td { border-bottom: none; }
 .native-table-separator { display: none !important; }
 .native-table-annotation > td { padding: 0 24px 0 64px; }

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -815,6 +815,137 @@ function clearFocus(ctx) {
   if (prev) prev.classList.remove('focused')
 }
 
+function changeNavAnchor(ctx) {
+  if (ctx.currentChangeIdx < 0 || ctx.currentChangeIdx >= ctx.changeGroups.length) return null
+  const group = ctx.changeGroups[ctx.currentChangeIdx]
+  let fileGroupIdx = 0
+  for (let i = 0; i < ctx.currentChangeIdx; i++) {
+    if (ctx.changeGroups[i].filePath === group.filePath) fileGroupIdx++
+  }
+  return { filePath: group.filePath, fileGroupIdx }
+}
+
+function changeIndexForAnchor(ctx, anchor) {
+  if (!anchor) return -1
+  let fileGroupIdx = 0
+  let last = -1
+  for (let i = 0; i < ctx.changeGroups.length; i++) {
+    if (ctx.changeGroups[i].filePath !== anchor.filePath) continue
+    if (fileGroupIdx === anchor.fileGroupIdx) return i
+    fileGroupIdx++
+    last = i
+  }
+  return last
+}
+
+function nextLogicalChangeSibling(node) {
+  if (node.nextElementSibling) return node.nextElementSibling
+  const section = node.parentElement
+  if (!section || section.tagName !== 'THEAD') return null
+  const table = section.closest('table.native-table')
+  return table && table.tBodies.length ? table.tBodies[0].firstElementChild : null
+}
+
+function areConsecutiveChangeSiblings(a, b) {
+  let node = nextLogicalChangeSibling(a)
+  while (node && node !== b) {
+    if (node.classList.contains('line-block') &&
+        !node.classList.contains('line-block-added') &&
+        !node.classList.contains('line-block-modified') &&
+        !node.classList.contains('diff-added') &&
+        !node.classList.contains('diff-removed')) return false
+    if (node.classList.contains('deletion-marker')) {
+      node = nextLogicalChangeSibling(node)
+      continue
+    }
+    node = nextLogicalChangeSibling(node)
+  }
+  return node === b
+}
+
+function buildChangeGroups(ctx) {
+  const anchor = changeNavAnchor(ctx)
+  const documentChanges = Array.from(ctx.el.querySelectorAll(
+    '.line-block-added, .line-block-modified, .deletion-marker'
+  )).map(el => el.closest('.native-table-annotation') || el)
+    .filter((el, index, elements) => elements.indexOf(el) === index)
+  const diffChanges = Array.from(ctx.el.querySelectorAll(
+    '.diff-view .line-block.diff-added, .diff-view .line-block.diff-removed, .diff-view-unified .line-block.diff-added, .diff-view-unified .line-block.diff-removed'
+  ))
+  const changes = documentChanges.length > 0 ? documentChanges : diffChanges
+
+  ctx.changeGroups = []
+  let group = null
+  changes.forEach(el => {
+    const filePath = el.dataset.filePath || ''
+    if (!group || group.filePath !== filePath || !areConsecutiveChangeSiblings(group.elements[group.elements.length - 1], el)) {
+      group = { elements: [el], filePath }
+      ctx.changeGroups.push(group)
+    } else {
+      group.elements.push(el)
+    }
+  })
+  ctx.currentChangeIdx = changeIndexForAnchor(ctx, anchor)
+}
+
+function navigateToChange(ctx, direction) {
+  if (ctx.changeGroups.length === 0) return
+
+  ctx.el.querySelectorAll('.change-flash').forEach(el => el.classList.remove('change-flash'))
+
+  const viewportCenter = window.innerHeight / 2
+  const threshold = 50
+  let targetIdx = -1
+  const current = ctx.changeGroups[ctx.currentChangeIdx]
+  const currentRect = current?.elements[0].getBoundingClientRect()
+  const currentCenter = currentRect ? (currentRect.top + currentRect.bottom) / 2 : null
+
+  if (currentCenter !== null && Math.abs(currentCenter - viewportCenter) < threshold * 3) {
+    targetIdx = (ctx.currentChangeIdx + direction + ctx.changeGroups.length) % ctx.changeGroups.length
+  } else if (direction > 0) {
+    targetIdx = ctx.changeGroups.findIndex(group => {
+      const rect = group.elements[0].getBoundingClientRect()
+      return (rect.top + rect.bottom) / 2 > viewportCenter + threshold
+    })
+    if (targetIdx === -1) targetIdx = 0
+  } else {
+    for (let i = ctx.changeGroups.length - 1; i >= 0; i--) {
+      const rect = ctx.changeGroups[i].elements[0].getBoundingClientRect()
+      if ((rect.top + rect.bottom) / 2 < viewportCenter - threshold) {
+        targetIdx = i
+        break
+      }
+    }
+    if (targetIdx === -1) targetIdx = ctx.changeGroups.length - 1
+  }
+
+  ctx.currentChangeIdx = targetIdx
+  const target = ctx.changeGroups[targetIdx]
+  target.elements[0].scrollIntoView({ block: 'center', behavior: 'instant' })
+  target.elements.forEach(el => el.classList.add('change-flash'))
+
+  // Keep j/k/c keyboard focus aligned with the landed change (crit local parity).
+  const focusRoot = target.elements[0]
+  const blockEl = focusRoot.classList.contains('line-block')
+    ? focusRoot
+    : focusRoot.querySelector('.line-block')
+  if (blockEl) {
+    const blocks = ctx.el.querySelectorAll('.line-block')
+    for (let i = 0; i < blocks.length; i++) {
+      if (blocks[i] !== blockEl) continue
+      const prev = ctx.el.querySelector('.line-block.focused')
+      if (prev) prev.classList.remove('focused')
+      ctx.focusedBlockIndex = i
+      ctx.focusedFilePath = target.filePath || blockEl.dataset.filePath || ctx.focusedFilePath
+      if (ctx.activeForms.length === 0) blockEl.classList.add('focused')
+      rememberKeyboardFocusFromBlock(ctx, blockEl)
+      break
+    }
+  } else if (target.filePath) {
+    ctx.focusedFilePath = target.filePath
+  }
+}
+
 // Vim-style visual line mode: anchor on the focused block, extend with j/k.
 function enterVisualMode(ctx) {
   if (ctx.focusedBlockIndex < 0) return
@@ -1776,6 +1907,7 @@ function render(ctx) {
   renderReviewConversation(ctx)
   applyHideResolved(ctx)
   restoreKeyboardFocus(ctx)
+  buildChangeGroups(ctx)
 }
 
 // ---- Multi-file rendering ---------------------------------------------------
@@ -4634,6 +4766,8 @@ export const DocumentRenderer = {
     ctx.visualMode = null
     ctx.focusedBlockIndex = -1
     ctx.keyboardFocusTarget = null
+    ctx.changeGroups = []
+    ctx.currentChangeIdx = -1
     ctx.identity = ctx.el.dataset.identity || ""
     ctx.userId = ctx.el.dataset.userId || ""
     ctx.reviewOwnerId = ctx.el.dataset.reviewOwnerId || ""
@@ -5263,6 +5397,10 @@ export const DocumentRenderer = {
       // Comment navigation
       if (shortcutAction === 'previous_comment') { e.preventDefault(); navigateToComment(ctx, -1); return }
       if (shortcutAction === 'next_comment') { e.preventDefault(); navigateToComment(ctx, 1); return }
+
+      // Review diff navigation
+      if (shortcutAction === 'previous_change') { e.preventDefault(); navigateToChange(ctx, -1); return }
+      if (shortcutAction === 'next_change') { e.preventDefault(); navigateToChange(ctx, 1); return }
 
       // Review comment form
       if (shortcutAction === 'general_comment') {

--- a/assets/js/shortcut-registry.js
+++ b/assets/js/shortcut-registry.js
@@ -11,6 +11,8 @@ export const shortcutGroups = [
     { id: "next_block", binding: "j", action: "Next block", modes: FILES },
     { id: "previous_block", binding: "k", action: "Previous block", modes: FILES },
     { id: "visual_mode", binding: "Shift+V", action: "Visual line mode (extend with next/previous block, then comment)", modes: FILES },
+    { id: "next_change", binding: "n", action: "Next change", modes: FILES },
+    { id: "previous_change", binding: "Shift+N", action: "Previous change", modes: FILES },
     { id: "next_comment", binding: "]", action: "Next comment", modes: FILES },
     { id: "previous_comment", binding: "[", action: "Previous comment", modes: FILES },
   ] },

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -13,10 +13,10 @@
         "@sentry/browser": "^10.51.0",
         "@tailwindcss/typography": "^0.5.19",
         "dompurify": "3.4.13",
-        "highlight.js": "^11.11.1",
+        "highlight.js": "^11.11.2",
         "highlightjs-heex": "^1.0.1",
         "markdown-it": "^15.0.0",
-        "mermaid": "^11.16.0"
+        "mermaid": "^11.16.1"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1071,9 +1071,9 @@
       "license": "MIT"
     },
     "node_modules/highlight.js": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "version": "11.11.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.2.tgz",
+      "integrity": "sha512-oaXMACAU0kzOMXBjWpNcX+vlwSBCIAiZ9BHa7gA15NOTtT2L/l8OSZDuqS2XppOhZBPJ7hm4o8ep2kyuip2uEQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"

--- a/assets/package.json
+++ b/assets/package.json
@@ -15,9 +15,9 @@
     "@sentry/browser": "^10.51.0",
     "@tailwindcss/typography": "^0.5.19",
     "dompurify": "3.4.13",
-    "highlight.js": "^11.11.1",
+    "highlight.js": "^11.11.2",
     "highlightjs-heex": "^1.0.1",
     "markdown-it": "^15.0.0",
-    "mermaid": "^11.16.0"
+    "mermaid": "^11.16.1"
   }
 }

--- a/e2e/keyboard.spec.ts
+++ b/e2e/keyboard.spec.ts
@@ -268,11 +268,11 @@ test.describe("Keyboard Shortcuts", () => {
     const textarea = page.locator(".comment-form textarea");
     await expect(textarea).toBeVisible({ timeout: 5_000 });
 
-    // Type 'j' in the textarea — should NOT trigger navigation
-    await textarea.type("j");
-    await expect(textarea).toHaveValue("j");
+    // Type navigation shortcuts in the textarea — they must not leave the editor.
+    await textarea.type("jn");
+    await expect(textarea).toHaveValue("jn");
 
-    // No block should get focused from the shortcut
+    // No block should get focused from the shortcut.
     await expect(page.locator(".line-block.focused")).toHaveCount(0);
   });
 });

--- a/e2e/review-page.spec.ts
+++ b/e2e/review-page.spec.ts
@@ -243,6 +243,43 @@ test.describe("Review Page — Rendered Tables", () => {
     expect(await tables.first().evaluate(table => getComputedStyle(table).marginTop)).toBe("0px");
   });
 
+  test("n and Shift+N navigate and flash rendered table diff changes", async ({ page, request }) => {
+    const update = async (content: string) => {
+      const response = await request.put(`${API_ORIGIN}/api/reviews/${token}`, {
+        data: {
+          delete_token: deleteToken,
+          files: [
+            { path: "table.md", content },
+            { path: "notes.md", content: "# Notes\n\nA second file exercises the multi-file renderer.\n" },
+          ],
+          comments: [],
+        },
+      });
+      expect(response.ok()).toBeTruthy();
+    };
+    await update(TABLE_MARKDOWN.replace("| beta | waiting for review |", "| beta | changed once |"));
+    await update(
+      TABLE_MARKDOWN
+        .replace("| beta | waiting for review |", "| beta | changed twice |")
+        .replace("| gamma | ready |", "| gamma | changed separately |")
+    );
+
+    await loadReview(page, token);
+    const tableSection = page.locator(".file-section").filter({ hasText: "table.md" });
+    await page.locator("button.crit-round-diff-btn").click();
+    await expect(tableSection.locator(".diff-view")).toBeVisible();
+
+    await page.keyboard.press("n");
+    const firstTarget = page.locator(".change-flash");
+    await expect(firstTarget).toHaveCount(1);
+    const firstText = await firstTarget.textContent();
+
+    await page.keyboard.press("Shift+N");
+    const previousTarget = page.locator(".change-flash");
+    await expect(previousTarget).toHaveCount(1);
+    expect(await previousTarget.textContent()).not.toBe(firstText);
+  });
+
   test("drag selection has continuous row-height gutter segments", async ({ page }) => {
     await loadReview(page, token);
     const first = page.getByRole("cell", { name: "x", exact: true }).locator("..").locator(".line-gutter");


### PR DESCRIPTION
## Summary
- Port CLI change-hunk navigation (`n` / `Shift+N`, flash, keyboard focus sync) to the hosted review renderer.
- Bump `highlight.js` and `mermaid` declarations to match crit (`11.11.2` / `11.16.1`).

## Test plan
- [x] Playwright: `e2e/review-page.spec.ts` change-nav case + keyboard textarea isolation
- [x] `mix test test/crit_web/live/review_live_test.exs`
- [ ] CI green


Made with [Cursor](https://cursor.com)