### PR TITLE
fix: stop word-diff spans from reopening at hljs tag boundaries

### DIFF
--- a/assets/js/document-renderer.js
+++ b/assets/js/document-renderer.js
@@ -177,15 +177,14 @@ function applyWordDiffToHtml(html, ranges, cssClass) {
   var i = 0             // position in html string
 
   while (i < html.length) {
-    // Skip HTML tags (don't count them as visible characters)
+    // Skip HTML tags (don't count them as visible characters).
+    // Keep any open word-diff span across tags — closing/reopening at each tag
+    // boundary creates empty highlight spans inside nested hljs markup.
     if (html[i] === '<') {
-      // If we're in a word-diff range, close it before the tag, reopen after
-      if (inRange) result += '</span>'
       var tagEnd = html.indexOf('>', i)
       if (tagEnd === -1) { result += html.slice(i); break }
       result += html.slice(i, tagEnd + 1)
       i = tagEnd + 1
-      if (inRange) result += '<span class="' + cssClass + '">'
       continue
     }
 


### PR DESCRIPTION
## Summary
- Keep word-diff highlight spans open across nested syntax-highlight tags in `applyWordDiffToHtml`
- Fixes phantom whitespace in HEEx/Elixir diffs where empty `diff-word-add` spans rendered inside nested hljs markup

## Review
- [x] Code review: passed
- [x] Parity audit: ported from companion crit PR

## Test plan
- [x] `mix precommit` (1133 tests, 0 failures)
- [x] Visual validation on PL-3727 HEEx diff (price-currency line)

See also: tomasz-tomczyk/crit (companion PR for CLI)

Made with [Cursor](https://cursor.com)