### PR TITLE
chore: apply pre-release audit fixes for comment tables

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1140,7 +1140,7 @@ body.dragging { user-select: none; cursor: grabbing; }
   border-radius: 1px;
   padding: 1px 0;
 }
-.comment-body { padding: 10px 14px; color: var(--crit-editor-fg); font-size: 14px; line-height: 1.6; word-break: break-word; }
+.comment-body { padding: 10px 14px; color: var(--crit-editor-fg); font-size: 14px; line-height: 1.6; word-break: break-word; overflow-x: auto; }
 .comment-body p { margin: 0 0 0.5em; }
 .comment-body p:last-child { margin-bottom: 0; }
 .comment-body code { background: var(--crit-editor-bg-elevated); padding: 1px 5px; border-radius: 3px; font-family: var(--crit-font-code); font-size: 0.9em; }
@@ -1551,12 +1551,7 @@ body.dragging { user-select: none; cursor: grabbing; }
 }
 
 /* ===== Diff Gutter Backgrounds ===== */
-/* Unified diff */
-.diff-container.unified .addition .diff-gutter-num:last-child { background: var(--crit-diff-add-gutter); }
-.diff-container.unified .deletion .diff-gutter-num:first-child { background: var(--crit-diff-del-gutter); }
-/* Split diff */
-.diff-split-side.deletion .diff-gutter-num { background: var(--crit-diff-del-gutter); }
-.diff-split-side.addition .diff-gutter-num { background: var(--crit-diff-add-gutter); }
+/* Round-diff gutter colors use .line-block / .diff-view-unified in JS. */
 
 .comment-body a { color: var(--crit-brand); text-decoration: none; border-bottom: 1px solid var(--crit-brand-subtle); }
 .comment-body a:hover { color: var(--crit-brand-hover); }
@@ -1909,7 +1904,7 @@ body.dragging { user-select: none; cursor: grabbing; }
   font-family: var(--crit-font-body);
   font-size: 14px;
   line-height: 1.6;
-  overflow: hidden;
+  overflow-x: auto;
 }
 
 .reply-body ul, .reply-body ol {
@@ -4044,7 +4039,6 @@ body.sidebar-resizing * {
      the union of all its line boxes. Converting these spans to inline-block +
      max-width:100% + overflow:hidden constrains each span's bounding rect to
      its container, which stops Chrome from expanding the scrollable viewport. */
-  .diff-container,
   .diff-view,
   .diff-view-unified { overflow-x: auto; }
 

--- a/e2e/comment-markdown.spec.ts
+++ b/e2e/comment-markdown.spec.ts
@@ -1,10 +1,28 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Locator } from "@playwright/test";
 import {
   createReview,
   deleteReview,
   loadReview,
   addCommentViaUI,
 } from "./helpers";
+
+const TABLE_MD = [
+  "| Field | Type | Notes |",
+  "| --- | --- | --- |",
+  "| id | string | primary key |",
+  "| name | string | display name |",
+].join("\n");
+
+async function expectAllTableCellBorders(table: Locator) {
+  const cells = table.locator("th, td");
+  await expect(cells).not.toHaveCount(0);
+  for (const cell of await cells.all()) {
+    for (const side of ["top", "right", "bottom", "left"] as const) {
+      await expect(cell).toHaveCSS(`border-${side}-style`, "solid");
+      await expect(cell).toHaveCSS(`border-${side}-width`, "1px");
+    }
+  }
+}
 
 test.describe("Comment Markdown Rendering", () => {
   let token: string;
@@ -130,38 +148,38 @@ test.describe("Comment Markdown Rendering", () => {
   test("draws a border on every cell of a markdown table in a comment", async ({
     page,
   }) => {
-    const tableMd = [
-      "| Field | Type | Notes |",
-      "| --- | --- | --- |",
-      "| id | string | primary key |",
-      "| name | string | display name |",
-    ].join("\n");
-
     await loadReview(page, token);
-    await addCommentViaUI(page, tableMd, { waitText: "primary key" });
+    await addCommentViaUI(page, TABLE_MD, { waitText: "primary key" });
 
     const table = page.locator(".comment-card .comment-body table");
     await expect(table).toBeVisible();
     await expect(table).toHaveCSS("border-collapse", "collapse");
     await expect(table.locator("th")).toHaveCount(3);
+    await expect(table.locator("tbody tr")).toHaveCount(2);
 
-    for (const side of ["top", "right", "bottom", "left"] as const) {
-      await expect(table.locator("th").first()).toHaveCSS(
-        `border-${side}-style`,
-        "solid",
-      );
-      await expect(table.locator("th").first()).toHaveCSS(
-        `border-${side}-width`,
-        "1px",
-      );
-      await expect(table.locator("td").first()).toHaveCSS(
-        `border-${side}-style`,
-        "solid",
-      );
-      await expect(table.locator("td").first()).toHaveCSS(
-        `border-${side}-width`,
-        "1px",
-      );
-    }
+    await expectAllTableCellBorders(table);
+  });
+
+  test("draws a border on every cell of a markdown table in a reply", async ({
+    page,
+  }) => {
+    await loadReview(page, token);
+    await addCommentViaUI(page, "Which fields does this cover?", {
+      waitText: "Which fields",
+    });
+
+    const card = page.locator(".comment-card").filter({
+      hasText: "Which fields does this cover?",
+    });
+    await card.locator(".reply-input").click();
+    const replyTextarea = card.locator(".reply-textarea");
+    await expect(replyTextarea).toBeVisible({ timeout: 5_000 });
+    await replyTextarea.fill(TABLE_MD);
+    await card.locator(".reply-form-buttons .btn-primary").click();
+
+    const table = card.locator(".reply-body table");
+    await expect(table).toBeVisible();
+    await expect(table.locator("th")).toHaveCount(3);
+    await expectAllTableCellBorders(table);
   });
 });


### PR DESCRIPTION
## Summary
- Remove orphan `.diff-container` / `.diff-split-side` CSS left from CLI git-diff port
- Add `overflow-x: auto` on comment/reply bodies so wide markdown tables scroll in narrow cards
- Extend comment-table E2E to assert borders on every cell; add reply-table coverage

## Review
- [x] Code review: release audit + validation
- [x] Parity audit: CSS/table rules aligned with crit — see tomasz-tomczyk/crit#864

## Test plan
- [x] `mix precommit` (fresh test DB)
- [x] `mise run e2e -- e2e/comment-markdown.spec.ts` (10/10)