### PR TITLE
fix: keep reply body font when editing a comment with replies

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1878,6 +1878,7 @@ body.dragging { user-select: none; cursor: grabbing; }
 }
 
 .reply-body {
+  font-family: var(--crit-font-body);
   font-size: 14px;
   line-height: 1.6;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Set explicit `font-family: var(--crit-font-body)` on `.reply-body` so thread replies stay in proportional body font when nested inside `.comment-form` during parent comment edit
- Without this, replies inherit monospace from the diff/document context because they no longer sit under `.comment-card`

## Review
- [x] Code review: passed
- [x] Parity audit: passed (companion crit PR ships the regression test)

## Test plan
- [x] CSS-only change; crit companion PR adds regression test asserting `.reply-body` body font in both repos
- [ ] CI precommit + E2E

See also: tomasz-tomczyk/crit#853