### PR TITLE
fix: draw borders on tables in comment and reply bodies

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1560,6 +1560,34 @@ body.dragging { user-select: none; cursor: grabbing; }
 
 .comment-body a { color: var(--crit-brand); text-decoration: none; border-bottom: 1px solid var(--crit-brand-subtle); }
 .comment-body a:hover { color: var(--crit-brand-hover); }
+
+/* Sanitized comment markdown keeps no classes, so key off the elements.
+   A comment card is narrow: cells take a full border, not row rules alone.
+   Keep in sync with crit/web/style.css (.comment-body / .reply-body tables). */
+.comment-body table,
+.reply-body table {
+  border-collapse: collapse;
+  margin: 0.5em 0;
+  font-size: 0.95em;
+}
+.comment-body th,
+.comment-body td,
+.reply-body th,
+.reply-body td {
+  border: 1px solid var(--crit-border);
+  padding: 4px 10px;
+  text-align: left;
+}
+.comment-body th,
+.reply-body th {
+  font-weight: 600;
+  background: var(--crit-editor-bg-elevated);
+}
+.comment-body tbody tr:nth-child(even) td,
+.reply-body tbody tr:nth-child(even) td {
+  background: var(--crit-table-stripe);
+}
+
 .comment-time { font-size: 11px; color: var(--crit-editor-fg-muted); }
 .comment-author { display: flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 600; color: var(--crit-editor-fg-secondary); font-family: var(--crit-font-mono); }
 .comment-author-icon { width: 13px; height: 13px; flex-shrink: 0; }

--- a/e2e/comment-markdown.spec.ts
+++ b/e2e/comment-markdown.spec.ts
@@ -126,4 +126,42 @@ test.describe("Comment Markdown Rendering", () => {
     await expect(link).toHaveText("a link");
     await expect(link).toHaveAttribute("href", "https://example.com");
   });
+
+  test("draws a border on every cell of a markdown table in a comment", async ({
+    page,
+  }) => {
+    const tableMd = [
+      "| Field | Type | Notes |",
+      "| --- | --- | --- |",
+      "| id | string | primary key |",
+      "| name | string | display name |",
+    ].join("\n");
+
+    await loadReview(page, token);
+    await addCommentViaUI(page, tableMd, { waitText: "primary key" });
+
+    const table = page.locator(".comment-card .comment-body table");
+    await expect(table).toBeVisible();
+    await expect(table).toHaveCSS("border-collapse", "collapse");
+    await expect(table.locator("th")).toHaveCount(3);
+
+    for (const side of ["top", "right", "bottom", "left"] as const) {
+      await expect(table.locator("th").first()).toHaveCSS(
+        `border-${side}-style`,
+        "solid",
+      );
+      await expect(table.locator("th").first()).toHaveCSS(
+        `border-${side}-width`,
+        "1px",
+      );
+      await expect(table.locator("td").first()).toHaveCSS(
+        `border-${side}-style`,
+        "solid",
+      );
+      await expect(table.locator("td").first()).toHaveCSS(
+        `border-${side}-width`,
+        "1px",
+      );
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Port crit's `.comment-body` / `.reply-body` table CSS so markdown tables in hosted review comments get the same cell borders, header fill, and row stripes as the CLI.
- Add an e2e assertion that every cell draws a 1px solid border (`border-collapse: collapse`).

Parity for [crit#856](https://github.com/tomasz-tomczyk/crit/pull/856).

## Test plan
- [ ] `npx playwright test e2e/comment-markdown.spec.ts` (or CI e2e)
- [ ] Open a shared review with a markdown table in a comment/reply and confirm cells have borders in light and dark


Made with [Cursor](https://cursor.com)