### PR TITLE
ci: keep release smoke off the GitHub API

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -34,6 +34,21 @@ if System.get_env("SELFHOSTED") in ~w(true 1) do
   config :crit, :selfhosted, true
 end
 
+# The hosted site's background fetchers (GitHub star count + release
+# changelog) poll api.github.com during application boot. CI and offline
+# environments must be able to switch them off so startup never blocks on an
+# external API. Only applied when the env vars are set, so the existing
+# config.exs / test.exs defaults are preserved otherwise.
+case System.get_env("START_GITHUB_STARS") do
+  nil -> :ok
+  value -> config :crit, :start_github_stars, value in ~w(true 1)
+end
+
+case System.get_env("START_CHANGELOG") do
+  nil -> :ok
+  value -> config :crit, :start_changelog, value in ~w(true 1)
+end
+
 # HSTS + secure cookies — off by default to protect self-hosters on plain HTTP.
 # When enabled, browsers remember "always use HTTPS" for this domain and cookies
 # are only sent over HTTPS. Only enable when the deployment is behind HTTPS

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -11,6 +11,15 @@ export PORT="$smoke_port"
 export DATABASE_URL="${DATABASE_URL:?DATABASE_URL is required}"
 export SECRET_KEY_BASE="${SECRET_KEY_BASE:-$(openssl rand -base64 64)}"
 
+# Keep the smoke run hermetic: the prod release boots GithubStars/Changelog,
+# which block startup on api.github.com and retry with backoff. When the API
+# is slow (common under concurrent CI runs), boot stalls past the health
+# window below and the job fails spuriously — unrelated to the diff under
+# test. These fetchers are marketing-site features; the smoke test doesn't
+# exercise them.
+export START_GITHUB_STARS=false
+export START_CHANGELOG=false
+
 mix local.hex --force >/dev/null
 mix local.rebar --force >/dev/null
 mix deps.get --only prod

--- a/test/crit/config_test.exs
+++ b/test/crit/config_test.exs
@@ -160,4 +160,14 @@ defmodule Crit.ConfigTest do
       refute Config.ip_in_cidrs?({192, 168, 1, 6}, cidrs)
     end
   end
+
+  # Regression guard: config/test.exs disables the background GitHub API
+  # fetchers (star count + changelog) so tests never touch api.github.com.
+  # config/runtime.exs is evaluated after test.exs and must not clobber these
+  # keys when its env vars are unset — otherwise the test suite would start
+  # making external HTTP calls and flake when the API is slow.
+  test "background GitHub API fetchers are disabled in the test environment" do
+    assert Application.get_env(:crit, :start_github_stars) == false
+    assert Application.get_env(:crit, :start_changelog) == false
+  end
 end


### PR DESCRIPTION
## Problem

`Crit.GithubStars` and `Crit.Changelog` fetch api.github.com **during application boot** and block startup while retrying (Req retry with backoff). Under concurrent workflow runs — e.g. a Dependabot batch triggering ~26 CI runs at once — the GitHub API 504s from the runners, boot stalls past the release-smoke script's 30s health window, and the job fails spuriously with `role \"root\" does not exist` noise followed by exit code 7. Nothing to do with the dependency under test (seen on bandit 1.12.5 and mermaid 11.17.2 bumps; both passed on rerun when the API was fast).

## Fix

- **config/runtime.exs**: `START_GITHUB_STARS` / `START_CHANGELOG` env vars disable the two fetchers. Only applied when set, so existing defaults and the test-env disable in `config/test.exs` are untouched.
- **scripts/release-smoke.sh**: sets both to `false` so the smoke run is hermetic (also when run locally).
- **test/crit/config_test.exs**: regression guard that the fetchers stay disabled in the test environment (runtime.exs is evaluated after test.exs — this catches anyone clobbering the keys).

Verified locally: `mix test test/crit/config_test.exs` (21 tests, 0 failures), format clean, env override confirmed (`{nil, nil}` unset → unchanged behavior; `{false, false}` with vars set).

Note: this keeps the *boot-time* blocking design for the hosted site (star count is a marketing feature); a follow-up could make the fetches non-blocking at boot, but that's out of scope here.