### PR TITLE
fix: wrap overflowing markdown table cells

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1072,12 +1072,15 @@ body.dragging { user-select: none; cursor: grabbing; }
 
 /* Native rendered tables */
 .native-table-wrapper { width: 100%; overflow-x: auto; margin: 8px 0; }
-.native-table { width: 100%; border-collapse: separate; border-spacing: 0; table-layout: auto; font-size: 0.925rem; margin: 0; }
+.native-table { width: 100%; max-width: 100%; border-collapse: separate; border-spacing: 0; table-layout: auto; font-size: 0.925rem; margin: 0; }
 .native-table .line-block { display: table-row; }
 .native-table-gutter { position: relative; width: 52px; min-width: 52px; padding: 0; vertical-align: top; }
 .native-table-gutter > .line-gutter { position: absolute; inset: 0; box-sizing: border-box; width: 52px; }
+.native-table th.line-content,
+.native-table td.line-content { overflow-wrap: break-word; }
 .native-table th.line-content { text-align: left; font-weight: 600; padding: 10px 14px; color: var(--crit-editor-fg-secondary); border-bottom: 2px solid var(--crit-border); }
 .native-table td.line-content { padding: 8px 14px; border-bottom: 1px solid var(--crit-border); }
+.native-table .line-content code { white-space: pre-wrap; overflow-wrap: break-word; }
 .native-table tbody tr.table-even td.line-content { background: var(--crit-table-stripe); }
 .native-table .line-block.has-comment > .line-content { background: var(--crit-comment-range-bg); }
 .native-table .line-block:hover > .line-content { background: var(--crit-selection-bg); }

--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -2713,12 +2713,22 @@ function blockHasComment(block, commentedLineSet) {
   return false
 }
 
-function wrapNativeTableAnnotation(element) {
+function nativeTableColCount(hint) {
+  if (hint && hint.tagName === "TR" && hint.classList.contains("line-block") &&
+      !hint.classList.contains("native-table-separator") && hint.cells.length) {
+    return hint.cells.length
+  }
+  const table = hint && hint.closest && hint.closest("table.native-table")
+  const sample = table && table.querySelector("tr.line-block:not(.native-table-separator)")
+  return (sample && sample.cells.length) || 1
+}
+
+function wrapNativeTableAnnotation(element, colHint) {
   const row = document.createElement("tr")
   row.className = "native-table-annotation"
   if (element.dataset.filePath) row.dataset.filePath = element.dataset.filePath
   const cell = document.createElement("td")
-  cell.colSpan = 100
+  cell.colSpan = nativeTableColCount(colHint)
   cell.appendChild(element)
   row.appendChild(cell)
   return row
@@ -2833,7 +2843,7 @@ function renderBlock(ctx, block, index, commentsMap, commentedLineSet, filePath)
       fragment.appendChild(element)
       return
     }
-    fragment.appendChild(wrapNativeTableAnnotation(element))
+    fragment.appendChild(wrapNativeTableAnnotation(element, lineBlockEl))
   }
 
   // Comments after this block
@@ -4120,7 +4130,7 @@ function insertInlineComment(ctx, comment) {
     insertAfter = next
   }
   const newEl = createCommentElement(comment, ctx)
-  insertAfter.after(inNativeTable ? wrapNativeTableAnnotation(newEl) : newEl)
+  insertAfter.after(inNativeTable ? wrapNativeTableAnnotation(newEl, insertAfter) : newEl)
 }
 
 function removeInlineComment(ctx, comment) {

--- a/e2e/review-page.spec.ts
+++ b/e2e/review-page.spec.ts
@@ -156,6 +156,8 @@ test.describe("Review Page — Rendered Tables", () => {
     await expect(table.locator("tbody tr.table-row")).toHaveCount(4);
     await expect(table.locator("colgroup")).toHaveCount(0);
     expect(await table.evaluate(element => getComputedStyle(element).tableLayout)).toBe("auto");
+    expect(await table.locator("thead th.line-content").first()
+      .evaluate(element => getComputedStyle(element).overflowWrap)).toBe("break-word");
     expect(await table.locator("..").evaluate(element => getComputedStyle(element).borderTopWidth)).toBe("0px");
   });
 


### PR DESCRIPTION
## Summary
- Wrap overflowing native markdown table cells with `overflow-wrap: break-word` while keeping `table-layout: auto`, so short columns stay content-sized instead of splitting equally or forcing a horizontal scrollbar.
- Span comment annotation rows by the table's real column count instead of `colspan=100`, so commenting across rows cannot collapse cells.
- Assert wrap mode in the rendered-tables e2e spec.

## Review
- [x] Code review: passed
- [x] Parity audit: passed

## Test plan
- `mix precommit` (1133 passed)
- `mise run e2e` (162 passed)

See also: tomasz-tomczyk/crit#841